### PR TITLE
Issue #111

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -139,6 +139,10 @@ if (GPUACCELERATED)
         set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \
             -G -g -lineinfo"
         )
+    else()
+        set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \
+            -O2"
+        )
     endif()
 endif()
 
@@ -149,6 +153,13 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
     -std=c99"
 )
+
+# Use -O2 for all but debug mode by default 
+if (NOT("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
+        -O2"
+    )
+endif()
 
 # Set c flags for release
 set(CMAKE_C_FLAGS_RELEASE 
@@ -187,6 +198,13 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -std=c++98 -Wall"
 )
+
+# Use -O2 for all but debug mode by default 
+if (NOT("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} \
+        -O2"
+    )
+endif()
 
 # Set c++ flags for release
 set(CMAKE_CXX_FLAGS_RELEASE


### PR DESCRIPTION
changed build system so that if no CMAKE_BUILD_TYPE is specified, optimisation level defaults to -O2

Addresses issue #111 