### PR TITLE
Example PR

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -3291,6 +3291,17 @@ ComplexMatrixN bindArraysToStackComplexMatrixN(
     )
 #endif
 
+/** Returns the sum of either the real or imaginary values of every amplitude in 
+ * the given \p qureg, regardless of whether \p qureg is a state-vector or density matrix.
+ *
+ * @ingroup calc 
+ * @param[in] qureg the qureg of which to compute the sum of amplitudes
+ * @param[in] flag 0 indicates to sum the real values, and 1 indicates to sum the imaginary values
+ * @return the sum of the real (or imaginary) values of every amplitude in \p qureg
+ * @throws invalidQuESTInputError if \p val is not 0 or 1
+ * @author Tyson Jones
+ */
+qreal calcAmpSum(Qureg qureg, int flag);
 
 // end prevention of C++ name mangling
 #ifdef __cplusplus

--- a/QuEST/src/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/src/CPU/QuEST_cpu_distributed.c
@@ -1460,3 +1460,14 @@ void statevec_multiControlledMultiQubitUnitary(Qureg qureg, long long int ctrlMa
         if (swapTargs[t] != targs[t])
             statevec_swapQubitAmps(qureg, targs[t], swapTargs[t]);
 }
+
+qreal statevec_calcAmpSum(Qureg qureg, int flag) {
+    
+    qreal localSum = statevec_calcAmpSumLocal(qureg, flag);
+    qreal globalSum;
+    
+    int numVals = 1;
+    MPI_Allreduce(&localSum, &globalSum, numVals, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+    
+    return globalSum;
+}

--- a/QuEST/src/CPU/QuEST_cpu_internal.h
+++ b/QuEST/src/CPU/QuEST_cpu_internal.h
@@ -188,5 +188,7 @@ void statevec_multiControlledTwoQubitUnitaryLocal(Qureg qureg, long long int ctr
 
 void statevec_multiControlledMultiQubitUnitaryLocal(Qureg qureg, long long int ctrlMask, int* targs, const int numTargs, ComplexMatrixN u);
 
+qreal statevec_calcAmpSumLocal(Qureg qureg, int flag);
+
 
 # endif // QUEST_CPU_INTERNAL_H

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -321,3 +321,8 @@ void statevec_swapQubitAmps(Qureg qureg, int qb1, int qb2)
 {
     statevec_swapQubitAmpsLocal(qureg, qb1, qb2);
 }
+
+qreal statevec_calcAmpSum(Qureg qureg, int flag) {
+    
+    return statevec_calcAmpSumLocal(qureg, flag);
+}

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -818,6 +818,13 @@ void applyPauliSum(Qureg inQureg, enum pauliOpType* allPauliCodes, qreal* termCo
 /*
  * calculations
  */
+ 
+qreal calcAmpSum(Qureg qureg, int flag) {
+    validateRealOrImagFlag(flag, __func__);
+    
+    // valid also for density-matrices
+    return statevec_calcAmpSum(qureg, flag);
+}
 
 qreal calcTotalProb(Qureg qureg) {
     if (qureg.isDensityMatrix)  

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -245,6 +245,8 @@ void statevec_setWeightedQureg(Complex fac1, Qureg qureg1, Complex fac2, Qureg q
 
 void statevec_applyPauliSum(Qureg inQureg, enum pauliOpType* allCodes, qreal* termCoeffs, int numSumTerms, Qureg outQureg);
 
+qreal statevec_calcAmpSum(Qureg qureg, int flag);
+
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -70,6 +70,7 @@ typedef enum {
     E_INVALID_NUM_TWO_QUBIT_KRAUS_OPS,
     E_INVALID_NUM_N_QUBIT_KRAUS_OPS,
     E_INVALID_KRAUS_OPS,
+    E_INVALID_REAL_OR_IMAG_FLAG,
     E_MISMATCHING_NUM_TARGS_KRAUS_SIZE
 } ErrorCode;
 
@@ -120,6 +121,7 @@ static const char* errorMessages[] = {
     [E_INVALID_NUM_TWO_QUBIT_KRAUS_OPS] = "At least 1 and at most 16 two-qubit Kraus operators may be specified.",
     [E_INVALID_NUM_N_QUBIT_KRAUS_OPS] = "At least 1 and at most 4*N^2 of N-qubit Kraus operators may be specified.",
     [E_INVALID_KRAUS_OPS] = "The specified Kraus map is not a completely positive, trace preserving map.",
+    [E_INVALID_REAL_OR_IMAG_FLAG] = "The flag argument must be either 0 or 1 (to indicate summing of the real or imaginary values respectively).",
     [E_MISMATCHING_NUM_TARGS_KRAUS_SIZE] = "Every Kraus operator must be of the same number of qubits as the number of targets."
 };
 
@@ -507,6 +509,10 @@ void validateMultiQubitKrausMap(Qureg qureg, int numTargs, ComplexMatrixN* ops, 
     
     int isPos = isCompletelyPositiveMapN(ops, numOps);
     QuESTAssert(isPos, E_INVALID_KRAUS_OPS, caller);
+}
+
+void validateRealOrImagFlag(int flag, const char* caller) {
+    QuESTAssert(flag == 0 || flag == 1, E_INVALID_REAL_OR_IMAG_FLAG, caller);
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -99,6 +99,8 @@ void validateMultiQubitKrausMap(Qureg qureg, int numTargs, ComplexMatrixN* ops, 
 
 void validateOneQubitDampingProb(qreal prob, const char* caller);
 
+void validateRealOrImagFlag(int flag, const char* caller);
+
 # ifdef __cplusplus
 }
 # endif


### PR DESCRIPTION
> **Do not** accept this PR

This is an example of how to contribute a new funciton to QuEST.

This new function `calcAmpSum` is relatively simple in several ways:
- the `statevec_calcAmpSum` implementation and `densmatr_calcAmpSum` implementations are identical, so only the former is defined
- the distributed CPU version merely invokes the local CPU version and performs additional reduction, so an explicit `statevec_calcAmpSumDistributed` definition is not needed.
- besides validation, there is no common hardware-agnostic processing needed, so `statevec_calcAmpSum` is defined directly in the backends, and not in `QuEST_common.c`

The complications of this function were:
- additional user-input validation (in `QuEST_validation`) needed to be defined
- in multithreaded mode, this function needed an OMP reduction
- in distributed mode, this function needed an MPI reduction
- in GPU mode, this function needed a parallel & sequential reduction