### PR TITLE
OpenMP version mismatch will still lead to an attempted link

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -318,7 +318,7 @@ target_compile_definitions(QuEST
 
 # ----- OMP -------------------------------------------------------------------
 
-if (OPENMP_FOUND)
+if (MULTITHREADED AND OPENMP_FOUND)
   target_link_libraries(QuEST PUBLIC OpenMP::OpenMP_C)
 endif ()
 


### PR DESCRIPTION
In [QuEST/CMakeLists.txt:138](https://github.com/QuEST-Kit/QuEST/blob/c8b954abd1fd0a9f1a2e8fb98efed700f2ff75bf/QuEST/CMakeLists.txt#L138) when `MULTITHREADED` is set to 0 due to the version being too low, the library will still be attempted to be linked in [QuEST/CMakeLists.txt:322](https://github.com/QuEST-Kit/QuEST/blob/c8b954abd1fd0a9f1a2e8fb98efed700f2ff75bf/QuEST/CMakeLists.txt#L322).

We can simply check for both OPENMP_FOUND and MULTITHREADED before linking OpenMP.