### PR TITLE
Fix overflow issues in validateNumQubitsInQureg

### DIFF
--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -280,7 +280,7 @@ void validateNumQubitsInQureg(int numQubits, int numRanks, const char* caller) {
     QuESTAssert( numQubits <= maxQubits, E_NUM_AMPS_EXCEED_TYPE, caller);
     
     // must be at least one amplitude per node
-    long unsigned int numAmps = (1<<numQubits);
+    long unsigned int numAmps = (1UL<<numQubits);
     QuESTAssert(numAmps >= numRanks, E_DISTRIB_QUREG_TOO_SMALL, caller);
 }
  

--- a/tests/test_data_structures.cpp
+++ b/tests/test_data_structures.cpp
@@ -167,7 +167,7 @@ TEST_CASE( "createDensityQureg", "[data_structures]" ) {
             /* n-qubit density matrix contains 2^(2n) amplitudes 
              * so can be spread between at most 2^(2n) ranks
              */
-            int minQb = GENERATE( range(3,maxQb) );
+            int minQb = GENERATE_COPY( range(3,maxQb) );
             env.numRanks = (int) pow(2, 2*minQb);
             int numQb = GENERATE_COPY( range(1,minQb) );
             REQUIRE_THROWS_WITH( createDensityQureg(numQb, env), Contains("Too few qubits") );
@@ -236,7 +236,7 @@ TEST_CASE( "createQureg", "[data_structures]" ) {
             REQUIRE_THROWS_WITH( createQureg(maxQb+1, env), Contains("Too many qubits") && Contains("size_t type") );
             
             // too few amplitudes to distribute
-            int minQb = GENERATE( range(2,maxQb) );
+            int minQb = GENERATE_COPY( range(2,maxQb) );
             env.numRanks = (int) pow(2, minQb);
             int numQb = GENERATE_COPY( range(1,minQb) );
             REQUIRE_THROWS_WITH( createQureg(numQb, env), Contains("Too few qubits") );

--- a/tests/test_data_structures.cpp
+++ b/tests/test_data_structures.cpp
@@ -167,7 +167,7 @@ TEST_CASE( "createDensityQureg", "[data_structures]" ) {
             /* n-qubit density matrix contains 2^(2n) amplitudes 
              * so can be spread between at most 2^(2n) ranks
              */
-            int minQb = GENERATE( range(3,10) );
+            int minQb = GENERATE( range(3,32) );
             env.numRanks = (int) pow(2, 2*minQb);
             int numQb = GENERATE_COPY( range(1,minQb) );
             REQUIRE_THROWS_WITH( createDensityQureg(numQb, env), Contains("Too few qubits") );
@@ -236,7 +236,7 @@ TEST_CASE( "createQureg", "[data_structures]" ) {
             REQUIRE_THROWS_WITH( createQureg(maxQb+1, env), Contains("Too many qubits") && Contains("size_t type") );
             
             // too few amplitudes to distribute
-            int minQb = GENERATE( range(2,10) );
+            int minQb = GENERATE( range(2,64) );
             env.numRanks = (int) pow(2, minQb);
             int numQb = GENERATE_COPY( range(1,minQb) );
             REQUIRE_THROWS_WITH( createQureg(numQb, env), Contains("Too few qubits") );

--- a/tests/test_data_structures.cpp
+++ b/tests/test_data_structures.cpp
@@ -161,7 +161,7 @@ TEST_CASE( "createDensityQureg", "[data_structures]" ) {
             QuESTEnv env = QUEST_ENV;
             
             // too many amplitudes to store in type
-            int maxQb = (int) calcLog2(SIZE_MAX) - 1;
+            int maxQb = (int) calcLog2(SIZE_MAX) / 2;
             REQUIRE_THROWS_WITH( createDensityQureg(maxQb+1, env), Contains("Too many qubits") && Contains("size_t type") );
             
             /* n-qubit density matrix contains 2^(2n) amplitudes 

--- a/tests/test_data_structures.cpp
+++ b/tests/test_data_structures.cpp
@@ -167,7 +167,7 @@ TEST_CASE( "createDensityQureg", "[data_structures]" ) {
             /* n-qubit density matrix contains 2^(2n) amplitudes 
              * so can be spread between at most 2^(2n) ranks
              */
-            int minQb = GENERATE( range(3,32) );
+            int minQb = GENERATE( range(3,maxQb) );
             env.numRanks = (int) pow(2, 2*minQb);
             int numQb = GENERATE_COPY( range(1,minQb) );
             REQUIRE_THROWS_WITH( createDensityQureg(numQb, env), Contains("Too few qubits") );
@@ -236,7 +236,7 @@ TEST_CASE( "createQureg", "[data_structures]" ) {
             REQUIRE_THROWS_WITH( createQureg(maxQb+1, env), Contains("Too many qubits") && Contains("size_t type") );
             
             // too few amplitudes to distribute
-            int minQb = GENERATE( range(2,64) );
+            int minQb = GENERATE( range(2,maxQb) );
             env.numRanks = (int) pow(2, minQb);
             int numQb = GENERATE_COPY( range(1,minQb) );
             REQUIRE_THROWS_WITH( createQureg(numQb, env), Contains("Too few qubits") );


### PR DESCRIPTION
* Added `UL` type literal for calculating `numAmps` in `validateNumQubitsInQureg`. The existing implementation caused an overflow, leading to `E_DISTRIB_QUREG_TOO_SMALL` even when `2^numQubits >= numRanks`.
* Modified the `number of amplitudes` section in `createQureg` and `createDensityQureg` tests to check for up to 64 numQubits.