### PR TITLE
Phase functions with shift

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -209,6 +209,7 @@ typedef struct Vector
  *    - \p SCALED_NORM maps state \f$|x\rangle|y\rangle\dots\f$ to \f$\text{coeff} \sqrt{x^2 + y^2 + \dots}\f$
  *    - \p INVERSE_NORM maps state \f$|x\rangle|y\rangle\dots\f$ to \f$1/\sqrt{x^2 + y^2 + \dots}\f$
  *    - \p SCALED_INVERSE_NORM maps state \f$|x\rangle|y\rangle\dots\f$ to \f$\text{coeff}/\sqrt{x^2 + y^2 + \dots}\f$
+ *    - \p SCALED_INVERSE_SHIFTED_NORM maps state \f$|x\rangle|y\rangle\dots\f$ to \f$\text{coeff}/\sqrt{(x-\Delta_x)^2 + (y-\Delta_y)^2 + \dots}\f$
  *
  * Product based phase functions:
  *    - \p PRODUCT maps state \f$|x\rangle|y\rangle|z\rangle\dots\f$ to \f$x \; y \; z \dots\f$
@@ -221,14 +222,16 @@ typedef struct Vector
  *    - \p SCALED_DISTANCE maps state \f$|x_1\rangle|x_2\rangle|y_1\rangle|y_2\rangle\dots\f$ to \f$\text{coeff}\sqrt{(x_1-x_2)^2 + (y_1-y_2)^2 + \dots}\f$
  *    - \p INVERSE_DISTANCE maps state \f$|x_1\rangle|x_2\rangle|y_1\rangle|y_2\rangle\dots\f$ to \f$1/\sqrt{(x_1-x_2)^2 + (y_1-y_2)^2 + \dots}\f$
  *    - \p SCALED_INVERSE_DISTANCE maps state \f$|x_1\rangle|x_2\rangle|y_1\rangle|y_2\rangle\dots\f$ to \f$\text{coeff}/\sqrt{(x_1-x_2)^2 + (y_1-y_2)^2 + \dots}\f$
+ *    - \p SCALED_INVERSE_SHIFTED_DISTANCE maps state \f$|x_1\rangle|x_2\rangle|y_1\rangle|y_2\rangle\dots\f$ to \f$\text{coeff}/\sqrt{(x_1-x_2-\Delta_x)^2 + (y_1-y_2-\Delta_y)^2 + \dots}\f$
  *
  * @ingroup type 
  * @author Tyson Jones
+ * @author Richard Meister (shifted functions)
  */
 enum phaseFunc {
-    NORM=0,     SCALED_NORM=1,      INVERSE_NORM=2,         SCALED_INVERSE_NORM=3, 
-    PRODUCT=4,  SCALED_PRODUCT=5,   INVERSE_PRODUCT=6,      SCALED_INVERSE_PRODUCT=7, 
-    DISTANCE=8, SCALED_DISTANCE=9,  INVERSE_DISTANCE=10,    SCALED_INVERSE_DISTANCE=11};
+    NORM=0,     SCALED_NORM=1,      INVERSE_NORM=2,      SCALED_INVERSE_NORM=3,      SCALED_INVERSE_SHIFTED_NORM=4,
+    PRODUCT=5,  SCALED_PRODUCT=6,   INVERSE_PRODUCT=7,   SCALED_INVERSE_PRODUCT=8,
+    DISTANCE=9, SCALED_DISTANCE=10, INVERSE_DISTANCE=11, SCALED_INVERSE_DISTANCE=12, SCALED_INVERSE_SHIFTED_DISTANCE=13};
     
 /** Flags for specifying how the bits in sub-register computational basis states 
  * are mapped to indices in functions like applyPhaseFunc().

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -5951,7 +5951,7 @@ void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg
  *   ```
  *   invokes phase function 
  *   \f[
- *      f(\vec{r}, \theta)|_{\theta=0.5} \; = \; \begin{cases} \pi & \;\;\; \vec{r}=\vec{0} \\ \displaystyle 0.5 \sqrt{ \sum_j^{\text{numRegs}} {r_j}^2 } & \;\;\;\text{otherwise} \end{cases}.
+ *      f(\vec{r}, \theta)|_{\theta=0.5} \; = \; \begin{cases} \pi & \;\;\; \vec{r}=\vec{0} \\ \displaystyle 0.5 \left[ \sum_j^{\text{numRegs}} {r_j}^2 \right]^{-1/2} & \;\;\;\text{otherwise} \end{cases}.
  *   \f] 
  *
  * - Functions allowing the shifting of sub-register values, which are \p SCALED_INVERSE_SHIFTED_NORM

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -5953,6 +5953,38 @@ void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg
  *   \f[
  *      f(\vec{r}, \theta)|_{\theta=0.5} \; = \; \begin{cases} \pi & \;\;\; \vec{r}=\vec{0} \\ \displaystyle 0.5 \sqrt{ \sum_j^{\text{numRegs}} {r_j}^2 } & \;\;\;\text{otherwise} \end{cases}.
  *   \f] 
+ *
+ * - Functions allowing the shifting of sub-register values, which are \p SCALED_INVERSE_SHIFTED_NORM
+ *   and \p SCALED_INVERSE_SHIFTED_DISTANCE, need these shift values to be passed in the \p params
+ *   argument _after_ the scaling and divergence override parameters listed above. The function
+ *   \p SCALED_INVERSE_SHIFTED_NORM needs as many extra parameters, as there are sub-registers;
+ *   \p SCALED_INVERSE_SHIFTED_DISTANCE needs one extra parameter for each pair of sub-registers.
+ *   For example,
+ *   ```
+ *   enum phaseFunc functionNameCode = SCALED_INVERSE_SHIFTED_NORM;
+ *   int qubits[] = {0,1,2,3, 4,5,6,7};
+ *   int qubitsPerReg[] = {4, 4};
+ *   qreal params[] = {0.5, M_PI, 0.8, -0.3};
+ *   int numParams = 4;
+ *   applyParamNamedPhaseFunc(..., qubits, qubitsPerReg, 2, ..., functionNameCode, params, numParams);
+ *   ```
+ *   invokes phase function 
+ *   \f[
+ *      f(\vec{r}) \; = \; \begin{cases} \pi & \;\;\; \vec{r}=\vec{0} \\ \displaystyle 0.5 \left[(r_1-0.8)^2 + (r_2+0.3)^2\right]^{-1/2} & \;\;\;\text{otherwise} \end{cases}.
+ *   \f] 
+ *   and
+ *   ```
+ *   enum phaseFunc functionNameCode = SCALED_INVERSE_SHIFTED_DISTANCE;
+ *   int qubits[] = {0,1, 2,3, 4,5, 6,7};
+ *   int qubitsPerReg[] = {2, 2, 2, 2};
+ *   qreal params[] = {0.5, M_PI, 0.8, -0.3};
+ *   int numParams = 4;
+ *   applyParamNamedPhaseFunc(..., qubits, qubitsPerReg, 4, ..., functionNameCode, params, numParams);
+ *   ```
+ *   invokes phase function 
+ *   \f[
+ *      f(\vec{r}) \; = \; \begin{cases} \pi & \;\;\; \vec{r}=\vec{0} \\ \displaystyle 0.5 \left[(r_1-r_2-0.8)^2 + (r_3-r_4+0.3)^2\right]^{-1/2} & \;\;\;\text{otherwise} \end{cases}.
+ *   \f] 
  * 
  *   > You can further override \f$f(\vec{r}, \vec{\theta})\f$ at one or more \f$\vec{r}\f$ values
  *   > via applyParamNamedPhaseFuncOverrides().
@@ -5997,6 +6029,7 @@ void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg
  * - if \p functionNameCode is not a valid ::phaseFunc
  * - if \p numParams is incompatible with \p functionNameCode (for example, no parameters were passed to \p SCALED_PRODUCT)
  * @author Tyson Jones
+ * @author Richard Meister (shifted functions)
  */
 void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams);
 

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -4477,11 +4477,17 @@ void statevec_applyParamNamedPhaseFuncOverrides(
             else {
                 // compute norm related phases
                 if (phaseFuncName == NORM || phaseFuncName == INVERSE_NORM ||
-                    phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM) {
+                    phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM ||
+                    phaseFuncName == SCALED_INVERSE_SHIFTED_NORM) {
 
                     norm = 0;
-                    for (r=0; r<numRegs; r++)
-                        norm += phaseInds[r]*phaseInds[r];
+                    if (phaseFuncName == SCALED_INVERSE_SHIFTED_NORM) {
+                        for (r=0; r<numRegs; r++)
+                            norm += (phaseInds[r] - params[2+r])*(phaseInds[r] - params[2+r]);
+                    }
+                    else
+                        for (r=0; r<numRegs; r++)
+                            norm += phaseInds[r]*phaseInds[r];
                     norm = sqrt(norm);
 
                     if (phaseFuncName == NORM)
@@ -4490,7 +4496,7 @@ void statevec_applyParamNamedPhaseFuncOverrides(
                         phase = (norm == 0.)? params[0] : 1/norm;
                     else if (phaseFuncName == SCALED_NORM)
                         phase = params[0] * norm;
-                    else if (phaseFuncName == SCALED_INVERSE_NORM)
+                    else if (phaseFuncName == SCALED_INVERSE_NORM || phaseFuncName == SCALED_INVERSE_SHIFTED_NORM)
                         phase = (norm == 0.)? params[1] : params[0] / norm;
                 }
                 // compute product related phases
@@ -4512,11 +4518,17 @@ void statevec_applyParamNamedPhaseFuncOverrides(
                 }
                 // compute Euclidean distance related phases 
                 else if (phaseFuncName == DISTANCE || phaseFuncName == INVERSE_DISTANCE ||
-                         phaseFuncName == SCALED_DISTANCE || phaseFuncName == SCALED_INVERSE_DISTANCE) {
+                         phaseFuncName == SCALED_DISTANCE || phaseFuncName == SCALED_INVERSE_DISTANCE ||
+                         phaseFuncName == SCALED_INVERSE_SHIFTED_DISTANCE) {
 
                     dist = 0;
-                    for (r=0; r<numRegs; r+=2)
-                        dist += (phaseInds[r+1] - phaseInds[r])*(phaseInds[r+1] - phaseInds[r]);
+                    if (phaseFuncName == SCALED_INVERSE_SHIFTED_DISTANCE) {
+                        for (r=0; r<numRegs; r+=2)
+                            dist += (phaseInds[r+1] - phaseInds[r] - params[2+r/2])*(phaseInds[r+1] - phaseInds[r] - params[2+r/2]);
+                    }
+                    else
+                        for (r=0; r<numRegs; r+=2)
+                            dist += (phaseInds[r+1] - phaseInds[r])*(phaseInds[r+1] - phaseInds[r]);
                     dist = sqrt(dist);
 
                     if (phaseFuncName == DISTANCE)
@@ -4525,7 +4537,7 @@ void statevec_applyParamNamedPhaseFuncOverrides(
                         phase = (dist == 0.)? params[0] : 1/dist;
                     else if (phaseFuncName == SCALED_DISTANCE)
                         phase = params[0] * dist;
-                    else if (phaseFuncName == SCALED_INVERSE_DISTANCE)
+                    else if (phaseFuncName == SCALED_INVERSE_DISTANCE || phaseFuncName == SCALED_INVERSE_SHIFTED_DISTANCE)
                         phase = (dist == 0.)? params[1] : params[0] / dist;
                 }
             }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -3768,10 +3768,18 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
     else {
         // compute norm related phases
         if (phaseFuncName == NORM || phaseFuncName == INVERSE_NORM ||
-            phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM) {
+            phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM ||
+            phaseFuncName == SCALED_INVERSE_SHIFTED_NORM) {
             qreal norm = 0;
-            for (int r=0; r<numRegs; r++)
-                norm += phaseInds[r*stride+offset]*phaseInds[r*stride+offset];
+            if (phaseFuncName == SCALED_INVERSE_SHIFTED_NORM) {
+                for (int r=0; r<numRegs; r++) {
+                    qreal dif = phaseInds[r*stride+offset] - params[2+r];
+                    norm += dif*dif;
+                }
+            }
+            else
+                for (int r=0; r<numRegs; r++)
+                    norm += phaseInds[r*stride+offset]*phaseInds[r*stride+offset];
             norm = sqrt(norm);
 
             if (phaseFuncName == NORM)
@@ -3780,7 +3788,7 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
                 phase = (norm == 0.)? params[0] : 1/norm;
             else if (phaseFuncName == SCALED_NORM)
                 phase = params[0] * norm;
-            else if (phaseFuncName == SCALED_INVERSE_NORM)
+            else if (phaseFuncName == SCALED_INVERSE_NORM || phaseFuncName == SCALED_INVERSE_SHIFTED_NORM)
                 phase = (norm == 0.)? params[1] : params[0] / norm;
         }
         // compute product related phases
@@ -3802,13 +3810,21 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
         }
         // compute Euclidean distance related phases 
         else if (phaseFuncName == DISTANCE || phaseFuncName == INVERSE_DISTANCE ||
-                 phaseFuncName == SCALED_DISTANCE || phaseFuncName == SCALED_INVERSE_DISTANCE) {
+                 phaseFuncName == SCALED_DISTANCE || phaseFuncName == SCALED_INVERSE_DISTANCE ||
+                 phaseFuncName == SCALED_INVERSE_SHIFTED_DISTANCE) {
 
             qreal dist = 0;
-            for (int r=0; r<numRegs; r+=2) {
-                qreal dif = (phaseInds[(r+1)*stride+offset] - phaseInds[r*stride+offset]);
-                dist += dif*dif;
+            if (phaseFuncName == SCALED_INVERSE_SHIFTED_DISTANCE) {
+                for (int r=0; r<numRegs; r+=2) {
+                    qreal dif = (phaseInds[(r+1)*stride+offset] - phaseInds[r*stride+offset] - params[2+r/2]);
+                    dist += dif*dif;
+                }
             }
+            else
+                for (int r=0; r<numRegs; r+=2) {
+                    qreal dif = (phaseInds[(r+1)*stride+offset] - phaseInds[r*stride+offset]);
+                    dist += dif*dif;
+                }
             dist = sqrt(dist);
 
             if (phaseFuncName == DISTANCE)
@@ -3817,7 +3833,7 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
                 phase = (dist == 0.)? params[0] : 1/dist;
             else if (phaseFuncName == SCALED_DISTANCE)
                 phase = params[0] * dist;
-            else if (phaseFuncName == SCALED_INVERSE_DISTANCE)
+            else if (phaseFuncName == SCALED_INVERSE_DISTANCE || phaseFuncName == SCALED_INVERSE_SHIFTED_DISTANCE)
                 phase = (dist == 0.)? params[1] : params[0] / dist;
         }
     }

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -186,7 +186,7 @@ static const char* errorMessages[] = {
     [E_INVALID_PHASE_FUNC_OVERRIDE_UNSIGNED_INDEX] = "Invalid phase function override index, in the UNSIGNED encoding. Must be >=0, and <= the maximum index possible of the corresponding qubit subregister (2^numQubits-1).",
     [E_INVALID_PHASE_FUNC_OVERRIDE_TWOS_COMPLEMENT_INDEX] = "Invalid phase function override index, in the TWOS_COMPLEMENT encoding. Must be between (inclusive) -2^(N-1) and +2^(N-1)-1, where N is the number of qubits (including the sign qubit).",
     [E_INVALID_PHASE_FUNC_NAME] = "Invalid named phase function, which must be one of {NORM, SCALED_NORM, INVERSE_NORM, SCALED_INVERSE_NORM, PRODUCT, SCALED_PRODUCT, INVERSE_PRODUCT, SCALED_INVERSE_PRODUCT, DISTANCE, SCALED_DISTANCE, INVERSE_DISTANCE, SCALED_INVERSE_DISTANCE}.",
-    [E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS] = "Invalid number of parameters passed for the given named phase function. {NORM, PRODUCT, DISTANCE} accept 0 parameters, {INVERSE_NORM, INVERSE_PRODUCT, INVERSE_DISTANCE} accept 1 parameter (the phase at the divergence), {SCALED_NORM, SCALED_INVERSE_NORM, SCALED_PRODUCT} accept 1 parameter (the scaling coefficient), and SCALED_INVERSE_PRODUCT, SCALED_DISTANCE, SCALED_INVERSE_DISTANCE} accept 2 parameters (the coefficient then divergence phase).",
+    [E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS] = "Invalid number of parameters passed for the given named phase function. {NORM, PRODUCT, DISTANCE} accept 0 parameters, {INVERSE_NORM, INVERSE_PRODUCT, INVERSE_DISTANCE} accept 1 parameter (the phase at the divergence), {SCALED_NORM, SCALED_INVERSE_NORM, SCALED_PRODUCT} accept 1 parameter (the scaling coefficient), {SCALED_INVERSE_PRODUCT, SCALED_DISTANCE, SCALED_INVERSE_DISTANCE} accept 2 parameters (the coefficient then divergence phase), SCALED_INVERSE_SHIFTED_NORM accepts 2 + (number of sub-registers) parameters (the coefficient, then the divergence phase, followed by the offset for each sub-register), SCALED_INVERSE_SHIFTED_DISTANCE accepts 2 + (number of sub-registers) / 2 parameters (the coefficient, then the divergence phase, followed by the offset for each pair of sub-registers).",
     [E_INVALID_BIT_ENCODING] = "Invalid bit encoding. Must be one of {UNSIGNED, TWOS_COMPLEMENT}.",
     [E_INVALID_NUM_QUBITS_TWOS_COMPLEMENT] = "A sub-register contained too few qubits to employ TWOS_COMPLEMENT encoding. Must use >1 qubits (allocating one for the sign).",
     [E_NEGATIVE_EXPONENT_WITHOUT_ZERO_OVERRIDE] = "The phase function contained a negative exponent which would diverge at zero, but the zero index was not overriden.",
@@ -912,6 +912,7 @@ void validatePhaseFuncName(enum phaseFunc funcCode, int numRegs, int numParams, 
         funcCode == INVERSE_NORM ||
         funcCode == SCALED_NORM ||
         funcCode == SCALED_INVERSE_NORM ||
+        funcCode == SCALED_INVERSE_SHIFTED_NORM ||
         funcCode == PRODUCT ||
         funcCode == INVERSE_PRODUCT ||
         funcCode == SCALED_PRODUCT ||
@@ -919,7 +920,8 @@ void validatePhaseFuncName(enum phaseFunc funcCode, int numRegs, int numParams, 
         funcCode == DISTANCE ||
         funcCode == INVERSE_DISTANCE ||
         funcCode == SCALED_DISTANCE ||
-        funcCode == SCALED_INVERSE_DISTANCE,
+        funcCode == SCALED_INVERSE_DISTANCE ||
+        funcCode == SCALED_INVERSE_SHIFTED_DISTANCE,
             E_INVALID_PHASE_FUNC_NAME, caller);
 
     if (funcCode == NORM || 
@@ -942,10 +944,17 @@ void validatePhaseFuncName(enum phaseFunc funcCode, int numRegs, int numParams, 
         funcCode == SCALED_INVERSE_DISTANCE)
             QuESTAssert(numParams == 2, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
             
+    if (funcCode == SCALED_INVERSE_SHIFTED_NORM)
+        QuESTAssert(numParams == 2 + numRegs, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
+
+    if (funcCode == SCALED_INVERSE_SHIFTED_DISTANCE)
+        QuESTAssert(numParams == 2 + numRegs / 2, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
+
     if (funcCode == DISTANCE ||
         funcCode == INVERSE_DISTANCE ||
         funcCode == SCALED_DISTANCE ||
-        funcCode == SCALED_INVERSE_DISTANCE)
+        funcCode == SCALED_INVERSE_DISTANCE ||
+        funcCode == SCALED_INVERSE_SHIFTED_DISTANCE)
             QuESTAssert(numRegs%2 == 0, E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC, caller);
 }
 

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -1110,12 +1110,12 @@ TEST_CASE( "applyNamedPhaseFunc", "[operators]" ) {
         }
         SECTION( "phase function name" ) {
             
-            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 12 );
+            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 14 );
             REQUIRE_THROWS_WITH( applyNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func), Contains("Invalid named phase function") );
         }
         SECTION( "phase function parameters" ) {
 
-            enum phaseFunc func = GENERATE( SCALED_NORM, INVERSE_NORM, SCALED_INVERSE_NORM, SCALED_PRODUCT, INVERSE_PRODUCT, SCALED_INVERSE_PRODUCT, SCALED_DISTANCE, INVERSE_DISTANCE, SCALED_INVERSE_DISTANCE );
+            enum phaseFunc func = GENERATE( SCALED_NORM, INVERSE_NORM, SCALED_INVERSE_NORM, SCALED_INVERSE_SHIFTED_NORM, SCALED_PRODUCT, INVERSE_PRODUCT, SCALED_INVERSE_PRODUCT, SCALED_DISTANCE, INVERSE_DISTANCE, SCALED_INVERSE_DISTANCE, SCALED_INVERSE_SHIFTED_DISTANCE );
             REQUIRE_THROWS_WITH( applyNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func), Contains("Invalid number of parameters") );
         }
         SECTION( "distance pair registers" ) {
@@ -1330,12 +1330,12 @@ TEST_CASE( "applyNamedPhaseFuncOverrides", "[operators]" ) {
         }
         SECTION( "phase function name" ) {
             
-            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 12 );
+            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 14 );
             REQUIRE_THROWS_WITH( applyNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, NULL, NULL, 0), Contains("Invalid named phase function") );
         }
         SECTION( "phase function parameters" ) {
 
-            enum phaseFunc func = GENERATE( SCALED_NORM, INVERSE_NORM, SCALED_INVERSE_NORM, SCALED_PRODUCT, INVERSE_PRODUCT, SCALED_INVERSE_PRODUCT, SCALED_DISTANCE, INVERSE_DISTANCE, SCALED_INVERSE_DISTANCE );
+            enum phaseFunc func = GENERATE( SCALED_NORM, INVERSE_NORM, SCALED_INVERSE_NORM, SCALED_INVERSE_SHIFTED_NORM, SCALED_PRODUCT, INVERSE_PRODUCT, SCALED_INVERSE_PRODUCT, SCALED_DISTANCE, INVERSE_DISTANCE, SCALED_INVERSE_DISTANCE, SCALED_INVERSE_SHIFTED_DISTANCE );
             REQUIRE_THROWS_WITH( applyNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, NULL, NULL, 0), Contains("Invalid number of parameters") );
         }
         SECTION( "distance pair registers" ) {
@@ -1750,12 +1750,12 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
         }
         SECTION( "phase function name" ) {
             
-            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 12 );
+            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 14 );
             REQUIRE_THROWS_WITH( applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, NULL, 0), Contains("Invalid named phase function") );
         }
         SECTION( "phase function parameters" ) {
             
-            qreal params[] = {0, 0};
+            qreal* params = (qreal*) calloc(numRegs + 3, sizeof(*params));
             
             SECTION( "no parameter functions" ) {
                 
@@ -1775,6 +1775,21 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
                 int numParams = GENERATE( 0, 1, 3 );
                 REQUIRE_THROWS_WITH( applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams), Contains("Invalid number of parameters") );
             }
+            SECTION( "shifted distance" ) {
+                
+                if (numRegs%2 == 0) {
+                    enum phaseFunc func = SCALED_INVERSE_SHIFTED_DISTANCE;
+                    int numParams = GENERATE_COPY( 0, 1, numRegs/2 - 1, numRegs/2, numRegs/2 + 1, numRegs/2 + 3 );
+                    REQUIRE_THROWS_WITH( applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams), Contains("Invalid number of parameters") );
+                }
+            }
+            SECTION( "shifted norm" ) {
+                
+                enum phaseFunc func = SCALED_INVERSE_SHIFTED_NORM;
+                int numParams = GENERATE_COPY( 0, 1, numRegs-1, numRegs, numRegs+1, numRegs+3 );
+                REQUIRE_THROWS_WITH( applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams), Contains("Invalid number of parameters") );
+            }
+            free(params);
         }
         SECTION( "distance pair registers" ) {
             
@@ -2193,12 +2208,12 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
         }
         SECTION( "phase function name" ) {
             
-            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 12 );
+            enum phaseFunc func = (enum phaseFunc) GENERATE( -1, 14 );
             REQUIRE_THROWS_WITH( applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, NULL, 0, NULL, NULL, 0), Contains("Invalid named phase function") );
         }
         SECTION( "phase function parameters" ) {
             
-            qreal params[] = {0, 0};
+            qreal* params = (qreal*) calloc(numRegs + 3, sizeof(*params));
             
             SECTION( "no parameter functions" ) {
                 
@@ -2218,6 +2233,21 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
                 int numParams = GENERATE( 0, 1, 3 );
                 REQUIRE_THROWS_WITH( applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams, NULL, NULL, 0), Contains("Invalid number of parameters") );
             }
+            SECTION( "shifted distance" ) {
+                
+                if (numRegs%2 == 0) {
+                    enum phaseFunc func = SCALED_INVERSE_SHIFTED_DISTANCE;
+                    int numParams = GENERATE_COPY( 0, 1, numRegs/2 - 1, numRegs/2, numRegs/2 + 1, numRegs/2 + 3 );
+                    REQUIRE_THROWS_WITH( applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams, NULL, NULL, 0), Contains("Invalid number of parameters") );
+                }
+            }
+            SECTION( "shifted norm" ) {
+                
+                enum phaseFunc func = SCALED_INVERSE_SHIFTED_NORM;
+                int numParams = GENERATE_COPY( 0, 1, numRegs-1, numRegs, numRegs+1, numRegs+3 );
+                REQUIRE_THROWS_WITH( applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams, NULL, NULL, 0), Contains("Invalid number of parameters") );
+            }
+            free(params);
         }
         SECTION( "distance pair registers" ) {
             

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -1532,7 +1532,7 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
                 
                 enum phaseFunc func = SCALED_INVERSE_SHIFTED_NORM;
                 int numParams = 2 + numRegs;
-                qreal* params = (qreal*) malloc(numParams * sizeof(*params));
+                qreal params[numParams];
                 params[0] = getRandomReal(-10, 10); // scaling
                 params[1] = getRandomReal(-4, 4); // divergence override
                 for (int r=0; r<numRegs; r++)
@@ -1548,7 +1548,6 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
 
                 applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams);
                 applyReferenceOp(refVec, regs, totalNumQubits, diagMatr);
-                free(params);
                 REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
             }
             SECTION( "INVERSE_PRODUCT" ) {
@@ -1684,7 +1683,7 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
                 // test only if there are an even number of registers
                 if (numRegs%2 == 0) {
                     int numParams = 2 + numRegs/2;
-                    qreal* params = (qreal*) malloc(numParams * sizeof(*params));
+                    qreal params[numParams];
                     params[0] = getRandomReal( -10, 10 ); // scaling
                     params[1] = getRandomReal( -4, 4 ); // divergence override
                     for (int r=0; r<numRegs/2; r++)
@@ -1700,7 +1699,6 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
                     
                     applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams);
                     applyReferenceOp(refVec, regs, totalNumQubits, diagMatr);
-                    free(params);
                     REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
                 }
             }
@@ -1755,7 +1753,9 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
         }
         SECTION( "phase function parameters" ) {
             
-            qreal* params = (qreal*) calloc(numRegs + 3, sizeof(*params));
+            qreal params[numRegs + 3];
+            for (int r=0; r<numRegs + 3; r++)
+                params[r] = 0;
             
             SECTION( "no parameter functions" ) {
                 
@@ -1789,7 +1789,6 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
                 int numParams = GENERATE_COPY( 0, 1, numRegs-1, numRegs, numRegs+1, numRegs+3 );
                 REQUIRE_THROWS_WITH( applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams), Contains("Invalid number of parameters") );
             }
-            free(params);
         }
         SECTION( "distance pair registers" ) {
             
@@ -1974,7 +1973,7 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
                 
                 enum phaseFunc func = SCALED_INVERSE_SHIFTED_NORM;
                 int numParams = 2 + numRegs;
-                qreal* params = (qreal*) malloc(numParams * sizeof(*params));
+                qreal params[numParams];
                 params[0] = getRandomReal(-10, 10); // scaling
                 params[1] = getRandomReal(-4, 4); // divergence override
                 for (int r=0; r<numRegs; r++)
@@ -1992,7 +1991,6 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
 
                 applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams, overrideInds, overridePhases, numOverrides);
                 applyReferenceOp(refVec, regs, totalNumQubits, diagMatr);
-                free(params);
                 REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
             }
             SECTION( "INVERSE_PRODUCT" ) {
@@ -2140,7 +2138,7 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
                 // test only if there are an even number of registers
                 if (numRegs%2 == 0) {
                     int numParams = 2 + numRegs/2;
-                    qreal* params = (qreal*) malloc(numParams * sizeof(*params));
+                    qreal params[numParams];
                     params[0] = getRandomReal( -10, 10 ); // scaling
                     params[1] = getRandomReal( -4, 4 ); // divergence override
                     for (int r=0; r<numRegs/2; r++)
@@ -2158,7 +2156,6 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
                     
                     applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams, overrideInds, overridePhases, numOverrides);
                     applyReferenceOp(refVec, regs, totalNumQubits, diagMatr);
-                    free(params);
                     REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
                 }
             }
@@ -2213,7 +2210,9 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
         }
         SECTION( "phase function parameters" ) {
             
-            qreal* params = (qreal*) calloc(numRegs + 3, sizeof(*params));
+            qreal params[numRegs + 3];
+            for (int r=0; r<numRegs + 3; r++)
+                params[r] = 0;
             
             SECTION( "no parameter functions" ) {
                 
@@ -2247,7 +2246,6 @@ TEST_CASE( "applyParamNamedPhaseFuncOverrides", "[operators]" ) {
                 int numParams = GENERATE_COPY( 0, 1, numRegs-1, numRegs, numRegs+1, numRegs+3 );
                 REQUIRE_THROWS_WITH( applyParamNamedPhaseFuncOverrides(quregVec, regs, numQubitsPerReg, numRegs, UNSIGNED, func, params, numParams, NULL, NULL, 0), Contains("Invalid number of parameters") );
             }
-            free(params);
         }
         SECTION( "distance pair registers" ) {
             


### PR DESCRIPTION
The functions `applyParamNamedPhaseFunc()` and `applyParamNamedPhaseFuncOverrides()` now accept the new function types `SCALED_INVERSE_SHIFTED_NORM` and `SCALED_INVERSE_SHIFTED_DISTANCE`, which work in much the same way as the already implemented `SCALED_INVERSE_NORM` and `SCALED_INVERSE_DISTANCE`, but add a constant value to each of the sub-registers (or pairs of sub-registers) before calculating the norm and distance, respectively.