### PR TITLE
Bug fix of issue #236

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -309,7 +309,7 @@ target_include_directories(QuEST
 # ----- Definitions -----------------------------------------------------------
 
 target_compile_definitions(QuEST
-    PRIVATE
+    PUBLIC
     QuEST_PREC=${PRECISION}
 )
 


### PR DESCRIPTION
Changing target_compile_definitions to public so that they are inherited by the user circuit file