### PR TITLE
Implementing calculateStateOverlap

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -1987,6 +1987,19 @@ void controlledNot(Qureg qureg, int controlQubit, int targetQubit);
  */
 void controlledPauliY(Qureg qureg, int controlQubit, int targetQubit);
 
+/**
+ * Computes an overlap <A|B> of a classical state A represented by a decimal and a reference state B given as a Qureg.
+ *
+ * @ingroup calc
+ * @param[in] classical_state_descriptor decimal representation of binary string corresponding to a classical state
+ * @param[in] ket a reference state to compute an overlap with
+ * @return an overlap of a classical state represented by classical_state_descriptor and a reference state ket
+ * @throws invalidQuESTInputError
+ * 	if \p classical_state_descriptor does not represent a valid quantum state
+ * @author Milos Prokop
+ */
+Complex calcInnerProductWithClassicalState(int classical_state_descriptor, Qureg ket);
+
 /** Gives the probability of a specified qubit being measured in the given outcome (0 or 1).
  * This performs no actual measurement and does not change the state of the qubits.
  * 

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -1110,6 +1110,29 @@ Complex statevec_calcInnerProductLocal(Qureg bra, Qureg ket) {
     return innerProd;
 }
 
+Complex statevec_calcInnerProductWithClassicalState_local(int classical_state_descriptor, Qureg ket){
+
+	long long int numAmps = ket.numAmpsPerChunk;
+	int chunkId = ket.chunkId;
+
+	qreal *ketVecReal = ket.stateVec.real;
+	qreal *ketVecImag = ket.stateVec.imag;
+
+	if(classical_state_descriptor < chunkId*numAmps || classical_state_descriptor >= (chunkId+1)*numAmps){
+		Complex zero;
+		zero.real = zero.imag = 0;
+		return zero;
+	}
+
+	long long int index = classical_state_descriptor - chunkId*numAmps;
+
+	Complex innerProd;
+	innerProd.real = ketVecReal[index];
+	innerProd.imag = ketVecImag[index];
+
+	return innerProd;
+}
+
 
 
 void densmatr_initClassicalState (Qureg qureg, long long int stateInd)

--- a/QuEST/src/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/src/CPU/QuEST_cpu_distributed.c
@@ -50,6 +50,24 @@ Complex statevec_calcInnerProduct(Qureg bra, Qureg ket) {
     return globalInnerProd;
 }
 
+Complex statevec_calcInnerProductWithClassicalState(int classical_state_descriptor, Qureg ket) {
+
+	Complex localInnerProd = statevec_calcInnerProductWithClassicalState_local(classical_state_descriptor, ket);
+    if (ket.numChunks == 1)
+        return localInnerProd;
+
+    qreal localReal = localInnerProd.real;
+    qreal localImag = localInnerProd.imag;
+    qreal globalReal, globalImag;
+    MPI_Allreduce(&localReal, &globalReal, 1, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&localImag, &globalImag, 1, MPI_QuEST_REAL, MPI_SUM, MPI_COMM_WORLD);
+
+    Complex globalInnerProd;
+    globalInnerProd.real = globalReal;
+    globalInnerProd.imag = globalImag;
+    return globalInnerProd;
+}
+
 qreal densmatr_calcTotalProb(Qureg qureg) {
 	
 	// computes the trace by summing every element ("diag") with global index (2^n + 1)i for i in [0, 2^n-1]

--- a/QuEST/src/CPU/QuEST_cpu_internal.h
+++ b/QuEST/src/CPU/QuEST_cpu_internal.h
@@ -98,6 +98,8 @@ Complex densmatr_calcExpecDiagonalOpLocal(Qureg qureg, DiagonalOp op);
 
 Complex statevec_calcInnerProductLocal(Qureg bra, Qureg ket);
 
+Complex statevec_calcInnerProductWithClassicalState_local(int classical_state_descriptor, Qureg ket);
+
 void statevec_compactUnitaryLocal (Qureg qureg, int targetQubit, Complex alpha, Complex beta);
 
 void statevec_compactUnitaryDistributed (Qureg qureg,

--- a/QuEST/src/CPU/QuEST_cpu_local.c
+++ b/QuEST/src/CPU/QuEST_cpu_local.c
@@ -115,6 +115,11 @@ Complex statevec_calcInnerProduct(Qureg bra, Qureg ket) {
     return statevec_calcInnerProductLocal(bra, ket);
 }
 
+Complex statevec_calcInnerProductWithClassicalState(int classical_state_descriptor, Qureg ket) {
+
+    return statevec_calcInnerProductWithClassicalState_local(classical_state_descriptor, ket);
+}
+
 qreal densmatr_calcTotalProb(Qureg qureg) {
     
     // computes the trace using Kahan summation

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -915,6 +915,14 @@ Complex calcInnerProduct(Qureg bra, Qureg ket) {
     return statevec_calcInnerProduct(bra, ket);
 }
 
+Complex calcInnerProductWithClassicalState(int classical_state_descriptor, Qureg ket) {
+
+    validateClassicalStateDescriptor(classical_state_descriptor, ket.numAmpsTotal, __func__);
+    validateStateVecQureg(ket, __func__);
+
+    return statevec_calcInnerProductWithClassicalState(classical_state_descriptor, ket);
+}
+
 qreal calcDensityInnerProduct(Qureg rho1, Qureg rho2) {
     validateDensityMatrQureg(rho1, __func__);
     validateDensityMatrQureg(rho2, __func__);

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -179,6 +179,8 @@ qreal statevec_calcFidelity(Qureg qureg, Qureg pureState);
 
 Complex statevec_calcInnerProduct(Qureg bra, Qureg ket);
 
+Complex statevec_calcInnerProductWithClassicalState(int classical_state_descriptor, Qureg ket);
+
 qreal statevec_calcExpecPauliProd(Qureg qureg, int* targetQubits, enum pauliOpType* pauliCodes, int numTargets, Qureg workspace);
 
 qreal statevec_calcExpecPauliSum(Qureg qureg, enum pauliOpType* allCodes, qreal* termCoeffs, int numSumTerms, Qureg workspace);

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -94,7 +94,8 @@ typedef enum {
     E_INVALID_TROTTER_ORDER,
     E_INVALID_TROTTER_REPS,
     E_MISMATCHING_QUREG_DIAGONAL_OP_SIZE,
-    E_DIAGONAL_OP_NOT_INITIALISED
+    E_DIAGONAL_OP_NOT_INITIALISED,
+	E_INVALID_CLASS_STATE_DESCR
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -161,7 +162,8 @@ static const char* errorMessages[] = {
     [E_INVALID_TROTTER_ORDER] = "The Trotterisation order must be 1, or an even number (for higher-order Suzuki symmetrized expansions).",
     [E_INVALID_TROTTER_REPS] = "The number of Trotter repetitions must be >=1.",
     [E_MISMATCHING_QUREG_DIAGONAL_OP_SIZE] = "The qureg must represent an equal number of qubits as that in the applied diagonal operator.",
-    [E_DIAGONAL_OP_NOT_INITIALISED] = "The diagonal operator has not been initialised through createDiagonalOperator()."
+    [E_DIAGONAL_OP_NOT_INITIALISED] = "The diagonal operator has not been initialised through createDiagonalOperator().",
+	[E_INVALID_CLASS_STATE_DESCR] = "Invalid classical state descriptor."
 };
 
 void exitWithError(const char* msg, const char* func) {
@@ -478,6 +480,10 @@ void validateVector(Vector vec, const char* caller) {
 
 void validateStateVecQureg(Qureg qureg, const char* caller) {
     QuESTAssert( ! qureg.isDensityMatrix, E_DEFINED_ONLY_FOR_STATEVECS, caller);
+}
+
+void validateClassicalStateDescriptor(int classical_state_descriptor, long long int ket_amps_total, const char* caller){
+    QuESTAssert( classical_state_descriptor >= 0 && classical_state_descriptor < (1ULL<<ket_amps_total), E_INVALID_CLASS_STATE_DESCR, caller);
 }
 
 void validateDensityMatrQureg(Qureg qureg, const char* caller) {

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -64,6 +64,8 @@ void validateVector(Vector vector, const char* caller);
 
 void validateStateVecQureg(Qureg qureg, const char* caller);
 
+void validateClassicalStateDescriptor(int classical_state_descriptor, long long int ket_amps_total, const char* caller);
+
 void validateDensityMatrQureg(Qureg qureg, const char* caller);
 
 void validateOutcome(int outcome, const char* caller);


### PR DESCRIPTION
Implementing ``Complex calcInnerProductWithClassicalState`` that evaluates braket <A|B> of a classical state A representing by a decimal and a state B given by qureg.