### PR TITLE
Update required cmake version to 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # author: Tyson Jones (testing)
 
 # CMake initialisation.
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7)
 
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 message(STATUS "CMake build type: ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
This fixes the bug described in #129 in cmake in https://gitlab.kitware.com/cmake/cmake/-/issues/14201 where cuda_add_library would not pick up the include files as given by target_include_directories.
This was fixed in this [commit](https://gitlab.kitware.com/cmake/cmake/-/commit/7ded655f7ba82ea72a82d0555449f2df5ef38594) which first made it into cmake version 3.7, and therefore this fix simply increases our required cmake version.