### PR TITLE
prevented error on passing c flags through -Xcompiler. 

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -109,6 +109,10 @@ endif()
 
 if (GPUACCELERATED)
     find_package(CUDA REQUIRED)
+    # Stop nvcc sending c compile flags through using -Xcompiler and breaking
+    # on compilation of a cpp file receiving -std=c99. In long term should figure 
+    # out why CMAKE_C_FLAGS and not CMAKE_CXX_FLAGS are being sent through to a cpp file
+    set(CUDA_PROPAGATE_HOST_FLAGS FALSE)
 endif()
 
 


### PR DESCRIPTION
Prevented error seen in #148 on passing c flags through -Xcompiler. As far as I can tell these are not strictly required as the c compiler is still receiving them. Should investigate why CMAKE_C_FLAGS and not CMAKE_CXX_FLAGS are being passed through to compile a c++ file

-- now branched from dev, not master