### PR TITLE
Win32 compatibility

### DIFF
--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -209,8 +209,10 @@ void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
 void invalidQuESTInputError(const char* errMsg, const char* errFunc) {
     default_invalidQuESTInputError(errMsg, errFunc);
 }
-#else
+#elif defined(_WIN64)
 #pragma comment(linker, "/alternatename:invalidQuESTInputError=default_invalidQuESTInputError")   
+#else
+#pragma comment(linker, "/alternatename:_invalidQuESTInputError=_default_invalidQuESTInputError")
 #endif
 
 void QuESTAssert(int isValid, ErrorCode code, const char* func){


### PR DESCRIPTION
Compilation for x86 on Windows prefixes exported C functions with an underscore, while x64 does not. This is important for the weak symbol `invalidQuESTInputError`, which for Windows is realised through the `alternatename` pragma linker comment. This commit implements different pragmas for win32 and win64, one with and one without name mangling.