### PR TITLE
patching GPU build

### DIFF
--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -473,7 +473,7 @@ QuESTEnv createQuESTEnv(void) {
     
     env.seeds = NULL;
     env.numSeeds = 0;
-    seedQuESTDefault(env);
+    seedQuESTDefault(&env);
     
     return env;
 }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -3980,7 +3980,7 @@ void seedQuEST(QuESTEnv *env, unsigned long int *seedArray, int numSeeds) {
         free(env->seeds);
         
     // record keys in permanent heap
-    env->seeds = malloc(numSeeds * sizeof *(env->seeds));
+    env->seeds = (unsigned long int*) malloc(numSeeds * sizeof *(env->seeds));
     for (int i=0; i<numSeeds; i++)
         (env->seeds)[i] = seedArray[i];
     env->numSeeds = numSeeds;

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -2114,7 +2114,7 @@ qreal statevec_findProbabilityOfZero(Qureg qureg, int measureQubit)
     qreal stateProb=0;
     
     // 1-qubit edge-case breaks below loop logic
-    if (qureg.numQubitsTotal == 1) {
+    if (qureg.numQubitsInStateVec == 1) {
         qreal amp;
         cudaMemcpy(&amp, qureg.deviceStateVec.real, sizeof(qreal), cudaMemcpyDeviceToHost);
         stateProb += amp*amp;

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -2111,9 +2111,20 @@ qreal densmatr_findProbabilityOfZero(Qureg qureg, int measureQubit)
 
 qreal statevec_findProbabilityOfZero(Qureg qureg, int measureQubit)
 {
+    qreal stateProb=0;
+    
+    // 1-qubit edge-case breaks below loop logic
+    if (qureg.numQubitsTotal == 1) {
+        qreal amp;
+        cudaMemcpy(&amp, qureg.deviceStateVec.real, sizeof(qreal), cudaMemcpyDeviceToHost);
+        stateProb += amp*amp;
+        cudaMemcpy(&amp, qureg.deviceStateVec.imag, sizeof(qreal), cudaMemcpyDeviceToHost);
+        stateProb += amp*amp;
+        return stateProb;
+    }
+    
     long long int numValuesToReduce = qureg.numAmpsPerChunk>>1;
     int valuesPerCUDABlock, numCUDABlocks, sharedMemSize;
-    qreal stateProb=0;
     int firstTime=1;
     int maxReducedPerLevel = REDUCE_SHARED_SIZE;
 


### PR DESCRIPTION
- patching GPU compile, broken by hasty introduction of `seedQuEST()` for pyQuEST
- patching 1-qubit edge-case of GPU `calcProbOfOutcome` (#231)