### PR TITLE
Improve usability as library

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -112,10 +112,6 @@ endif()
 
 if (GPUACCELERATED)
     find_package(CUDA REQUIRED)
-    # Stop nvcc sending c compile flags through using -Xcompiler and breaking
-    # on compilation of a cpp file receiving -std=c99. In long term should figure 
-    # out why CMAKE_C_FLAGS and not CMAKE_CXX_FLAGS are being sent through to a cpp file
-    set(CUDA_PROPAGATE_HOST_FLAGS FALSE)
 endif()
 
 

--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -290,16 +290,19 @@ endif()
 
 add_subdirectory(src)
 
+if (NOT WIN32)
+    set(BUILD_SHARED_LIBS TRUE CACHE BOOL "Whether to build a dynamic library")
+else ()
+    set(BUILD_SHARED_LIBS FALSE CACHE BOOL "Whether to build a dynamic library")
+endif ()
+
+
 if (GPUACCELERATED)
-    cuda_add_library(QuEST SHARED
-        ${QuEST_SRC}
-    )
-elseif (WIN32)
-    add_library(QuEST STATIC
+    cuda_add_library(QuEST
         ${QuEST_SRC}
     )
 else ()
-    add_library(QuEST SHARED
+    add_library(QuEST
         ${QuEST_SRC}
     )
 endif()


### PR DESCRIPTION
This PR addresses two issues:

1. The current configuration blocks C and C++ flags from automatically being propagated through to the compiler by nvcc via `-Xcompiler`. This makes it unnecessarily complicated to pass flags like `-fPIC` to the compiler in GPU accelerated mode. There is a comment in the code complaining that the wrong flags were passed through (C flags to C++ compilers), but in the current version this problem could not be reproduced, despite testing compilation of a `.cpp` user source file with cmake 3.7.0 (minimum supported) and 3.22rc2 (most recent) on
    - Ubuntu 20.04.3 with GCC 8.4.0 and nvcc 10.1.243
    - macOS 10.13.6 with Clang 3.9.1 and nvcc 10.0.130
    - Windows 10.0.19043.928 with MSVC 14.29.30133 and nvcc 11.5.50

    It therefore seems safe to re-enable automatic flag propagation.

2. The behaviour to build a shared or static library is currently hard-coded into the `CMakeLists.txt` file, and if a parent project wants to deviate from this default, it must first patch QuEST. It is therefore preferable to use the `BUILD_SHARED_LIBS` cache variable to set this default behaviour, which can be overridden by the user or a parent project.

Both these issues are resolved in this PR.