### PR TITLE
added support for efficient diagonal operators

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -329,7 +329,7 @@ target_link_libraries(QuEST PUBLIC ${MPI_C_LIBRARIES})
 
 # ----- GPU -------------------------------------------------------------------
 
-target_link_libraries(QuEST PUBLIC ${CUDA_LIBRARIES})
+target_link_libraries(QuEST ${CUDA_LIBRARIES})
 
 
 # ----- Coverage testing with GCC or Clang ------------------------------------

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -260,7 +260,9 @@ typedef struct QuESTEnv
  * @returns an object representing the set of qubits
  * @param[in] numQubits number of qubits in the system
  * @param[in] env object representing the execution environment (local, multinode etc)
- * @throws exitWithError if \p numQubits <= 0
+ * @throws exitWithError if \p numQubits <= 0, or if \p numQubits is so large that 
+ *      the number of amplitudes cannot fit in a long long int type, 
+ *      or if in distributed mode, there are more nodes than elements in the would-be state-vector
  * @author Ania Brown
  */
 Qureg createQureg(int numQubits, QuESTEnv env);
@@ -274,7 +276,9 @@ Qureg createQureg(int numQubits, QuESTEnv env);
  * @returns an object representing the set of qubits
  * @param[in] numQubits number of qubits in the system
  * @param[in] env object representing the execution environment (local, multinode etc)
- * @throws exitWithError if \p numQubits <= 0
+ * @throws exitWithError if \p numQubits <= 0, or if \p numQubits is so large that 
+ *      the number of amplitudes cannot fit in a long long int type, 
+ *      or if in distributed mode, there are more nodes than elements in the would-be density-matrix
  * @author Tyson Jones
  */
 Qureg createDensityQureg(int numQubits, QuESTEnv env);
@@ -758,7 +762,12 @@ void initDebugState(Qureg qureg);
 /** Initialise qureg by specifying the complete statevector.
  * The real and imaginary components of the amplitudes are passed in separate arrays,
  * each of which must have length \p qureg.numAmpsTotal.
- * There is no automatic checking that the passed arrays are L2 normalised.
+ * There is no automatic checking that the passed arrays are L2 normalised, so this 
+ * can be used to prepare \p qureg in a non-physical state.
+ *
+ * In distributed mode, this would require the complete statevector to fit in 
+ * every node. To manually prepare a statevector which cannot fit in every node,
+ * use setAmps()
  *
  * @ingroup init
  * @param[in,out] qureg the object representing the set of qubits to be initialised
@@ -2779,7 +2788,7 @@ qreal calcExpecPauliProd(Qureg qureg, int* targetQubits, enum pauliOpType* pauli
  * (number of represented qubits) as \p qureg, and is used as working space. When this function returns, \p qureg 
  * will be unchanged and \p workspace will be set to \p qureg pre-multiplied with the final Pauli product.
  * NOTE that if \p qureg is a density matrix, \p workspace will become \f$ \hat{\sigma} \rho \f$ 
- * which is itself not a density matrix (it is distinct from \f$ \hat{\sigma}^\dagger \rho \hat{\sigma} \f$).
+ * which is itself not a density matrix (it is distinct from \f$ \hat{\sigma} \rho \hat{\sigma}^\dagger \f$).
  *
  * This function works by cloning the \p qureg state into \p workspace, applying each of the specified
  * Pauli products to \p workspace (one Pauli operation at a time), then computing its inner product with \p qureg (for statevectors)
@@ -2818,7 +2827,7 @@ qreal calcExpecPauliSum(Qureg qureg, enum pauliOpType* allPauliCodes, qreal* ter
  * When this function returns, \p qureg  will be unchanged and \p workspace will be set to
  * \p qureg pre-multiplied with the final Pauli product in \p hamil.
  * NOTE that if \p qureg is a density matrix, \p workspace will become \f$ \hat{\sigma} \rho \f$ 
- * which is itself not a density matrix (it is distinct from \f$ \hat{\sigma}^\dagger \rho \hat{\sigma} \f$).
+ * which is itself not a density matrix (it is distinct from \f$ \hat{\sigma} \rho \hat{\sigma}^\dagger \f$).
  *
  * This function works by cloning the \p qureg state into \p workspace, applying each of the specified
  * Pauli products in \p hamil to \p workspace (one Pauli operation at a time), then computing its inner product with \p qureg (for statevectors)

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -444,7 +444,9 @@ void initPauliHamil(PauliHamil hamil, qreal* coeffs, enum pauliOpType* codes);
  * There is no requirement that the operator is unitary or Hermitian - 
  * any complex operator is allowed.
  *
- * This function allocates space for 2^n complex amplitudes, which are initially zero.
+ * The operator is initialised to all zero.
+ *
+ * This function allocates space for 2^\p numQubits complex amplitudes, which are initially zero.
  * This is the same cost as a state-vector of equal size.
  * The elements should be modified with setDiagonalOpElems().
  * This memory must later be freed with destroyDiagonalOp().
@@ -460,17 +462,17 @@ void initPauliHamil(PauliHamil hamil, qreal* coeffs, enum pauliOpType* codes);
  * in modifying .real and .imag directly, and should instead use initDiagonalOp().
   * E.g. the following is valid code when when distributed between TWO nodes:
  *
- *     // create {1,2,3,4,5,6,7,8, 9,10,11,12,13,14,15,16}
- *     DiagonalOp op = createDiagonalOp(4, env); // 16 amplitudes total
- *     for (int i=0; i<8; i++) {
- *         if (env.rank == 0)
- *             op.real[i] = (i+1);
- *         if (env.rank == 1)
- *             op.real[i] = (i+1+8);
- *     }
+ *      // create {1,2,3,4,5,6,7,8, 9,10,11,12,13,14,15,16}
+ *      DiagonalOp op = createDiagonalOp(4, env); // 16 amplitudes total
+ *      for (int i=0; i<8; i++) {
+ *          if (env.rank == 0)
+ *              op.real[i] = (i+1);
+ *          if (env.rank == 1)
+ *              op.real[i] = (i+1+8);
+ *      }
  *
  * @ingroup type
- * @returns a DiagonalOp instance, with 2^n-length .real and .imag arrays
+ * @returns a DiagonalOp instance, with 2^n-length .real and .imag arrays, initialised to zero
  * @param[in] numQubits number of qubit, informing the dimension of the operator.
  * @param[in] env object representing the execution environment (local, multinode etc)
  * @throws exitWithError if \p numQubits <= 0, or if \p numQubits is so large that 

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -558,6 +558,18 @@ void initDiagonalOp(DiagonalOp op, qreal* real, qreal* imag);
  */
 void setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* real, qreal* imag, long long int numElems);
 
+/** Apply a diagonal complex operator, which is possibly non-unitary and non-Hermitian,
+ * on the entire \p qureg,  
+ *
+ * @ingroup operator
+ * @param[in,out] qureg the state to operate the diagonal operator upon
+ * @param[in] op the diagonal operator to apply
+ * @throws exitWithError if \p op was not created, 
+ *      or if \p op acts on a different number of qubits than \p qureg represents
+ * @author Tyson Jones
+ */
+void applyDiagonalOp(Qureg qureg, DiagonalOp op);
+
 /** Print the current state vector of probability amplitudes for a set of qubits to file.
  * File format:
  * @verbatim

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -570,6 +570,30 @@ void setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* real, qrea
  */
 void applyDiagonalOp(Qureg qureg, DiagonalOp op);
 
+/** Computes the expected value of the diagonal operator \p op for state \p qureg. 
+ * Since \p op is not necessarily Hermitian, the expected value may be a complex 
+ * number.
+ *
+ * Let \f$ D \f$ be the diagonal operator \p op, with diagonal elements \f$ d_i \f$.
+ * Then if \p qureg is a state-vector \f$|\psi\rangle \f$, this function computes
+ * \f[
+    \langle \psi | D | \psi \rangle = \sum_i |\psi_i|^2 \, d_i
+ * \f]
+ * If \p qureg is a density matrix \f$ \rho \f$, this function computes 
+ * \f[ 
+    \text{Trace}( D \rho ) = \sum_i \rho_{ii} \, d_i
+ * \f]
+ *
+ * @ingroup calc
+ * @param[in] qureg a state-vector or density matrix
+ * @param[in] op    the diagonal operator to compute the expected value of
+ * @return the expected vaulue of the operator
+ * @throws exitWithError if \p op was not created,
+ *      or if \p op acts on a different number of qubits than \p qureg represents.
+ * @author Tyson Jones
+ */
+Complex calcExpecDiagonalOp(Qureg qureg, DiagonalOp op);
+
 /** Print the current state vector of probability amplitudes for a set of qubits to file.
  * File format:
  * @verbatim

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -3855,7 +3855,7 @@ void agnostic_setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* r
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (localStartInd,localEndInd, vecRe,vecIm, reals,imags, offset) \
+    shared   (localStartInd,localEndInd, vecRe,vecIm, real,imag, offset) \
     private  (index) 
 # endif
     {
@@ -3864,8 +3864,8 @@ void agnostic_setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* r
 # endif
         // iterate these local inds - this might involve no iterations
         for (index=localStartInd; index < localEndInd; index++) {
-            vecRe[index] = reals[index + offset];
-            vecIm[index] = imags[index + offset];
+            vecRe[index] = real[index + offset];
+            vecIm[index] = imag[index + offset];
         }
     }
 }

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -1331,6 +1331,33 @@ void statevec_destroyQureg(Qureg qureg, QuESTEnv env){
     qureg.pairStateVec.imag = NULL;
 }
 
+DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
+
+    // the 2^numQubits values will be evenly split between the env.numRanks nodes
+    DiagonalOp op;
+    op.numQubits = numQubits;
+    op.numElemsPerChunk = (1LL << numQubits) / env.numRanks;
+    op.chunkId = env.rank;
+    op.numChunks = env.numRanks;
+
+    // allocate CPU memory (initialised to zero)
+    op.real = (qreal*) calloc(op.numElemsPerChunk, sizeof(qreal));
+    op.imag = (qreal*) calloc(op.numElemsPerChunk, sizeof(qreal));
+
+    // check cpu memory allocation was successful
+    if ( !op.real || !op.imag ) {
+        printf("Could not allocate memory!\n");
+        exit(EXIT_FAILURE);
+    }
+
+    return op;
+}
+
+void agnostic_destroyDiagonalOp(DiagonalOp op) {
+    free(op.real);
+    free(op.imag);
+}
+
 void statevec_reportStateToScreen(Qureg qureg, QuESTEnv env, int reportRank){
     long long int index;
     int rank;

--- a/QuEST/src/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/src/CPU/QuEST_cpu_distributed.c
@@ -476,8 +476,6 @@ void densmatr_initPureState(Qureg targetQureg, Qureg copyQureg) {
     }
 }
 
-
-
 void exchangeStateVectors(Qureg qureg, int pairRank){
     // MPI send/receive vars
     int TAG=100;
@@ -1240,7 +1238,6 @@ void statevec_hadamard(Qureg qureg, const int targetQubit)
     }
 }
 
-
 /** Find chunks to skip when calculating probability of qubit being zero.
  * When calculating probability of a bit q being zero,
  * sum up 2^q values, then skip 2^q values, etc. This function finds if an entire chunk
@@ -1353,7 +1350,6 @@ long long int getGlobalIndOfOddParityInChunk(Qureg qureg, int qb1, int qb2) {
     
     return -1;
 }
-
 
 void statevec_swapQubitAmps(Qureg qureg, int qb1, int qb2) {
     

--- a/QuEST/src/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/src/CPU/QuEST_cpu_distributed.c
@@ -1523,3 +1523,40 @@ void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op) {
     copyDiagOpIntoMatrixPairState(qureg, op);
     densmatr_applyDiagonalOpLocal(qureg, op);
 }
+
+Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
+
+    Complex localExpec = statevec_calcExpecDiagonalOpLocal(qureg, op);
+    if (qureg.numChunks == 1)
+        return localExpec;
+        
+    qreal localReal = localExpec.real;
+    qreal localImag = localExpec.imag;
+    qreal globalReal, globalImag;
+    MPI_Allreduce(&localReal, &globalReal, 1, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&localImag, &globalImag, 1, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+    
+    Complex globalExpec;
+    globalExpec.real = globalReal;
+    globalExpec.imag = globalImag;
+    return globalExpec;
+}
+
+Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
+    
+    Complex localVal = densmatr_calcExpecDiagonalOpLocal(qureg, op);
+    if (qureg.numChunks == 1)
+        return localVal;
+    
+    qreal localRe = localVal.real;
+    qreal localIm = localVal.imag;
+    qreal globalRe, globalIm;
+    
+    MPI_Allreduce(&localRe, &globalRe, 1, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&localIm, &globalIm, 1, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+    
+    Complex globalVal;
+    globalVal.real = globalRe;
+    globalVal.imag = globalIm;
+    return globalVal;
+}

--- a/QuEST/src/CPU/QuEST_cpu_internal.h
+++ b/QuEST/src/CPU/QuEST_cpu_internal.h
@@ -89,6 +89,8 @@ void densmatr_mixTwoQubitDepolarisingQ1LocalQ2DistributedPart3(Qureg qureg, cons
                 
 void densmatr_applyDiagonalOpLocal(Qureg qureg, DiagonalOp op);
 
+Complex densmatr_calcExpecDiagonalOpLocal(Qureg qureg, DiagonalOp op);
+
 
 /*
  * state vector operations
@@ -189,6 +191,8 @@ void statevec_swapQubitAmpsDistributed(Qureg qureg, int pairRank, int qb1, int q
 void statevec_multiControlledTwoQubitUnitaryLocal(Qureg qureg, long long int ctrlMask, const int q1, const int q2, ComplexMatrix4 u);
 
 void statevec_multiControlledMultiQubitUnitaryLocal(Qureg qureg, long long int ctrlMask, int* targs, const int numTargs, ComplexMatrixN u);
+
+Complex statevec_calcExpecDiagonalOpLocal(Qureg qureg, DiagonalOp op);
 
 
 # endif // QUEST_CPU_INTERNAL_H

--- a/QuEST/src/CPU/QuEST_cpu_internal.h
+++ b/QuEST/src/CPU/QuEST_cpu_internal.h
@@ -86,6 +86,8 @@ void densmatr_mixTwoQubitDepolarisingDistributed(Qureg qureg, const int targetQu
 
 void densmatr_mixTwoQubitDepolarisingQ1LocalQ2DistributedPart3(Qureg qureg, const int targetQubit,
                 const int qubit2, qreal delta, qreal gamma);
+                
+void densmatr_applyDiagonalOpLocal(Qureg qureg, DiagonalOp op);
 
 
 /*

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -344,5 +344,5 @@ Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
 
 Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
     
-    return densmatr_calcExpecDiagonalOp(qureg, op);
+    return densmatr_calcExpecDiagonalOpLocal(qureg, op);
 }

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -321,3 +321,19 @@ void statevec_swapQubitAmps(Qureg qureg, int qb1, int qb2)
 {
     statevec_swapQubitAmpsLocal(qureg, qb1, qb2);
 }
+
+void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op) {
+
+    // we must preload qureg.pairStateVec with the elements of op.
+    // instead of needless cloning, we'll just temporarily swap the pointers
+    qreal* rePtr = qureg.pairStateVec.real;
+    qreal* imPtr = qureg.pairStateVec.imag;
+    qureg.pairStateVec.real = op.real;
+    qureg.pairStateVec.imag = op.imag;
+    
+    densmatr_applyDiagonalOpLocal(qureg, op);
+    
+    qureg.pairStateVec.real = rePtr;
+    qureg.pairStateVec.imag = imPtr;
+}
+

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -337,3 +337,12 @@ void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op) {
     qureg.pairStateVec.imag = imPtr;
 }
 
+Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
+
+    return statevec_calcExpecDiagonalOpLocal(qureg, op);
+}
+
+Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
+    
+    return densmatr_calcExpecDiagonalOp(qureg, op);
+}

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -55,6 +55,7 @@ void densmatr_mixTwoQubitDepolarising(Qureg qureg, int qubit1, int qubit2, qreal
 }
 
 qreal densmatr_calcPurity(Qureg qureg) {
+    
     return densmatr_calcPurityLocal(qureg);
 }
 
@@ -110,6 +111,7 @@ void densmatr_initPureState(Qureg qureg, Qureg pureState) {
 }
 
 Complex statevec_calcInnerProduct(Qureg bra, Qureg ket) {
+    
     return statevec_calcInnerProductLocal(bra, ket);
 }
 
@@ -160,8 +162,6 @@ qreal statevec_calcTotalProb(Qureg qureg){
         // Don't change the bracketing on the following line
         c = ( t - pTotal ) - y;
         pTotal = t;
-
-
     } 
     return pTotal;
 }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -3097,7 +3097,7 @@ Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
 __global__ void densmatr_calcExpecDiagonalOpKernel(
     int getRealComp,
     qreal* matReal, qreal* matImag, qreal* opReal, qreal* opImag, 
-    int numQubits, qreal* reducedArray) 
+    int numQubits, long long int numTermsToSum, qreal* reducedArray) 
 {
     /** if the thread represents a diagonal op, then it computes either a 
      *  real or imag term of matr_{ii} op_i. Otherwise, it writes a 0 to the 
@@ -3106,8 +3106,7 @@ __global__ void densmatr_calcExpecDiagonalOpKernel(
     
     // index will identy one of the 2^Q diagonals to be summed
     long long int matInd = blockIdx.x*blockDim.x + threadIdx.x;
-    long long int numAmpsTotal = (1LL << (2*numQubits));
-    if (matInd >= numAmpsTotal) return;
+    if (matInd >= numTermsToSum) return;
     
     long long int diagSpacing = (1LL << numQubits) + 1LL;
     int isDiag = ((matInd % diagSpacing) == 0);
@@ -3174,7 +3173,7 @@ Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
                 getRealComp,
                 qureg.deviceStateVec.real, qureg.deviceStateVec.imag, 
                 op.deviceOperator.real, op.deviceOperator.imag, 
-                numValuesToReduce, 
+                op.numQubits, numValuesToReduce, 
                 qureg.firstLevelReduction);
             firstTime = 0;
         } else {
@@ -3209,7 +3208,7 @@ Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
                 getRealComp,
                 qureg.deviceStateVec.real, qureg.deviceStateVec.imag, 
                 op.deviceOperator.real, op.deviceOperator.imag, 
-                numValuesToReduce, 
+                op.numQubits, numValuesToReduce, 
                 qureg.firstLevelReduction);
             firstTime = 0;
         } else {

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -161,7 +161,7 @@ void statevec_setAmps(Qureg qureg, long long int startInd, qreal* reals, qreal* 
     cudaMemcpy(
         qureg.deviceStateVec.imag + startInd,
         imags,
-        numAmps * sizeof(*(qureg.deviceStateVec.real)), 
+        numAmps * sizeof(*(qureg.deviceStateVec.imag)), 
         cudaMemcpyHostToDevice);
 }
 
@@ -1527,6 +1527,7 @@ void statevec_multiRotateZ(Qureg qureg, long long int mask, qreal angle)
     CUDABlocks = ceil((qreal)(qureg.numAmpsPerChunk)/threadsPerCUDABlock);
     statevec_multiRotateZKernel<<<CUDABlocks, threadsPerCUDABlock>>>(qureg, mask, cosAngle, sinAngle);
 }
+
 qreal densmatr_calcTotalProb(Qureg qureg) {
     
     // computes the trace using Kahan summation

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -976,6 +976,15 @@ qreal calcExpecPauliHamil(Qureg qureg, PauliHamil hamil, Qureg workspace) {
     return statevec_calcExpecPauliSum(qureg, hamil.pauliCodes, hamil.termCoeffs, hamil.numSumTerms, workspace);
 }
 
+Complex calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
+    validateDiagonalOp(qureg, op, __func__);
+    
+    if (qureg.isDensityMatrix)
+        return densmatr_calcExpecDiagonalOp(qureg, op);
+    else
+        return statevec_calcExpecDiagonalOp(qureg, op);
+}
+
 qreal calcHilbertSchmidtDistance(Qureg a, Qureg b) {
     validateDensityMatrQureg(a, __func__);
     validateDensityMatrQureg(b, __func__);

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -1244,6 +1244,19 @@ void initPauliHamil(PauliHamil hamil, qreal* coeffs, enum pauliOpType* codes) {
     }
 }
 
+DiagonalOp createDiagonalOp(int numQubits, QuESTEnv env) {
+    validateNumQubitsInDiagOp(numQubits, env.numRanks, __func__);
+    
+    return agnostic_createDiagonalOp(numQubits, env);
+}
+
+void destroyDiagonalOp(DiagonalOp op, QuESTEnv env) {
+    // env accepted for API consistency
+    validateDiagOpInit(op, __func__);
+    
+    agnostic_destroyDiagonalOp(op);
+}
+
 /*
  * debug
  */

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -1257,6 +1257,25 @@ void destroyDiagonalOp(DiagonalOp op, QuESTEnv env) {
     agnostic_destroyDiagonalOp(op);
 }
 
+void syncDiagonalOp(DiagonalOp op) {
+    validateDiagOpInit(op, __func__);
+    
+    agnostic_syncDiagonalOp(op);
+}
+
+void initDiagonalOp(DiagonalOp op, qreal* real, qreal* imag) {
+    validateDiagOpInit(op, __func__);
+    
+    agnostic_setDiagonalOpElems(op, 0, real, imag, 1LL << op.numQubits);
+}
+
+void setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* real, qreal* imag, long long int numElems) {
+    validateDiagOpInit(op, __func__);
+    validateNumElems(op, startInd, numElems, __func__);
+    
+    agnostic_setDiagonalOpElems(op, startInd, real, imag, numElems);
+}
+
 /*
  * debug
  */

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -884,6 +884,17 @@ void applyMultiControlledMatrixN(Qureg qureg, int* ctrls, const int numCtrls, in
     qasm_recordComment(qureg, "Here, an undisclosed %d-by-%d matrix (possibly non-unitary, and including %d controlled qubits) was multiplied onto %d undisclosed qubits", dim, dim, numCtrls, numTot);
 }
 
+void applyDiagonalOp(Qureg qureg, DiagonalOp op) {
+    validateDiagonalOp(qureg, op, __func__);
+
+    if (qureg.isDensityMatrix)
+        densmatr_applyDiagonalOp(qureg, op);
+    else
+        statevec_applyDiagonalOp(qureg, op);
+
+    qasm_recordComment(qureg, "Here, the register was modified to an undisclosed and possibly unphysical state (via applyDiagonalOp).");
+}
+
 
 /*
  * calculations

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -252,6 +252,10 @@ void statevec_applyPauliSum(Qureg inQureg, enum pauliOpType* allCodes, qreal* te
  
 void agnostic_applyTrotterCircuit(Qureg qureg, PauliHamil hamil, qreal time, int order, int reps);
 
+DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env);
+
+void agnostic_destroyDiagonalOp(DiagonalOp op);
+
 
 # ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -102,6 +102,8 @@ void densmatr_mixMultiQubitKrausMap(Qureg qureg, int* targets, int numTargets, C
 
 void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op);
 
+Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op);
+
 
 /* 
  * operations upon state vectors
@@ -248,6 +250,8 @@ void statevec_setWeightedQureg(Complex fac1, Qureg qureg1, Complex fac2, Qureg q
 void statevec_applyPauliSum(Qureg inQureg, enum pauliOpType* allCodes, qreal* termCoeffs, int numSumTerms, Qureg outQureg);
 
 void statevec_applyDiagonalOp(Qureg qureg, DiagonalOp op);
+
+Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op);
 
 
 /* 

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -99,7 +99,9 @@ void densmatr_mixKrausMap(Qureg qureg, int target, ComplexMatrix2 *ops, int numO
 void densmatr_mixTwoQubitKrausMap(Qureg qureg, int target1, int target2, ComplexMatrix4 *ops, int numOps);
 
 void densmatr_mixMultiQubitKrausMap(Qureg qureg, int* targets, int numTargets, ComplexMatrixN* ops, int numOps);
-    
+
+void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op);
+
 
 /* 
  * operations upon state vectors
@@ -244,6 +246,8 @@ void statevec_multiRotatePauli(Qureg qureg, int* targetQubits, enum pauliOpType*
 void statevec_setWeightedQureg(Complex fac1, Qureg qureg1, Complex fac2, Qureg qureg2, Complex facOut, Qureg out);
 
 void statevec_applyPauliSum(Qureg inQureg, enum pauliOpType* allCodes, qreal* termCoeffs, int numSumTerms, Qureg outQureg);
+
+void statevec_applyDiagonalOp(Qureg qureg, DiagonalOp op);
 
 
 /* 

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -256,6 +256,9 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env);
 
 void agnostic_destroyDiagonalOp(DiagonalOp op);
 
+void agnostic_syncDiagonalOp(DiagonalOp op);
+
+void agnostic_setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* real, qreal* imag, long long int numElems);
 
 # ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -38,8 +38,11 @@ typedef enum {
     E_INVALID_CONTROL_QUBIT,
     E_INVALID_STATE_INDEX,
     E_INVALID_AMP_INDEX,
+    E_INVALID_ELEM_INDEX,
     E_INVALID_NUM_AMPS,
-    E_INVALID_OFFSET_NUM_AMPS,
+    E_INVALID_NUM_ELEMS,
+    E_INVALID_OFFSET_NUM_AMPS_QUREG,
+    E_INVALID_OFFSET_NUM_ELEMS_DIAG,
     E_TARGET_IS_CONTROL,
     E_TARGET_IN_CONTROLS,
     E_CONTROL_TARGET_COLLISION,
@@ -101,8 +104,11 @@ static const char* errorMessages[] = {
     [E_INVALID_CONTROL_QUBIT] = "Invalid control qubit. Must be >=0 and <numQubits.",
     [E_INVALID_STATE_INDEX] = "Invalid state index. Must be >=0 and <2^numQubits.",
     [E_INVALID_AMP_INDEX] = "Invalid amplitude index. Must be >=0 and <2^numQubits.",
+    [E_INVALID_ELEM_INDEX] = "Invalid element index. Must be >=0 and <2^numQubits.",
     [E_INVALID_NUM_AMPS] = "Invalid number of amplitudes. Must be >=0 and <=2^numQubits.",
-    [E_INVALID_OFFSET_NUM_AMPS] = "More amplitudes given than exist in the statevector from the given starting index.",
+    [E_INVALID_NUM_ELEMS] = "Invalid number of elements. Must be >=0 and <=2^numQubits.",
+    [E_INVALID_OFFSET_NUM_AMPS_QUREG] = "More amplitudes given than exist in the statevector from the given starting index.",
+    [E_INVALID_OFFSET_NUM_ELEMS_DIAG] = "More elements given than exist in the diagonal operator from the given starting index.",
     [E_TARGET_IS_CONTROL] = "Control qubit cannot equal target qubit.",
     [E_TARGET_IN_CONTROLS] = "Control qubits cannot include target qubit.",
     [E_CONTROL_TARGET_COLLISION] = "Control and target qubits must be disjoint.",
@@ -343,7 +349,14 @@ void validateAmpIndex(Qureg qureg, long long int ampInd, const char* caller) {
 void validateNumAmps(Qureg qureg, long long int startInd, long long int numAmps, const char* caller) {
     validateAmpIndex(qureg, startInd, caller);
     QuESTAssert(numAmps >= 0 && numAmps <= qureg.numAmpsTotal, E_INVALID_NUM_AMPS, caller);
-    QuESTAssert(numAmps + startInd <= qureg.numAmpsTotal, E_INVALID_OFFSET_NUM_AMPS, caller);
+    QuESTAssert(numAmps + startInd <= qureg.numAmpsTotal, E_INVALID_OFFSET_NUM_AMPS_QUREG, caller);
+}
+
+void validateNumElems(DiagonalOp op, long long int startInd, long long int numElems, const char* caller) {
+    long long int indMax = 1LL << op.numQubits;
+    QuESTAssert(startInd >= 0 && startInd < indMax, E_INVALID_ELEM_INDEX, caller);
+    QuESTAssert(numElems >= 0 && numElems <= indMax, E_INVALID_NUM_ELEMS, caller);
+    QuESTAssert(numElems + startInd <= indMax, E_INVALID_OFFSET_NUM_ELEMS_DIAG, caller);
 }
 
 void validateTarget(Qureg qureg, int targetQubit, const char* caller) {

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -92,7 +92,8 @@ typedef enum {
     E_INVALID_PAULI_HAMIL_FILE_PAULI_CODE,
     E_MISMATCHING_PAULI_HAMIL_QUREG_NUM_QUBITS,
     E_INVALID_TROTTER_ORDER,
-    E_INVALID_TROTTER_REPS
+    E_INVALID_TROTTER_REPS,
+    E_MISMATCHING_QUREG_DIAGONAL_OP_SIZE,
     E_DIAGONAL_OP_NOT_INITIALISED
 } ErrorCode;
 
@@ -158,7 +159,8 @@ static const char* errorMessages[] = {
     [E_INVALID_PAULI_HAMIL_FILE_PAULI_CODE] = "The PauliHamil file (%s) contained an invalid pauli code (%d). Codes must be 0 (or PAULI_I), 1 (PAULI_X), 2 (PAULI_Y) or 3 (PAULI_Z) to indicate the identity, X, Y and Z operators respectively.",
     [E_MISMATCHING_PAULI_HAMIL_QUREG_NUM_QUBITS] = "The PauliHamil must act on the same number of qubits as exist in the Qureg.",
     [E_INVALID_TROTTER_ORDER] = "The Trotterisation order must be 1, or an even number (for higher-order Suzuki symmetrized expansions).",
-    [E_INVALID_TROTTER_REPS] = "The number of Trotter repetitions must be >=1."
+    [E_INVALID_TROTTER_REPS] = "The number of Trotter repetitions must be >=1.",
+    [E_MISMATCHING_QUREG_DIAGONAL_OP_SIZE] = "The qureg must represent an equal number of qubits as that in the applied diagonal operator.",
     [E_DIAGONAL_OP_NOT_INITIALISED] = "The diagonal operator has not been initialised through createDiagonalOperator()."
 };
 
@@ -670,6 +672,11 @@ void validateTrotterParams(int order, int reps, const char* caller) {
 
 void validateDiagOpInit(DiagonalOp op, const char* caller) {
     QuESTAssert(op.real != NULL && op.imag != NULL, E_DIAGONAL_OP_NOT_INITIALISED, caller);
+}
+
+void validateDiagonalOp(Qureg qureg, DiagonalOp op, const char* caller) {
+    validateDiagOpInit(op, caller);
+    QuESTAssert(qureg.numQubitsRepresented == op.numQubits, E_MISMATCHING_QUREG_DIAGONAL_OP_SIZE, caller);
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -126,6 +126,8 @@ void validateTrotterParams(int order, int reps, const char* caller);
 
 void validateDiagOpInit(DiagonalOp, const char* caller);
 
+void validateNumElems(DiagonalOp op, long long int startInd, long long int numElems, const char* caller);
+
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -126,6 +126,8 @@ void validateTrotterParams(int order, int reps, const char* caller);
 
 void validateDiagOpInit(DiagonalOp, const char* caller);
 
+void validateDiagonalOp(Qureg qureg, DiagonalOp op, const char* caller);
+
 void validateNumElems(DiagonalOp op, long long int startInd, long long int numElems, const char* caller);
 
 # ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -24,6 +24,8 @@ void validateNumQubitsInQureg(int numQubits, int numRanks, const char* caller);
 
 void validateNumQubitsInMatrix(int numQubits, const char* caller);
 
+void validateNumQubitsInDiagOp(int numQubits, int numRanks, const char* caller);
+
 void validateAmpIndex(Qureg qureg, long long int ampInd, const char* caller);
 
 void validateStateIndex(Qureg qureg, long long int stateInd, const char* caller);
@@ -121,6 +123,8 @@ void validateHamilFilePauliParsed(int parsed, PauliHamil h, FILE* file, char* fn
 void validateHamilFilePauliCode(enum pauliOpType code, PauliHamil h, FILE* file, char* fn, const char* caller);
 
 void validateTrotterParams(int order, int reps, const char* caller);
+
+void validateDiagOpInit(DiagonalOp, const char* caller);
 
 # ifdef __cplusplus
 }

--- a/tests/test_calculations.cpp
+++ b/tests/test_calculations.cpp
@@ -155,6 +155,8 @@ TEST_CASE( "calcExpecDiagonalOp", "[calculations]" ) {
             REQUIRE( res.real == Approx(real(tr)).margin(100*REAL_EPS) );
             REQUIRE( res.imag == Approx(imag(tr)).margin(100*REAL_EPS) );
         }
+        
+        destroyDiagonalOp(op, QUEST_ENV);
     }
     SECTION( "input validation" ) {
         

--- a/tests/test_calculations.cpp
+++ b/tests/test_calculations.cpp
@@ -128,6 +128,7 @@ TEST_CASE( "calcExpecDiagonalOp", "[calculations]" ) {
             op.real[i] = getRandomReal(-5, 5);
             op.imag[i] = getRandomReal(-5, 5);
         }
+        syncDiagonalOp(op);
         
         SECTION( "state-vector" ) {
 
@@ -151,8 +152,8 @@ TEST_CASE( "calcExpecDiagonalOp", "[calculations]" ) {
                 tr += matRef[i][i];
 
             Complex res = calcExpecDiagonalOp(mat, op);
-            REQUIRE( res.real == Approx(real(tr)).margin(REAL_EPS) );
-            REQUIRE( res.imag == Approx(imag(tr)).margin(REAL_EPS) );
+            REQUIRE( res.real == Approx(real(tr)).margin(100*REAL_EPS) );
+            REQUIRE( res.imag == Approx(imag(tr)).margin(100*REAL_EPS) );
         }
     }
     SECTION( "input validation" ) {
@@ -214,7 +215,7 @@ TEST_CASE( "calcExpecPauliHamil", "[calculations]" ) {
             qreal res = calcExpecPauliHamil(vec, hamil, vecWork);
             REQUIRE( res == Approx(real(prod)).margin(10*REAL_EPS) );
         } 
-        SECTION( "density matrix" ) {
+        SECTION( "density-matrix" ) {
             
             /* calcExpecPauliHamil calculates Trace( pauliHamil * qureg ) */
             matRef = refHamil * matRef;            
@@ -346,7 +347,7 @@ TEST_CASE( "calcExpecPauliProd", "[calculations]" ) {
             qreal res = calcExpecPauliProd(vec, targs, paulis, numTargs, vecWork);
             REQUIRE( res == Approx(real(prod)).margin(REAL_EPS) );
         }
-        SECTION( "density matrix" ) {
+        SECTION( "density-matrix" ) {
             
             /* calcExpecPauliProd calculates Trace( pauliProd * qureg ) */
 
@@ -473,7 +474,7 @@ TEST_CASE( "calcExpecPauliSum", "[calculations]" ) {
             qreal res = calcExpecPauliSum(vec, paulis, coeffs, numSumTerms, vecWork);
             REQUIRE( res == Approx(real(prod)).margin(10*REAL_EPS) );
         } 
-        SECTION( "density matrix" ) {
+        SECTION( "density-matrix" ) {
             
             /* calcExpecPauliSum calculates Trace( pauliSum * qureg ) */
             matRef = pauliSum * matRef;            

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -44,6 +44,7 @@ TEST_CASE( "applyDiagonalOp", "[operators]" ) {
             op.real[i] = getRandomReal(-5, 5);
             op.imag[i] = getRandomReal(-5, 5);
         }
+        syncDiagonalOp(op);
         
         SECTION( "state-vector" ) {
             
@@ -55,7 +56,7 @@ TEST_CASE( "applyDiagonalOp", "[operators]" ) {
             
             QMatrix ref = toQMatrix(op) * refMatr;
             applyDiagonalOp(quregMatr, op);
-            REQUIRE( areEqual(quregMatr, ref) );
+            REQUIRE( areEqual(quregMatr, ref, 100*REAL_EPS) );
         }
         
         destroyDiagonalOp(op, QUEST_ENV);
@@ -704,7 +705,7 @@ TEST_CASE( "applyTrotterCircuit", "[operators]" ) {
                 
                 applyTrotterCircuit(vec, hamil, time, order, reps);
                 multiRotatePauli(vecRef, targs, codes, numTargs, 2*time*coeff);
-                REQUIRE( areEqual(vec, vecRef) );
+                REQUIRE( areEqual(vec, vecRef, 10*REAL_EPS) );
             }
             SECTION( "density-matrix" ) {
                 

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -25,6 +25,58 @@ using Catch::Matchers::Contains;
 
 
 
+/** @sa applyDiagonalOp
+ * @ingroup unittest 
+ * @author Tyson Jones 
+ */
+TEST_CASE( "applyDiagonalOp", "[operators]" ) {
+    
+    PREPARE_TEST( quregVec, quregMatr, refVec, refMatr );
+    
+    SECTION( "correctness" ) {
+        
+        // try 10 random operators 
+        GENERATE( range(0,10) );
+        
+        // make a totally random (non-Hermitian) diagonal oeprator
+        DiagonalOp op = createDiagonalOp(NUM_QUBITS, QUEST_ENV);
+        for (long long int i=0; i<op.numElemsPerChunk; i++) {
+            op.real[i] = getRandomReal(-5, 5);
+            op.imag[i] = getRandomReal(-5, 5);
+        }
+        
+        SECTION( "state-vector" ) {
+            
+            QVector ref = toQMatrix(op) * refVec;
+            applyDiagonalOp(quregVec, op);
+            REQUIRE( areEqual(quregVec, ref) );
+        }
+        SECTION( "density-matrix" ) {
+            
+            QMatrix ref = toQMatrix(op) * refMatr;
+            applyDiagonalOp(quregMatr, op);
+            REQUIRE( areEqual(quregMatr, ref) );
+        }
+        
+        destroyDiagonalOp(op, QUEST_ENV);
+    }
+    SECTION( "input validation" ) {
+        
+        SECTION( "mismatching size" ) {
+            
+            DiagonalOp op = createDiagonalOp(NUM_QUBITS + 1, QUEST_ENV);
+            
+            REQUIRE_THROWS_WITH( applyDiagonalOp(quregVec, op), Contains("equal number of qubits"));
+            REQUIRE_THROWS_WITH( applyDiagonalOp(quregMatr, op), Contains("equal number of qubits"));
+            
+            destroyDiagonalOp(op, QUEST_ENV);
+        }
+    }
+    CLEANUP_TEST( quregVec, quregMatr );
+}
+
+
+
 /** @sa applyMatrix2
  * @ingroup unittest 
  * @author Tyson Jones 

--- a/tests/test_state_initialisations.cpp
+++ b/tests/test_state_initialisations.cpp
@@ -502,7 +502,7 @@ TEST_CASE( "setWeightedQureg", "[state_initialisations]" ) {
             refC = toQVector(vecC);
             setWeightedQureg(facA, vecC, facB, vecC, facC, vecC);
             refOut = numA*refC + numB*refC + numC*refC;
-            REQUIRE( areEqual(vecC, refOut, 1E2*REAL_EPS) );
+            REQUIRE( areEqual(vecC, refOut, 1E3*REAL_EPS) );
         
             // cleanup
             destroyQureg(vecA, QUEST_ENV);

--- a/tests/test_unitaries.cpp
+++ b/tests/test_unitaries.cpp
@@ -654,7 +654,7 @@ TEST_CASE( "controlledRotateZ", "[unitaries]" ) {
         
             controlledRotateZ(quregMatr, control, target, param);
             applyReferenceOp(refMatr, control, target, op);    
-            REQUIRE( areEqual(quregMatr, refMatr) );
+            REQUIRE( areEqual(quregMatr, refMatr, 10*REAL_EPS) );
         }
     }
     SECTION( "input validation" ) {

--- a/tests/utilities.hpp
+++ b/tests/utilities.hpp
@@ -106,6 +106,15 @@ QVector operator * (const QMatrix& m, const QVector& v);
  */
 QVector toQVector(Qureg qureg);
 
+/** Returns a vector with the same of the full diagonal operator,
+ * populated with \p op's elements.
+ * In distributed mode, this involves an all-to-all broadcast of \p op.
+ *
+ * @ingroup testutilities
+ * @author Tyson Jones
+ */
+QVector toQVector(DiagonalOp op);
+
 /** Returns an equal-size copy of the given density matrix \p qureg.
  * In GPU mode, this function involves a copy of \p qureg from GPU memory to RAM.
  * In distributed mode, this involves an all-to-all broadcast of \p qureg.
@@ -158,6 +167,13 @@ QMatrix toQMatrix(qreal* coeffs, pauliOpType* paulis, int numQubits, int numTerm
  * @author Tyson Jones
  */
 QMatrix toQMatrix(PauliHamil hamil);
+
+/** Returns a 2^\p N-by-2^\p N complex diagonal matrix form of the DiagonalOp
+ *
+ * @ingroup testutilities
+ * @author Tyson Jones
+ */
+QMatrix toQMatrix(DiagonalOp op);
 
 /** Returns a \p ComplexMatrix2 copy of QMatix \p qm.
  * Demands that \p qm is a 2-by-2 matrix.
@@ -807,6 +823,14 @@ bool areEqual(QVector a, QVector b);
  * @author Tyson Jones
  */
 bool areEqual(QMatrix a, QMatrix b);
+
+/** Returns true if the absolute value of the difference between every element in 
+ * \p vec and those implied by \p reals and \p imags, is less than \p REAL_EPS.
+ *
+ * @ingroup testutilities 
+ * @author Tyson Jones
+ */
+bool areEqual(QVector vec, qreal* reals, qreal* imags);
 
 /** Returns the unit-norm complex number exp(i*\p phase). This function uses the 
  * Euler formula, and avoids problems with calling exp(__complex__) in a platform 


### PR DESCRIPTION
unit testing passed for:

- serial (MacOS)
- multithreaded and distributed (Ubuntu, for `2`, `4`, `8` and `16` nodes)
- GPU (Ubuntu, Quadro P5000)