### PR TITLE
fixed bug in distributed version of controlledPauliY

### DIFF
--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -2543,8 +2543,8 @@ void statevec_controlledPauliYDistributed (Qureg qureg, const int controlQubit, 
         for (thisTask=0; thisTask<numTasks; thisTask++) {
             controlBit = extractBit (controlQubit, thisTask+chunkId*chunkSize);
             if (controlBit){
-                stateVecRealOut[thisTask] = conjFac * stateVecRealIn[thisTask];
-                stateVecImagOut[thisTask] = conjFac * stateVecImagIn[thisTask];
+                stateVecRealOut[thisTask] = conjFac * stateVecImagIn[thisTask];
+                stateVecImagOut[thisTask] = conjFac * -stateVecRealIn[thisTask];
             }
         }
     }

--- a/QuEST/src/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/src/CPU/QuEST_cpu_distributed.c
@@ -1140,7 +1140,7 @@ void statevec_controlledPauliY(Qureg qureg, const int controlQubit, const int ta
             statevec_controlledPauliYDistributed(qureg,controlQubit,targetQubit,
                     qureg.pairStateVec, //in
                     qureg.stateVec,
-					conjFac); //out
+					-conjFac); //out
         }
     }
 }
@@ -1173,7 +1173,7 @@ void statevec_controlledPauliYConj(Qureg qureg, const int controlQubit, const in
             statevec_controlledPauliYDistributed(qureg,controlQubit,targetQubit,
                     qureg.pairStateVec, //in
                     qureg.stateVec,
-					conjFac); //out
+					-conjFac); //out
         }
     }
 }


### PR DESCRIPTION
Maths was not quite right in the distributed version. Also needed to account for the fact that in the distributed version sometimes we are operating on upper and sometimes on lower halves of a block, and there is a sign difference in how they are updated. This is handled by passing through (-1)xconjFac in the case of lower halves of a block.