### PR TITLE
adapted phase functions for density matrices

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -5459,7 +5459,7 @@ ComplexMatrixN bindArraysToStackComplexMatrixN(
     )
 #endif
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by the passed 
+/** Induces a phase change upon each amplitude of \p qureg, determined by the passed 
  * exponential polynomial "phase function". This effects a diagonal unitary of unit complex scalars,
  * targeting the nominated \p qubits.
  *
@@ -5509,6 +5509,19 @@ ComplexMatrixN bindArraysToStackComplexMatrixN(
  *   \end{aligned}
  *   \f]
  *
+ * - If \p qureg is a density matrix \f$\rho\f$, this function modifies \p qureg to
+ *   \f[
+ *      \rho \rightarrow \hat{D} \, \rho \, \hat{D}^\dagger
+ *   \f]
+ *   where \f$\hat{D}\f$ is the diagonal unitary operator 
+ *   \f[
+ *      \hat{D} = \text{diag} \, \{ \; e^{i f(r_0)}, \; e^{i f(r_1)}, \;  \dots \; \}.
+ *   \f]
+ *   This means element \f$\rho_{jk}\f$ is modified to
+ *   \f[
+ *      \alpha \, |j\rangle\langle k| \; \rightarrow \; e^{i (f(r_j) - f(r_k))} \; \alpha \, |j\rangle\langle k|
+ *   \f]\n
+ *
  * - The interpreted phase function can be previewed in the QASM log, as a comment. \n
  *   For example:
  *   ```
@@ -5534,7 +5547,7 @@ ComplexMatrixN bindArraysToStackComplexMatrixN(
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  *
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density matrix to be modified
  * @param[in] qubits a list of the indices of the qubits which will inform \f$r\f$ for each amplitude in \p qureg
  * @param[in] numQubits the length of list \p qubits
  * @param[in] encoding the ::bitEncoding under which to infer the binary value \f$r\f$ from the bits of \p qubits in each basis state of \p qureg
@@ -5542,7 +5555,6 @@ ComplexMatrixN bindArraysToStackComplexMatrixN(
  * @param[in] exponents the exponents of the exponential polynomial phase function \f$f(r)\f$
  * @param[in] numTerms the length of list \p coeffs, which must be the same as that of \p exponents
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique
  * - if \p numQubits < 0 or \p numQubits >= `qureg.numQubitsRepresented` 
@@ -5555,7 +5567,7 @@ ComplexMatrixN bindArraysToStackComplexMatrixN(
  */
 void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by the passed 
+/** Induces a phase change upon each amplitude of \p qureg, determined by the passed 
  * exponential polynomial "phase function", and an explicit set of 'overriding' values at specific 
  * state indices.
  *
@@ -5601,6 +5613,18 @@ void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding en
  * > evaluating the phase function \f$f(r)\f$, and hence are useful for avoiding 
  * > singularities or errors at diverging values of \f$r\f$.
  *
+ * - If \p qureg is a density matrix \f$\rho\f$, the overrides determine the diagonal unitary matrix 
+ *   \f$\hat{D}\f$, which is then applied to \p qureg as
+ *   \f[
+ *      \rho \; \rightarrow \; \hat{D} \, \rho \hat{D}^\dagger.
+ *   \f]
+ *   This means that with overrides \f$f(r_j) \rightarrow \theta\f$ and \f$f(r_k) \rightarrow \phi\f$,
+ *   element \f$\rho_{jk}\f$ is modified to
+ *   \f[
+ *      \alpha \, |j\rangle\langle k| \; \rightarrow \; 
+ *          \exp(\, i \, (\theta - \phi) \, ) \; \alpha \, |j\rangle\langle k|.
+ *   \f]\n
+ *
  * - The interpreted phase function and list of overrides can be previewed in the QASM log, as a comment. \n
  *   For example:
  *   ```
@@ -5629,7 +5653,7 @@ void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding en
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  * 
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density matrix to be modified
  * @param[in] qubits a list of the indices of the qubits which will inform \f$r\f$ for each amplitude in \p qureg
  * @param[in] numQubits the length of list \p qubits
  * @param[in] encoding the ::bitEncoding under which to infer the binary value \f$r\f$ from the bits of \p qubits in each basis state of \p qureg
@@ -5640,7 +5664,6 @@ void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding en
  * @param[in] overridePhases a list of replacement phase changes, for the corresponding \f$r\f$ values in \p overrideInds (one to one)
  * @param[in] numOverrides the lengths of lists \p overrideInds and \p overridePhases
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique
  * - if \p numQubits < 0 or \p numQubits >= `qureg.numQubitsRepresented` 
@@ -5655,7 +5678,7 @@ void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding en
  */
 void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by a
+/** Induces a phase change upon each amplitude of \p qureg, determined by a
  * multi-variable exponential polynomial "phase function". 
  *
  * This is a multi-variable extension of applyPhaseFunc(), whereby multiple sub-registers inform 
@@ -5759,6 +5782,13 @@ void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEn
  *   \end{aligned}
  *   \f]
  *
+ * - If \p qureg is a density matrix \f$\rho\f$, then its elements are modified as 
+ *   \f[
+ *      \alpha \, |j\rangle\langle k| \; \rightarrow \;
+ *          \exp(i \, (f(\vec{r}_j) - f(\vec{r}_k)) \, ) \; \alpha \, |j\rangle\langle k|,
+ *   \f]
+ *   where \f$f(\vec{r}_j)\f$ and \f$f(\vec{r}_k)\f$ are determined as above.\n\n
+ *
  * - The interpreted phase function can be previewed in the QASM log, as a comment. \n
  *   For example:
  *   ```
@@ -5788,7 +5818,7 @@ void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEn
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  *
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density matrix to be modified
  * @param[in] qubits a list of all the qubit indices contained in each sub-register
  * @param[in] numQubitsPerReg a list of the lengths of each sub-list in \p qubits
  * @param[in] numRegs the number of sub-registers, which is the length of both \p numQubitsPerReg and \p numTermsPerReg
@@ -5797,7 +5827,6 @@ void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEn
  * @param[in] exponents the exponents of all terms of the exponential polynomial phase function \f$f(\vec{r})\f$
  * @param[in] numTermsPerReg a list of the number of \p coeff and \p exponent terms supplied for each variable/sub-register
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique (including if sub-registers overlap)
  * - if \p numRegs <= 0 or \p numRegs > 100 (constrained by `MAX_NUM_REGS_APPLY_ARBITRARY_PHASE` in QuEST_precision.h)
@@ -5810,7 +5839,7 @@ void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEn
  */
 void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by a
+/** Induces a phase change upon each amplitude of \p qureg, determined by a
  * multi-variable exponential polynomial "phase function", and an explicit set of 'overriding' 
  * values at specific state indices.
  
@@ -5866,7 +5895,7 @@ void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int 
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  *
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density-matrix to be modified
  * @param[in] qubits a list of all the qubit indices contained in each sub-register
  * @param[in] numQubitsPerReg a list of the lengths of each sub-list in \p qubits
  * @param[in] numRegs the number of sub-registers, which is the length of both \p numQubitsPerReg and \p numTermsPerReg
@@ -5878,7 +5907,6 @@ void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int 
  * @param[in] overridePhases a list of replacement phase changes, for the corresponding \f$\vec{r}\f$ values in \p overrideInds
  * @param[in] numOverrides the lengths of list \p overridePhases (but not necessarily of \p overrideInds)
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique (including if sub-registers overlap)
  * - if \p numRegs <= 0 or \p numRegs > 100 (constrained by `MAX_NUM_REGS_APPLY_ARBITRARY_PHASE` in QuEST_precision.h)
@@ -5893,7 +5921,7 @@ void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int 
  */
 void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by a
+/** Induces a phase change upon each amplitude of \p qureg, determined by a
  * named (and potentially multi-variable) phase function.
  *
  * This effects a diagonal unitary operator, with a phase function \f$f(\vec{r})\f$ which may not be 
@@ -5940,7 +5968,7 @@ void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPer
  *   the function applyParamNamedPhaseFunc().\n\n
  *   > If the phase function \f$f(\vec{r})\f$ diverges at one or more \f$\vec{r}\f$ values, you should instead 
  *   > use applyNamedPhaseFuncOverrides() and specify explicit phase changes for these coordinates.
- *   > Otherwise, the corresponding amplitudes of the state-vector will become indeterminate (like `NaN`). \n
+ *   > Otherwise, the corresponding amplitudes of \p qureg will become indeterminate (like `NaN`). \n
  *
  * - The function \f$f(\vec{r})\f$ specifies the phase change to induce upon amplitude \f$\alpha\f$ 
  *   of computational basis state with the nominated sub-registers encoding values \f$r_1, \; \dots\f$.
@@ -5977,6 +6005,21 @@ void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPer
  *   \end{aligned}
  *   \f]\n
  *
+ * - If \p qureg is a density matrix, its elements are modified to
+ *   \f[
+        \alpha \, |j\rangle\langle k| \; \rightarrow \;
+            \exp(i (f(\vec{r}_j) \, - \, f(\vec{r}_k))) \; \alpha \, |j\rangle\langle k|
+ *   \f]
+ *   where \f$f(\vec{r}_j)\f$ and \f$f(\vec{r}_k)\f$ are determined as above. This is equivalent 
+ *   to modification
+ *   \f[
+ *          \rho \; \rightarrow \; \hat{D} \, \rho \, \hat{D}^\dagger
+ *   \f]
+ *   where \f$\hat{D}\f$ is the diagonal unitary 
+ *   \f[
+ *      \hat{D} = \text{diag}\, \{ \; e^{i f(\vec{r_0})}, \; e^{i f(\vec{r_1})}, \; \dots \; \}.
+ *   \f]\n
+ *
  * - The interpreted phase function can be previewed in the QASM log, as a comment. \n
  *   For example:
  *   ```
@@ -6000,14 +6043,13 @@ void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPer
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  * 
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density-matrix to be modified
  * @param[in] qubits a list of all the qubit indices contained in each sub-register
  * @param[in] numQubitsPerReg a list of the lengths of each sub-list in \p qubits
  * @param[in] numRegs the number of sub-registers, which is the length of both \p numQubitsPerReg and \p numTermsPerReg
  * @param[in] encoding the ::bitEncoding under which to infer the binary value \f$r_j\f$ from the bits of a sub-register
  * @param[in] functionNameCode the ::phaseFunc \f$f(\vec{r})\f$
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique (including if sub-registers overlap)
  * - if \p numRegs <= 0 or \p numRegs > 100 (constrained by `MAX_NUM_REGS_APPLY_ARBITRARY_PHASE` in QuEST_precision.h)
@@ -6019,7 +6061,7 @@ void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPer
  */
 void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by a
+/** Induces a phase change upon each amplitude of \p qureg, determined by a
  * named (and potentially multi-variable) phase function, and an explicit set of 'overriding' 
  * values at specific state indices.
  *
@@ -6069,7 +6111,7 @@ void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int num
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  * 
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector pr density-matrix to be modified
  * @param[in] qubits a list of all the qubit indices contained in each sub-register
  * @param[in] numQubitsPerReg a list of the lengths of each sub-list in \p qubits
  * @param[in] numRegs the number of sub-registers, which is the length of both \p numQubitsPerReg and \p numTermsPerReg
@@ -6079,7 +6121,6 @@ void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int num
  * @param[in] overridePhases a list of replacement phase changes, for the corresponding \f$\vec{r}\f$ values in \p overrideInds
  * @param[in] numOverrides the lengths of list \p overridePhases (but not necessarily of \p overrideInds)
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique (including if sub-registers overlap)
  * - if \p numRegs <= 0 or \p numRegs > 100 (constrained by `MAX_NUM_REGS_APPLY_ARBITRARY_PHASE` in QuEST_precision.h)
@@ -6093,7 +6134,7 @@ void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int num
  */
 void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by a
+/** Induces a phase change upon each amplitude of \p qureg, determined by a
  * named, paramaterized (and potentially multi-variable) phase function.
  *
  * See applyNamedPhaseFunc() for full documentation. \n
@@ -6153,7 +6194,7 @@ void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  * 
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density-matrix to be modified
  * @param[in] qubits a list of all the qubit indices contained in each sub-register
  * @param[in] numQubitsPerReg a list of the lengths of each sub-list in \p qubits
  * @param[in] numRegs the number of sub-registers, which is the length of both \p numQubitsPerReg and \p numTermsPerReg
@@ -6162,7 +6203,6 @@ void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg
  * @param[in] params a list of any additional parameters needed by the ::phaseFunc \p functionNameCode
  * @param[in] numParams the length of list \p params
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique (including if sub-registers overlap)
  * - if \p numRegs <= 0 or \p numRegs > 100 (constrained by `MAX_NUM_REGS_APPLY_ARBITRARY_PHASE` in QuEST_precision.h)
@@ -6174,7 +6214,7 @@ void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg
  */
 void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams);
 
-/** Induces a phase change upon each amplitude of state-vector \p qureg, determined by a
+/** Induces a phase change upon each amplitude of \p qureg, determined by a
  * named, parameterised (and potentially multi-variable) phase function, and an explicit set of 'overriding' 
  * values at specific state indices.
  *
@@ -6224,7 +6264,7 @@ void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, in
  * - applyDiagonalOp() to apply a non-unitary diagonal operator.
  * 
  * @ingroup operator
- * @param[in,out] qureg the state-vector to be modified
+ * @param[in,out] qureg the state-vector or density-matrix to be modified
  * @param[in] qubits a list of all the qubit indices contained in each sub-register
  * @param[in] numQubitsPerReg a list of the lengths of each sub-list in \p qubits
  * @param[in] numRegs the number of sub-registers, which is the length of both \p numQubitsPerReg and \p numTermsPerReg
@@ -6236,7 +6276,6 @@ void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, in
  * @param[in] overridePhases a list of replacement phase changes, for the corresponding \f$\vec{r}\f$ values in \p overrideInds
  * @param[in] numOverrides the lengths of list \p overridePhases (but not necessarily of \p overrideInds)
  * @exception invalidQuESTInputError()
- * - if \p qureg is a density matrix
  * - if any qubit in \p qubits has an invalid index (i.e. does not satisfy 0 <= qubit < `qureg.numQubitsRepresented`)
  * - if the elements of \p qubits are not unique (including if sub-registers overlap)
  * - if \p numRegs <= 0 or \p numRegs > 100 (constrained by `MAX_NUM_REGS_APPLY_ARBITRARY_PHASE` in QuEST_precision.h)

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -4228,7 +4228,8 @@ void agnostic_setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* r
 void statevec_applyPhaseFuncOverrides(
     Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int numTerms, 
-    long long int* overrideInds, qreal* overridePhases, int numOverrides)
+    long long int* overrideInds, qreal* overridePhases, int numOverrides,
+    int conj)
 {
     // each node/chunk modifies only local values in an embarrassingly parallel way 
 
@@ -4246,7 +4247,7 @@ void statevec_applyPhaseFuncOverrides(
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubits,encoding, coeffs,exponents,numTerms, overrideInds,overridePhases,numOverrides) \
+    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubits,encoding, coeffs,exponents,numTerms, overrideInds,overridePhases,numOverrides, conj) \
     private  (index, globalAmpInd, phaseInd, i,t,q, phase, c,s,re,im) 
 # endif
     {
@@ -4283,6 +4284,10 @@ void statevec_applyPhaseFuncOverrides(
             else
                 for (t=0; t<numTerms; t++)
                     phase += coeffs[t] * pow(phaseInd, exponents[t]);
+                    
+            // negate phase to conjugate operator 
+            if (conj)
+                phase *= -1;
 
             // modify amp to amp * exp(i phase) 
             c = cos(phase);
@@ -4300,7 +4305,8 @@ void statevec_applyPhaseFuncOverrides(
 void statevec_applyMultiVarPhaseFuncOverrides(
     Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int* numTermsPerReg, 
-    long long int* overrideInds, qreal* overridePhases, int numOverrides) 
+    long long int* overrideInds, qreal* overridePhases, int numOverrides,
+    int conj) 
 {
     // each node/chunk modifies only local values in an embarrassingly parallel way 
 
@@ -4323,7 +4329,7 @@ void statevec_applyMultiVarPhaseFuncOverrides(
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs,encoding, coeffs,exponents,numTermsPerReg, overrideInds,overridePhases,numOverrides) \
+    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs,encoding, coeffs,exponents,numTermsPerReg, overrideInds,overridePhases,numOverrides, conj) \
     private  (index,globalAmpInd, r,q,i,t,flatInd, found, phaseInds,phase, c,s,re,im) 
 # endif
     {
@@ -4379,6 +4385,10 @@ void statevec_applyMultiVarPhaseFuncOverrides(
                     }
                 }
             }
+            
+            // negate phase to conjugate operator 
+            if (conj)
+                phase *= -1;
 
             // modify amp to amp * exp(i phase) 
             c = cos(phase);
@@ -4397,8 +4407,9 @@ void statevec_applyParamNamedPhaseFuncOverrides(
     Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     enum phaseFunc phaseFuncName,
     qreal* params, int numParams,
-    long long int* overrideInds, qreal* overridePhases, int numOverrides) 
-{
+    long long int* overrideInds, qreal* overridePhases, int numOverrides,
+    int conj
+) {
     // each node/chunk modifies only local values in an embarrassingly parallel way 
 
     // note partitions of qubits, overrideInds are stored flat
@@ -4420,7 +4431,7 @@ void statevec_applyParamNamedPhaseFuncOverrides(
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs,encoding, phaseFuncName,params,numParams, overrideInds,overridePhases,numOverrides) \
+    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs,encoding, phaseFuncName,params,numParams, overrideInds,overridePhases,numOverrides, conj) \
     private  (index,globalAmpInd, r,q,i,flatInd, found, phaseInds,phase,norm,prod,dist, c,s,re,im) 
 # endif
     {
@@ -4522,6 +4533,10 @@ void statevec_applyParamNamedPhaseFuncOverrides(
                         phase = (dist == 0.)? params[1] : params[0] / dist;
                 }
             }
+            
+            // negate phase to conjugate operator 
+            if (conj)
+                phase *= -1;
 
             // modify amp to amp * exp(i phase) 
             c = cos(phase);

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -3520,8 +3520,9 @@ void agnostic_setDiagonalOpElems(DiagonalOp op, long long int startInd, qreal* r
 __global__ void statevec_applyPhaseFuncOverridesKernel(
     Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int numTerms, 
-    long long int* overrideInds, qreal* overridePhases, int numOverrides)
-{
+    long long int* overrideInds, qreal* overridePhases, int numOverrides, 
+    int conj
+) {
     long long int index = blockIdx.x*blockDim.x + threadIdx.x;
     if (index>=qureg.numAmpsPerChunk) return;
 
@@ -3554,6 +3555,10 @@ __global__ void statevec_applyPhaseFuncOverridesKernel(
     else
         for (int t=0; t<numTerms; t++)
             phase += coeffs[t] * pow(phaseInd, exponents[t]);
+            
+    // negate phase to conjugate operator 
+    if (conj)
+        phase *= -1;
 
     // modify amp to amp * exp(i phase) 
     qreal c = cos(phase);
@@ -3569,8 +3574,9 @@ __global__ void statevec_applyPhaseFuncOverridesKernel(
  void statevec_applyPhaseFuncOverrides(
      Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding,
      qreal* coeffs, qreal* exponents, int numTerms, 
-     long long int* overrideInds, qreal* overridePhases, int numOverrides)
- {
+     long long int* overrideInds, qreal* overridePhases, int numOverrides,
+     int conj
+ ) {
     // allocate device space for global list of {qubits}, {coeffs}, {exponents}, {overrideInds} and {overridePhases}
     int* d_qubits;                          size_t mem_qubits = numQubits * sizeof *d_qubits;
     qreal* d_coeffs;                        size_t mem_terms = numTerms * sizeof *d_coeffs;
@@ -3589,7 +3595,8 @@ __global__ void statevec_applyPhaseFuncOverridesKernel(
     statevec_applyPhaseFuncOverridesKernel<<<CUDABlocks,threadsPerCUDABlock>>>(
         qureg, d_qubits, numQubits, encoding, 
         d_coeffs, d_exponents, numTerms, 
-        d_overrideInds, d_overridePhases, numOverrides);
+        d_overrideInds, d_overridePhases, numOverrides,
+        conj);
 
     // cleanup device memory 
     cudaFree(d_qubits);
@@ -3603,8 +3610,9 @@ __global__ void statevec_applyMultiVarPhaseFuncOverridesKernel(
     Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int* numTermsPerReg, 
     long long int* overrideInds, qreal* overridePhases, int numOverrides,
-    long long int *phaseInds) 
-{
+    long long int *phaseInds,
+    int conj
+) {
     long long int index = blockIdx.x*blockDim.x + threadIdx.x;
     if (index>=qureg.numAmpsPerChunk) return;
 
@@ -3665,6 +3673,10 @@ __global__ void statevec_applyMultiVarPhaseFuncOverridesKernel(
             }
         }
     }
+    
+    // negate phase to conjugate operator 
+    if (conj)
+        phase *= -1;
 
     // modify amp to amp * exp(i phase) 
     qreal c = cos(phase);
@@ -3680,8 +3692,9 @@ __global__ void statevec_applyMultiVarPhaseFuncOverridesKernel(
 void statevec_applyMultiVarPhaseFuncOverrides(
     Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int* numTermsPerReg, 
-    long long int* overrideInds, qreal* overridePhases, int numOverrides) 
-{
+    long long int* overrideInds, qreal* overridePhases, int numOverrides,
+    int conj
+) {
     // determine size of arrays, for cloning into GPU memory
     size_t mem_numQubitsPerReg = numRegs * sizeof *numQubitsPerReg;
     size_t mem_numTermsPerReg = numRegs * sizeof *numTermsPerReg;
@@ -3727,7 +3740,8 @@ void statevec_applyMultiVarPhaseFuncOverrides(
         qureg, d_qubits, d_numQubitsPerReg, numRegs, encoding,
         d_coeffs, d_exponents, d_numTermsPerReg, 
         d_overrideInds, d_overridePhases, numOverrides,
-        d_phaseInds);
+        d_phaseInds, 
+        conj);
 
     // free device memory
     cudaFree(d_qubits);
@@ -3744,8 +3758,9 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
     Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     enum phaseFunc phaseFuncName, qreal* params, int numParams,
     long long int* overrideInds, qreal* overridePhases, int numOverrides,
-    long long int* phaseInds) 
-{
+    long long int* phaseInds,
+    int conj
+) {
     long long int index = blockIdx.x*blockDim.x + threadIdx.x;
     if (index>=qureg.numAmpsPerChunk) return;
 
@@ -3854,6 +3869,11 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
                 phase = (dist == 0.)? params[1] : params[0] / dist;
         }
     }
+    
+    
+    // negate phase to conjugate operator 
+    if (conj)
+        phase *= -1;
 
     // modify amp to amp * exp(i phase) 
     qreal c = cos(phase);
@@ -3869,8 +3889,9 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
 void statevec_applyParamNamedPhaseFuncOverrides(
     Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     enum phaseFunc phaseFuncName, qreal* params, int numParams,
-    long long int* overrideInds, qreal* overridePhases, int numOverrides) 
-{
+    long long int* overrideInds, qreal* overridePhases, int numOverrides,
+    int conj 
+) {
     // determine size of arrays, for cloning into GPU memory
     size_t mem_numQubitsPerReg = numRegs * sizeof *numQubitsPerReg;
     size_t mem_overridePhases = numOverrides * sizeof *overridePhases;
@@ -3908,7 +3929,8 @@ void statevec_applyParamNamedPhaseFuncOverrides(
         qureg, d_qubits, d_numQubitsPerReg, numRegs, encoding,
         phaseFuncName, d_params, numParams,
         d_overrideInds, d_overridePhases, numOverrides,
-        d_phaseInds);
+        d_phaseInds,
+        conj);
 
     // free device memory
     cudaFree(d_qubits);

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -3638,11 +3638,12 @@ __global__ void statevec_applyMultiVarPhaseFuncOverridesKernel(
     }
     else if  (encoding == TWOS_COMPLEMENT) {
         for (int r=0; r<numRegs; r++) {
+            phaseInds[r*stride+offset] = 0LL;
             for (int q=0; q<numQubitsPerReg[r]-1; q++)  
                 phaseInds[r*stride+offset] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);
             // use final qubit to indicate sign
             if (extractBit(qubits[flatInd++], globalAmpInd) == 1)
-                phaseInds[r*stride+offset] -= (1LL << (numQubitsPerReg[r]-1));
+                phaseInds[r*stride+offset] -= (1LL << (numQubitsPerReg[r]-1)); 
         }
     }
 
@@ -3787,6 +3788,7 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
     else if  (encoding == TWOS_COMPLEMENT) {
         int flatInd = 0;
         for (int r=0; r<numRegs; r++) {
+            phaseInds[r*stride+offset] = 0LL;
             for (int q=0; q<numQubitsPerReg[r]-1; q++)  
                 phaseInds[r*stride+offset] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);
             // use final qubit to indicate sign

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -725,93 +725,141 @@ void multiControlledMultiRotatePauli(Qureg qureg, int* controlQubits, int numCon
 }
 
 void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms) {
-    validateStateVecQureg(qureg, __func__);
     validateMultiQubits(qureg, qubits, numQubits, __func__);
     validateBitEncoding(numQubits, encoding, __func__);
     validatePhaseFuncTerms(numQubits, encoding, coeffs, exponents, numTerms, NULL, 0, __func__);
 
-    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, NULL, NULL, 0);
+    int conj = 0;
+    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, NULL, NULL, 0, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftIndices(qubits, numQubits, qureg.numQubitsRepresented);
+        statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, NULL, NULL, 0, conj);
+        shiftIndices(qubits, numQubits, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordPhaseFunc(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, NULL, NULL, 0);
 }
 
 void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
-    validateStateVecQureg(qureg, __func__);
     validateMultiQubits(qureg, qubits, numQubits, __func__);
     validateBitEncoding(numQubits, encoding, __func__);
     validatePhaseFuncOverrides(numQubits, encoding, overrideInds, numOverrides, __func__);
     validatePhaseFuncTerms(numQubits, encoding, coeffs, exponents, numTerms, overrideInds, numOverrides, __func__);
 
-    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides);
+    int conj = 0;
+    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftIndices(qubits, numQubits, qureg.numQubitsRepresented);
+        statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides, conj);
+        shiftIndices(qubits, numQubits, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordPhaseFunc(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides);
 }
 
 void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg) {
-    validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
     validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validateMultiVarPhaseFuncTerms(numQubitsPerReg, numRegs, encoding, exponents, numTermsPerReg, __func__);
 
-    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, NULL, NULL, 0);
+    int conj = 0;
+    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, NULL, NULL, 0, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, qureg.numQubitsRepresented);
+        statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, NULL, NULL, 0, conj);
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, NULL, NULL, 0);
 }
 
 void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
-    validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
     validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validateMultiVarPhaseFuncTerms(numQubitsPerReg, numRegs, encoding, exponents, numTermsPerReg, __func__);
     validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, encoding, overrideInds, numOverrides, __func__);
 
-    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
+    int conj = 0;
+    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, qureg.numQubitsRepresented);
+        statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides, conj);
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
 }
 
 void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode) {
-    validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
     validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, numRegs, 0, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, NULL, NULL, 0);
+    int conj = 0;
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, NULL, NULL, 0, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, qureg.numQubitsRepresented);
+        statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, NULL, NULL, 0, conj);
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, NULL, NULL, 0);
 }
 
 void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
-    validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
     validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, numRegs, 0, __func__);
     validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, encoding, overrideInds, numOverrides, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
+    int conj = 0;
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, qureg.numQubitsRepresented);
+        statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides, conj);
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
 }
 
 void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams) {
-    validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
     validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, numRegs, numParams, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, NULL, NULL, 0);
+    int conj = 0;
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, NULL, NULL, 0, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, qureg.numQubitsRepresented);
+        statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, NULL, NULL, 0, conj);
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, NULL, NULL, 0);
 }
 
 void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
-    validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
     validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, numRegs, numParams, __func__);
     validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, encoding, overrideInds, numOverrides, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
+    int conj = 0;
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides, conj);
+    if (qureg.isDensityMatrix) {
+        conj = 1;
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, qureg.numQubitsRepresented);
+        statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides, conj);
+        shiftSubregIndices(qubits, numQubitsPerReg, numRegs, - qureg.numQubitsRepresented);
+    }
 
     qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
 }

--- a/QuEST/src/QuEST_common.c
+++ b/QuEST/src/QuEST_common.c
@@ -152,6 +152,13 @@ void shiftIndices(int* indices, int numIndices, int shift) {
         indices[j] += shift;
 }
 
+void shiftSubregIndices(int* allInds, int* numIndsPerReg, int numRegs, int shift) {
+    int i=0;
+    for (int r=0; r<numRegs; r++)
+        for (int j=0; j<numIndsPerReg[r]; j++)
+            allInds[i++] += shift;
+}
+
 int generateMeasurementOutcome(qreal zeroProb, qreal *outcomeProb) {
     
     // randomly choose outcome

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -49,6 +49,8 @@ void getComplexPairAndPhaseFromUnitary(ComplexMatrix2 u, Complex* alpha, Complex
 
 void shiftIndices(int* indices, int numIndices, int shift);
 
+void shiftSubregIndices(int* allInds, int* numIndsPerReg, int numRegs, int shift);
+
 void conjugateMatrixN(ComplexMatrixN u);
 
 void getQuESTDefaultSeedKey(unsigned long int *key);
@@ -263,11 +265,11 @@ void statevec_applyDiagonalOp(Qureg qureg, DiagonalOp op);
 
 Complex statevec_calcExpecDiagonalOp(Qureg qureg, DiagonalOp op);
 
-void statevec_applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides, int conj);
 
-void statevec_applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides, int conj);
 
-void statevec_applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides, int conj);
 
 
 /* 

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -477,13 +477,6 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
         // try every kind of binary encodings
         enum bitEncoding encoding = GENERATE( UNSIGNED,TWOS_COMPLEMENT );
         
-        
-        
-        // DEBUG 
-        encoding = UNSIGNED;
-        
-        
-        
         // try every possible number of registers 
         // (between #qubits containing 1, and 1 containing #qubits)
         int numRegs;

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -2623,13 +2623,13 @@ TEST_CASE( "applyPhaseFunc", "[operators]" ) {
             
             applyPhaseFunc(quregVec, qubits, numQubits, encoding, coeffs, expons, numTerms);
             applyReferenceOp(refVec, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregVec, refVec) );
+            REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
         }
         SECTION( "density-matrix" ) {
         
             applyPhaseFunc(quregMatr, qubits, numQubits, encoding, coeffs, expons, numTerms);
             applyReferenceOp(refMatr, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregMatr, refMatr) );
+            REQUIRE( areEqual(quregMatr, refMatr, 1E2*REAL_EPS) );
         }
     }
     SECTION( "input validation" ) {

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -596,7 +596,12 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
         }
         SECTION( "density-matrix" ) {
             
-            printf("max phase: %lf\n", maxPhase);
+            
+            // DEBUG
+            if (!areEqual(quregMatr, refMatr, 1E6*REAL_EPS)) {
+                printf("max phase: %lf\n", maxPhase);
+            }
+            
             
             applyMultiVarPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, coeffs, expons, numTermsPerReg);
             applyReferenceOp(refMatr, regs, totalNumQubits, allRegMatr);

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -557,10 +557,6 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
         QMatrix allRegMatr{{1}};
         int startInd = 0;
         
-        // DEBUG 
-        qreal maxPhase = 0;
-        
-        
         for (int r=0; r<numRegs; r++) {
             
             QMatrix singleRegMatr = getZeroMatrix( 1 << numQubitsPerReg[r] );
@@ -598,15 +594,6 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
             
             applyMultiVarPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, coeffs, expons, numTermsPerReg);
             applyReferenceOp(refMatr, regs, totalNumQubits, allRegMatr);
-            
-            
-            // DEBUG
-            if (! areEqual(quregMatr, refMatr, 1E6*REAL_EPS) ) {
-                printf("\n\nmax phase: %lf\n", maxPhase);
-                printf("encoding: %d\n", encoding);
-                
-            }
-            
             REQUIRE( areEqual(quregMatr, refMatr, 1E6*REAL_EPS) );
         }
     }

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -596,15 +596,15 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
         }
         SECTION( "density-matrix" ) {
             
+            applyMultiVarPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, coeffs, expons, numTermsPerReg);
+            applyReferenceOp(refMatr, regs, totalNumQubits, allRegMatr);
+            
             
             // DEBUG
             if (!areEqual(quregMatr, refMatr, 1E6*REAL_EPS)) {
                 printf("max phase: %lf\n", maxPhase);
             }
             
-            
-            applyMultiVarPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, coeffs, expons, numTermsPerReg);
-            applyReferenceOp(refMatr, regs, totalNumQubits, allRegMatr);
             REQUIRE( areEqual(quregMatr, refMatr, 1E6*REAL_EPS) );
         }
     }

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -574,11 +574,6 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
                     phase += coeffs[t+startInd] * pow(ind, expons[t+startInd]);
                     
                 singleRegMatr[i][i] = expI(phase);
-                
-                
-                // dEBUG 
-                if (abs(phase) > maxPhase)
-                    maxPhase = phase;
             }                
             allRegMatr = getKroneckerProduct(singleRegMatr, allRegMatr);
             startInd += numTermsPerReg[r];

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -601,8 +601,10 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
             
             
             // DEBUG
-            if (!areEqual(quregMatr, refMatr, 1E6*REAL_EPS)) {
-                printf("max phase: %lf\n", maxPhase);
+            if (! areEqual(quregMatr, refMatr, 1E6*REAL_EPS) ) {
+                printf("\n\nmax phase: %lf\n", maxPhase);
+                printf("encoding: %d\n", encoding);
+                
             }
             
             REQUIRE( areEqual(quregMatr, refMatr, 1E6*REAL_EPS) );

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -1842,15 +1842,19 @@ TEST_CASE( "applyParamNamedPhaseFunc", "[operators]" ) {
             
             SECTION( "state-vector" ) {
                 
-                applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams);
-                applyReferenceOp(refVec, regs, totalNumQubits, diagMatr);
-                REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
+                if (numRegs%2 == 0) {
+                    applyParamNamedPhaseFunc(quregVec, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams);
+                    applyReferenceOp(refVec, regs, totalNumQubits, diagMatr);
+                    REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
+                }
             }
             SECTION( "density-matrix" ) {
                 
-                applyParamNamedPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams);
-                applyReferenceOp(refMatr, regs, totalNumQubits, diagMatr);
-                REQUIRE( areEqual(quregMatr, refMatr, 1E2*REAL_EPS) );
+                if (numRegs%2 == 0) {
+                    applyParamNamedPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, func, params, numParams);
+                    applyReferenceOp(refMatr, regs, totalNumQubits, diagMatr);
+                    REQUIRE( areEqual(quregMatr, refMatr, 1E2*REAL_EPS) );
+                }
             }
         }
     }

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -2784,13 +2784,13 @@ TEST_CASE( "applyPhaseFuncOverrides", "[operators]" ) {
             
             applyPhaseFuncOverrides(quregVec, qubits, numQubits, encoding, coeffs, expons, numTerms, overrideInds, overridePhases, numOverrides);
             applyReferenceOp(refVec, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregVec, refVec) );
+            REQUIRE( areEqual(quregVec, refVec, 1E4*REAL_EPS) );
         }
         SECTION( "density-matrix" ) {
             
             applyPhaseFuncOverrides(quregMatr, qubits, numQubits, encoding, coeffs, expons, numTerms, overrideInds, overridePhases, numOverrides);
             applyReferenceOp(refMatr, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregMatr, refMatr) );
+            REQUIRE( areEqual(quregMatr, refMatr, 1E6*REAL_EPS) );
         }
     }
     SECTION( "input validation" ) {

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -477,6 +477,13 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
         // try every kind of binary encodings
         enum bitEncoding encoding = GENERATE( UNSIGNED,TWOS_COMPLEMENT );
         
+        
+        
+        // DEBUG 
+        encoding = UNSIGNED;
+        
+        
+        
         // try every possible number of registers 
         // (between #qubits containing 1, and 1 containing #qubits)
         int numRegs;

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -2629,7 +2629,7 @@ TEST_CASE( "applyPhaseFunc", "[operators]" ) {
         
             applyPhaseFunc(quregMatr, qubits, numQubits, encoding, coeffs, expons, numTerms);
             applyReferenceOp(refMatr, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregMatr, refMatr, 1E4*REAL_EPS) );
+            REQUIRE( areEqual(quregMatr, refMatr, 1E6*REAL_EPS) );
         }
     }
     SECTION( "input validation" ) {

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -556,6 +556,11 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
          */
         QMatrix allRegMatr{{1}};
         int startInd = 0;
+        
+        // DEBUG 
+        qreal maxPhase = 0;
+        
+        
         for (int r=0; r<numRegs; r++) {
             
             QMatrix singleRegMatr = getZeroMatrix( 1 << numQubitsPerReg[r] );
@@ -573,6 +578,11 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
                     phase += coeffs[t+startInd] * pow(ind, expons[t+startInd]);
                     
                 singleRegMatr[i][i] = expI(phase);
+                
+                
+                // dEBUG 
+                if (abs(phase) > maxPhase)
+                    maxPhase = phase;
             }                
             allRegMatr = getKroneckerProduct(singleRegMatr, allRegMatr);
             startInd += numTermsPerReg[r];
@@ -585,6 +595,8 @@ TEST_CASE( "applyMultiVarPhaseFunc", "[operators]" ) {
             REQUIRE( areEqual(quregVec, refVec, 1E4*REAL_EPS) );
         }
         SECTION( "density-matrix" ) {
+            
+            printf("max phase: %lf\n", maxPhase);
             
             applyMultiVarPhaseFunc(quregMatr, regs, numQubitsPerReg, numRegs, encoding, coeffs, expons, numTermsPerReg);
             applyReferenceOp(refMatr, regs, totalNumQubits, allRegMatr);

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -2623,13 +2623,13 @@ TEST_CASE( "applyPhaseFunc", "[operators]" ) {
             
             applyPhaseFunc(quregVec, qubits, numQubits, encoding, coeffs, expons, numTerms);
             applyReferenceOp(refVec, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregVec, refVec, 1E2*REAL_EPS) );
+            REQUIRE( areEqual(quregVec, refVec, 1E4*REAL_EPS) );
         }
         SECTION( "density-matrix" ) {
         
             applyPhaseFunc(quregMatr, qubits, numQubits, encoding, coeffs, expons, numTerms);
             applyReferenceOp(refMatr, qubits, numQubits, matr);
-            REQUIRE( areEqual(quregMatr, refMatr, 1E2*REAL_EPS) );
+            REQUIRE( areEqual(quregMatr, refMatr, 1E4*REAL_EPS) );
         }
     }
     SECTION( "input validation" ) {


### PR DESCRIPTION
- enabled passing density matrices to functions `applyPhaseFunc()`, `applyPhaseFuncOverrides()`, `applyMultiVarPhaseFunc()`, `applyMultiVarPhaseFuncOverrides()`, `applyNamedPhaseFunc()`, `applyNamedPhaseFuncOverrides()`, `applyParamNamedPhaseFunc()` and `applyParamNamedPhaseFuncOverrides()`
- added density matrix unit tests for above
- patched insidious memory-initialisation GPU bug in multi-register versions of above, not triggered by state-vector unit tests since they allocated insufficient GPU memory. Scary!