### PR TITLE
Removed seeding by hostname from seedQuESTDefault.

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -1339,8 +1339,8 @@ Complex calcInnerProduct(Qureg bra, Qureg ket);
 
 /** Seed the Mersenne Twister used for random number generation in the QuEST environment with an example
  * defualt seed.
- * This default seeding function uses the mt19937 init_by_array function with three keys -- 
- * time, pid and hostname. Subsequent calls to mt19937 genrand functions will use this seeding. 
+ * This default seeding function uses the mt19937 init_by_array function with two keys -- 
+ * time and pid. Subsequent calls to mt19937 genrand functions will use this seeding. 
  * For a multi process code, the same seed is given to all process, therefore this seeding is only
  * appropriate to use for functions such as measure where all processes require the same random value.
  *

--- a/QuEST/src/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/src/CPU/QuEST_cpu_distributed.c
@@ -195,12 +195,6 @@ void reportQuESTEnv(QuESTEnv env){
     }
 }
 
-void reportNodeList(QuESTEnv env){
-    char hostName[256];
-    gethostname(hostName, 255);
-    printf("hostname on rank %d: %s\n", env.rank, hostName);
-}
-
 int getChunkIdFromIndex(Qureg qureg, long long int index){
     return index/qureg.numAmpsPerChunk; // this is numAmpsPerChunk
 }
@@ -1271,14 +1265,14 @@ void statevec_collapseToKnownProbOutcome(Qureg qureg, const int measureQubit, in
 }
 
 void seedQuESTDefault(){
-    // init MT random number generator with three keys -- time, pid and a hash of hostname 
+    // init MT random number generator with three keys -- time and pid
     // for the MPI version, it is ok that all procs will get the same seed as random numbers will only be 
     // used by the master process
 
-    unsigned long int key[3];
+    unsigned long int key[2];
     getQuESTDefaultSeedKey(key);
     // this seed will be used to generate the same random number on all procs,
     // therefore we want to make sure all procs receive the same key
-    MPI_Bcast(key, 3, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
-    init_by_array(key, 3);
+    MPI_Bcast(key, 2, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+    init_by_array(key, 2);
 }

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -181,10 +181,6 @@ void reportQuESTEnv(QuESTEnv env){
     printf("Precision: size of qreal is %ld bytes\n", sizeof(qreal));
 }
 
-void reportNodeList(QuESTEnv env){
-    printf("Hostname unknown: running locally\n");
-}
-
 qreal statevec_getRealAmp(Qureg qureg, long long int index){
     return qureg.stateVec.real[index];
 }
@@ -283,11 +279,11 @@ void statevec_collapseToKnownProbOutcome(Qureg qureg, const int measureQubit, in
 }
 
 void seedQuESTDefault(){
-    // init MT random number generator with three keys -- time, pid and a hash of hostname 
+    // init MT random number generator with three keys -- time and pid
     // for the MPI version, it is ok that all procs will get the same seed as random numbers will only be 
     // used by the master process
 
-    unsigned long int key[3];
+    unsigned long int key[2];
     getQuESTDefaultSeedKey(key);
-    init_by_array(key, 3);
+    init_by_array(key, 2);
 }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -2220,13 +2220,13 @@ void densmatr_twoQubitDepolarise(Qureg qureg, int qubit1, int qubit2, qreal depo
 }
 
 void seedQuESTDefault(){
-    // init MT random number generator with three keys -- time, pid and a hash of hostname 
+    // init MT random number generator with three keys -- time and pid
     // for the MPI version, it is ok that all procs will get the same seed as random numbers will only be 
     // used by the master process
 
-    unsigned long int key[3];
+    unsigned long int key[2];
     getQuESTDefaultSeedKey(key); 
-    init_by_array(key, 3); 
+    init_by_array(key, 2); 
 }  
 
 

--- a/QuEST/src/QuEST_common.c
+++ b/QuEST/src/QuEST_common.c
@@ -10,11 +10,9 @@
 # include "QuEST_validation.h"
 # include "mt19937ar.h"
 
-# define _BSD_SOURCE
 # include <unistd.h>
 # include <sys/types.h> 
 # include <sys/time.h>
-# include <sys/param.h>
 # include <stdio.h>
 # include <stdlib.h>
 
@@ -133,7 +131,7 @@ unsigned long int hashString(char *str){
 }
 
 void getQuESTDefaultSeedKey(unsigned long int *key){
-    // init MT random number generator with three keys -- time, pid and a hash of hostname 
+    // init MT random number generator with two keys -- time and pid
     // for the MPI version, it is ok that all procs will get the same seed as random numbers will only be 
     // used by the master process
 
@@ -145,11 +143,8 @@ void getQuESTDefaultSeedKey(unsigned long int *key){
 
     unsigned long int pid = getpid();
     unsigned long int msecs = (unsigned long int) time_in_mill;
-    char hostName[MAXHOSTNAMELEN+1];
-    gethostname(hostName, sizeof(hostName));
-    unsigned long int hostNameInt = hashString(hostName);
 
-    key[0] = msecs; key[1] = pid; key[2] = hostNameInt;
+    key[0] = msecs; key[1] = pid;
 }
 
 /** 

--- a/QuEST/src/QuEST_debug.h
+++ b/QuEST/src/QuEST_debug.h
@@ -39,12 +39,6 @@ void initStateFromSingleFile(Qureg *qureg, char filename[200], QuESTEnv env);
  */
 int compareStates(Qureg mq1, Qureg mq2, qreal precision);
 
-/** Report a list of CPU hostnames and the rank that is running on each if running with MPI enabled and an 
- * error message otherwise. For debugging purposes. 
- * @param[in] env object representing the execution environment. A single instance is used for each program
- * */
-void reportNodeList(QuESTEnv env);
-
 /** Set elements in the underlying state vector represenation of a density matrix. Not exposed in the public
  * API as this requires an understanding of how the state vector is used to represent a density matrix.
  * Currently can only be used to set all amps. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -158,7 +158,7 @@ and after compiling (see section below), gives psuedo-random output
 > Qubit 2 collapsed to 1 with probability 0.499604
 > ```
 
-QuEST uses the [Mersenne Twister](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/emt19937ar.html) algorithm to generate random numbers used for randomly collapsing the state-vector. The user can seed this RNG using `seedQuEST(arrayOfSeeds, arrayLength)`, otherwise QuEST will by default (through `seedQuESTDefault()`) create a seed from the current time, the process id, and the hostname.
+QuEST uses the [Mersenne Twister](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/emt19937ar.html) algorithm to generate random numbers used for randomly collapsing the state-vector. The user can seed this RNG using `seedQuEST(arrayOfSeeds, arrayLength)`, otherwise QuEST will by default (through `seedQuESTDefault()`) create a seed from the current time and the process id.
 
 ----------------------------
 


### PR DESCRIPTION
Default seeding is now done only by pid and time.
hostname seeding removed as it is messy to implement across windows and linux consistently.
Removing hostname seeding will only be a problem if two QuEST programs are launched on different nodes at the same millisecond and are assigned the same pid, therefore keeping it doesn't seem worth the cross platform compilation difficulty.

Nevertheless this change of behaviour should be noted in future releases. 

This addresses issue #23 as well as reports from an external user that the code did not compile on windows using mingw. 