### PR TITLE
Implementing HermitianDiagOp

### DIFF
--- a/QuEST/src/CPU/QuEST_cpu_internal.h
+++ b/QuEST/src/CPU/QuEST_cpu_internal.h
@@ -89,7 +89,11 @@ void densmatr_mixTwoQubitDepolarisingQ1LocalQ2DistributedPart3(Qureg qureg, int 
                 
 void densmatr_applyDiagonalOpLocal(Qureg qureg, DiagonalOp op);
 
+void densmatr_applyHermitianDiagOpLocal(Qureg qureg, HermitianDiagOp op);
+
 Complex densmatr_calcExpecDiagonalOpLocal(Qureg qureg, DiagonalOp op);
+
+qreal densmatr_calcExpecHermitianDiagOpLocal(Qureg qureg, HermitianDiagOp op);
 
 
 /*
@@ -194,5 +198,6 @@ void statevec_multiControlledMultiQubitUnitaryLocal(Qureg qureg, long long int c
 
 Complex statevec_calcExpecDiagonalOpLocal(Qureg qureg, DiagonalOp op);
 
+qreal statevec_calcExpecHermitianDiagOpLocal(Qureg qureg, HermitianDiagOp op);
 
 # endif // QUEST_CPU_INTERNAL_H

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -347,12 +347,34 @@ void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op) {
     qureg.pairStateVec.imag = imPtr;
 }
 
+void densmatr_applyHermitianDiagOp(Qureg qureg, HermitianDiagOp op) {
+
+    // we must preload qureg.pairStateVec with the elements of op.
+    // instead of needless cloning, we'll just temporarily swap the pointers
+    qreal* rePtr = qureg.pairStateVec.real;
+    qureg.pairStateVec.real = op.diag;
+    
+    densmatr_applyHermitianDiagOpLocal(qureg, op);
+
+    qureg.pairStateVec.real = rePtr;
+}
+
 Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
 
     return statevec_calcExpecDiagonalOpLocal(qureg, op);
 }
 
+qreal statevec_calcExpecHermitianDiagOp(Qureg qureg, HermitianDiagOp op) {
+
+    return statevec_calcExpecHermitianDiagOpLocal(qureg, op);
+}
+
 Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
     
     return densmatr_calcExpecDiagonalOpLocal(qureg, op);
+}
+
+qreal densmatr_calcExpecHermitianDiagOp(Qureg qureg, HermitianDiagOp op) {
+    
+    return densmatr_calcExpecHermitianDiagOpLocal(qureg, op);
 }

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -895,6 +895,17 @@ void applyDiagonalOp(Qureg qureg, DiagonalOp op) {
     qasm_recordComment(qureg, "Here, the register was modified to an undisclosed and possibly unphysical state (via applyDiagonalOp).");
 }
 
+void applyHermitianDiagOp(Qureg qureg, HermitianDiagOp op) {
+    validateHermitianDiagOp(qureg, op, __func__);
+
+    if (qureg.isDensityMatrix)
+        densmatr_applyHermitianDiagOp(qureg, op);
+    else
+        statevec_applyHermitianDiagOp(qureg, op);
+
+    qasm_recordComment(qureg, "Here, the register was modified to an undisclosed and possibly unphysical state (via applyHermitianDiagOp).");
+}
+
 
 /*
  * calculations
@@ -983,6 +994,15 @@ Complex calcExpecDiagonalOp(Qureg qureg, DiagonalOp op) {
         return densmatr_calcExpecDiagonalOp(qureg, op);
     else
         return statevec_calcExpecDiagonalOp(qureg, op);
+}
+
+qreal calcExpecHermitianDiagOp(Qureg qureg, HermitianDiagOp op) {
+    validateHermitianDiagOp(qureg, op, __func__);
+
+    if (qureg.isDensityMatrix)
+    	return densmatr_calcExpecHermitianDiagOp(qureg, op);
+    else
+        return statevec_calcExpecHermitianDiagOp(qureg, op);
 }
 
 qreal calcHilbertSchmidtDistance(Qureg a, Qureg b) {
@@ -1294,6 +1314,45 @@ void setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* real, qrea
     validateNumElems(op, startInd, numElems, __func__);
     
     agnostic_setDiagonalOpElems(op, startInd, real, imag, numElems);
+}
+
+HermitianDiagOp createHermitianDiagOp(int numQubits, QuESTEnv env) {
+    validateNumQubitsInDiagOp(numQubits, env.numRanks, __func__);
+
+    return agnostic_createHermitianDiagOp(numQubits, env);
+}
+
+void destroyHermitianDiagOp(HermitianDiagOp op, QuESTEnv env) {
+    // env accepted for API consistency
+    validateHermitianDiagOpInit(op, __func__);
+
+    agnostic_destroyHermitianDiagOp(op);
+}
+
+void syncHermitianDiagOp(HermitianDiagOp op) {
+    validateHermitianDiagOpInit(op, __func__);
+
+    agnostic_syncHermitianDiagOp(op);
+}
+
+void initHermitianDiagOp(HermitianDiagOp op, qreal* diag) {
+    validateHermitianDiagOpInit(op, __func__);
+
+    agnostic_setHermitianDiagOpElems(op, 0, diag, 1LL << op.numQubits);
+}
+
+void setHermitianDiagOpElemsFromIsingHamiltonian(HermitianDiagOp op, PauliHamil isingHam){
+    validateHermitianDiagOpInit(op, __func__);
+
+    agnostic_setHermitianDiagOpElemsFromIsingHamiltonian(op, isingHam);
+
+}
+
+void setHermitianDiagOpElems(HermitianDiagOp op, long long int startInd, qreal* diag, long long int numElems) {
+    validateHermitianDiagOpInit(op, __func__);
+    validateNumElemsHermitianDiagOp(op, startInd, numElems, __func__);
+
+    agnostic_setHermitianDiagOpElems(op, startInd, diag, numElems);
 }
 
 /*

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -104,6 +104,9 @@ void densmatr_applyDiagonalOp(Qureg qureg, DiagonalOp op);
 
 Complex densmatr_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op);
 
+void densmatr_applyHermitianDiagOp(Qureg qureg, HermitianDiagOp op);
+
+qreal densmatr_calcExpecHermitianDiagOp(Qureg qureg, HermitianDiagOp op);
 
 /* 
  * operations upon state vectors
@@ -253,6 +256,9 @@ void statevec_applyDiagonalOp(Qureg qureg, DiagonalOp op);
 
 Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op);
 
+void statevec_applyHermitianDiagOp(Qureg qureg, HermitianDiagOp op);
+
+qreal statevec_calcExpecHermitianDiagOp(Qureg qureg, HermitianDiagOp op);
 
 /* 
  * operations which differentiate between state-vectors and density matrices internally 
@@ -262,11 +268,21 @@ void agnostic_applyTrotterCircuit(Qureg qureg, PauliHamil hamil, qreal time, int
 
 DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env);
 
+HermitianDiagOp agnostic_createHermitianDiagOp(int numQubits, QuESTEnv env);
+
 void agnostic_destroyDiagonalOp(DiagonalOp op);
+
+void agnostic_destroyHermitianDiagOp(HermitianDiagOp op);
 
 void agnostic_syncDiagonalOp(DiagonalOp op);
 
+void agnostic_syncHermitianDiagOp(HermitianDiagOp op);
+
 void agnostic_setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* real, qreal* imag, long long int numElems);
+
+void agnostic_setHermitianDiagOpElems(HermitianDiagOp op, long long int startInd, qreal* diag, long long int numElems);
+
+void agnostic_setHermitianDiagOpElemsFromIsingHamiltonian(HermitianDiagOp op, PauliHamil isingHam);
 
 # ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -128,7 +128,14 @@ void validateDiagOpInit(DiagonalOp, const char* caller);
 
 void validateDiagonalOp(Qureg qureg, DiagonalOp op, const char* caller);
 
+void validateHermitianDiagOpInit(HermitianDiagOp, const char* caller);
+
+void validateHermitianDiagOp(Qureg qureg, HermitianDiagOp op, const char* caller);
+
 void validateNumElems(DiagonalOp op, long long int startInd, long long int numElems, const char* caller);
+
+void validateNumElemsHermitianDiagOp(HermitianDiagOp op, long long int startInd, long long int numElems, const char* caller);
+
 
 # ifdef __cplusplus
 }

--- a/tests/utilities.hpp
+++ b/tests/utilities.hpp
@@ -115,6 +115,16 @@ QVector toQVector(Qureg qureg);
  */
 QVector toQVector(DiagonalOp op);
 
+/** Returns a vector with the same of the full hermitian diagonal operator,
+ * populated with \p op's elements.
+ * In distributed mode, this involves an all-to-all broadcast of \p op.
+ *
+ * @ingroup testutilities
+ * @author Tyson Jones
+ */
+QVector toQVector(HermitianDiagOp op);
+
+
 /** Returns an equal-size copy of the given density matrix \p qureg.
  * In GPU mode, this function involves a copy of \p qureg from GPU memory to RAM.
  * In distributed mode, this involves an all-to-all broadcast of \p qureg.
@@ -174,6 +184,13 @@ QMatrix toQMatrix(PauliHamil hamil);
  * @author Tyson Jones
  */
 QMatrix toQMatrix(DiagonalOp op);
+
+/** Returns a 2^\p N-by-2^\p N hermitian diagonal matrix form of the HermitianDiagOp
+ *
+ * @ingroup testutilities
+ * @author Tyson Jones
+ */
+QMatrix toQMatrix(HermitianDiagOp op);
 
 /** Returns a \p ComplexMatrix2 copy of QMatix \p qm.
  * Demands that \p qm is a 2-by-2 matrix.


### PR DESCRIPTION
Implementation of Hermitian diagonal operator. The implementation was straightforward as a diagonal operator implementation already existed. This can be useful in scenarios when memory limits are being reached as we do not need to store imaginary amplitudes for the operator.

The commit also includes a function that can calculate diagonal of the Ising spin Hamiltonian, 
``void setHermitianDiagOpElemsFromIsingHamiltonian``
which can be useful when QuEST is used to simulate variational quantum algorithms.