### PR TITLE
fix bug in CPU calcHilbertSchmidtDistance (Balint)

### DIFF
--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -914,8 +914,8 @@ qreal densmatr_calcHilbertSchmidtDistanceSquaredLocal(Qureg a, Qureg b) {
     long long int numAmps = a.numAmpsPerChunk;
         
     qreal *aRe = a.stateVec.real;
-    qreal *aIm = b.stateVec.imag;
-    qreal *bRe = a.stateVec.real;
+    qreal *aIm = a.stateVec.imag;
+    qreal *bRe = b.stateVec.real;
     qreal *bIm = b.stateVec.imag;
     
     qreal trace = 0;


### PR DESCRIPTION
The function calcHilbertSchmidtDistance always returned incorrect values because of a bug -- only CPU is fixed