### PR TITLE
Cmake warnings

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -19,6 +19,8 @@
 # eg
 #   cmake -DDISTRIBUTED=1 ..
 
+cmake_minimum_required(VERSION 3.7)
+project(QuEST_Library)
 
 option(MULTITHREADED "Switches on OpenMP Threading if an OpenMP implementation can be found. Set to 0 to disable." 1)
 


### PR DESCRIPTION
Modified QuEST/CMakeLists.txt to suppress warnings and make it useful for a standalone library building.