### PR TITLE
Bugfix: fix macOS OpenMP linker errors

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -317,13 +317,17 @@ target_compile_definitions(QuEST
 # ----- LINK LIBRARY ---------------------------------------------------------
 # -----------------------------------------------------------------------------
 
+# ----- OMP -------------------------------------------------------------------
+
+target_link_libraries(QuEST PUBLIC OpenMP::OpenMP_C)
+
 # ----- MPI -------------------------------------------------------------------
 
-target_link_libraries(QuEST ${MPI_C_LIBRARIES})
+target_link_libraries(QuEST PUBLIC ${MPI_C_LIBRARIES})
 
 # ----- GPU -------------------------------------------------------------------
 
-target_link_libraries(QuEST ${CUDA_LIBRARIES})
+target_link_libraries(QuEST PUBLIC ${CUDA_LIBRARIES})
 
 
 # ----- Coverage testing with GCC or Clang ------------------------------------

--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -319,7 +319,9 @@ target_compile_definitions(QuEST
 
 # ----- OMP -------------------------------------------------------------------
 
-target_link_libraries(QuEST PUBLIC OpenMP::OpenMP_C)
+if (OPENMP_FOUND)
+  target_link_libraries(QuEST PUBLIC OpenMP::OpenMP_C)
+endif ()
 
 # ----- MPI -------------------------------------------------------------------
 


### PR DESCRIPTION
Compiling on macOS with OpenMP enabled and installed fails due to a missing `target_link_libraries(...)` in the `CMakeLists.txt`.

This isn't picked up by the CI as the tests don't have OpenMP installed. To demonstrate the issue and fix, I have a branch with actions that show the compile errors:

Before fix: https://github.com/drewsilcock/QuEST/runs/533841934?check_suite_focus=true
After fix: https://github.com/drewsilcock/QuEST/runs/533846020?check_suite_focus=true