### PR TITLE
Prevent hard exit

### DIFF
--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -13,6 +13,7 @@
 # include "QuEST.h"
 # include "QuEST_internal.h"
 # include "QuEST_precision.h"
+# include "QuEST_validation.h"
 # include "mt19937ar.h"
 
 # include "QuEST_cpu_internal.h"
@@ -1291,11 +1292,8 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
 {
     long long int numAmps = 1LL << numQubits;
     long long int numAmpsPerRank = numAmps/env.numRanks;
-    
-    if (numAmpsPerRank > SIZE_MAX) {
-        printf("Could not allocate memory (cannot fit numAmps into size_t)!");
-        exit (EXIT_FAILURE);
-    }
+
+    validateMemoryAllocationSize(numAmpsPerRank, __func__);
 
     size_t arrSize = (size_t) (numAmpsPerRank * sizeof(*(qureg->stateVec.real)));
     qureg->stateVec.real = malloc(arrSize);
@@ -1305,24 +1303,14 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
         qureg->pairStateVec.imag = malloc(arrSize);
     }
 
-    if ( (!(qureg->stateVec.real) || !(qureg->stateVec.imag))
-            && numAmpsPerRank ) {
-        printf("Could not allocate memory!");
-        exit (EXIT_FAILURE);
-    }
-
-    if ( env.numRanks>1 && (!(qureg->pairStateVec.real) || !(qureg->pairStateVec.imag))
-            && numAmpsPerRank ) {
-        printf("Could not allocate memory!");
-        exit (EXIT_FAILURE);
-    }
-
     qureg->numQubitsInStateVec = numQubits;
     qureg->numAmpsTotal = numAmps;
     qureg->numAmpsPerChunk = numAmpsPerRank;
     qureg->chunkId = env.rank;
     qureg->numChunks = env.numRanks;
     qureg->isDensityMatrix = 0;
+
+    validateQuregAllocation(qureg, __func__);
 }
 
 void statevec_destroyQureg(Qureg qureg, QuESTEnv env){
@@ -1357,10 +1345,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     op.imag = (qreal*) calloc(op.numElemsPerChunk, sizeof(qreal));
 
     // check cpu memory allocation was successful
-    if ( !op.real || !op.imag ) {
-        printf("Could not allocate memory!\n");
-        exit(EXIT_FAILURE);
-    }
+    validateDiagonalOpAllocation(op, __func__);
 
     return op;
 }

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -1310,7 +1310,7 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
     qureg->numChunks = env.numRanks;
     qureg->isDensityMatrix = 0;
 
-    validateQuregAllocation(qureg, __func__);
+    validateQuregAllocation(qureg, env, __func__);
 }
 
 void statevec_destroyQureg(Qureg qureg, QuESTEnv env){
@@ -1345,7 +1345,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     op.imag = (qreal*) calloc(op.numElemsPerChunk, sizeof(qreal));
 
     // check cpu memory allocation was successful
-    validateDiagonalOpAllocation(op, __func__);
+    validateDiagonalOpAllocation(&op, env, __func__);
 
     return op;
 }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -285,15 +285,15 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
         qureg->pairStateVec.imag = (qreal*) malloc(numAmpsPerRank * sizeof(qureg->pairStateVec.imag));
     }
 
-    // check cpu memory allocation was successful
-    validateQuregAllocation(qureg, __func__);
-
     qureg->numQubitsInStateVec = numQubits;
     qureg->numAmpsPerChunk = numAmpsPerRank;
     qureg->numAmpsTotal = numAmps;
     qureg->chunkId = env.rank;
     qureg->numChunks = env.numRanks;
     qureg->isDensityMatrix = 0;
+
+    // check cpu memory allocation was successful
+    validateQuregAllocation(qureg, __func__);
 
     // allocate GPU memory
     cudaMalloc(&(qureg->deviceStateVec.real), qureg->numAmpsPerChunk*sizeof(*(qureg->deviceStateVec.real)));

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -293,7 +293,7 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
     qureg->isDensityMatrix = 0;
 
     // check cpu memory allocation was successful
-    validateQuregAllocation(qureg, __func__);
+    validateQuregAllocation(qureg, env, __func__);
 
     // allocate GPU memory
     cudaMalloc(&(qureg->deviceStateVec.real), qureg->numAmpsPerChunk*sizeof(*(qureg->deviceStateVec.real)));
@@ -303,7 +303,7 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
             sizeof(qreal));
 
     // check gpu memory allocation was successful
-    validateQuregGPUAllocation(qureg, __func__);
+    validateQuregGPUAllocation(qureg, env, __func__);
 
 }
 
@@ -338,7 +338,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     // @TODO no handling of rank>1 allocation (no distributed GPU)
 
     // check cpu memory allocation was successful
-    validateDiagonalOpAllocation(op, __func__);
+    validateDiagonalOpAllocation(&op, env, __func__);
 
     // allocate GPU memory
     size_t arrSize = op.numElemsPerChunk * sizeof(qreal);
@@ -346,7 +346,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     cudaMalloc(&(op.deviceOperator.imag), arrSize);
 
     // check gpu memory allocation was successful
-    validateDiagonalOpGPUAllocation(op, __func__);
+    validateDiagonalOpGPUAllocation(&op, env, __func__);
 
     // initialise GPU memory to zero
     cudaMemset(op.deviceOperator.real, 0, arrSize);

--- a/QuEST/src/QuEST_qasm.c
+++ b/QuEST/src/QuEST_qasm.c
@@ -16,6 +16,7 @@
 # include "QuEST.h"
 # include "QuEST_precision.h"
 # include "QuEST_internal.h"
+# include "QuEST_validation.h"
 # include "QuEST_qasm.h"
 
 # include <math.h>
@@ -52,25 +53,19 @@ static const char* qasmGateLabels[] = {
     [GATE_SQRT_SWAP] = "sqrtswap" // needs decomp into cNOTs and Rx(pi/2)?
 };
 
-// @TODO make a proper internal error thing
-void bufferOverflow(void) {
-    printf("!!!\nINTERNAL ERROR: QASM line buffer filled!\n!!!");
-    exit(1);
-}
-
 void qasm_setup(Qureg* qureg) {
     
     // populate and attach QASM logger
     QASMLogger *qasmLog = malloc(sizeof *qasmLog);
     qureg->qasmLog = qasmLog;
     if (qasmLog == NULL)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     qasmLog->isLogging = 0;
     qasmLog->bufferSize = BUF_INIT_SIZE;
     qasmLog->buffer = malloc(qasmLog->bufferSize * sizeof *(qasmLog->buffer));
     if (qasmLog->buffer == NULL)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     // add headers and quantum / classical register creation
     qasmLog->bufferFill = snprintf(
@@ -79,7 +74,7 @@ void qasm_setup(Qureg* qureg) {
         QUREG_LABEL, qureg->numQubitsRepresented,
         MESREG_LABEL, qureg->numQubitsRepresented);
     if (qasmLog->bufferFill >= qasmLog->bufferSize)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
 }
 
 void qasm_startRecording(Qureg qureg) {
@@ -101,7 +96,7 @@ void addStringToQASM(Qureg qureg, char line[], int lineLen) {
                 
         int newBufSize = BUF_GROW_FAC * bufSize;
         if (lineLen + bufFill > newBufSize)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         
         char* newBuffer = malloc(newBufSize * sizeof *newBuffer);
         sprintf(newBuffer, "%s", buf);
@@ -171,7 +166,7 @@ void addGateToQASM(Qureg qureg, TargetGate gate, int* controlQubits, int numCont
     
     // check whether we overflowed buffer
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
         
     addStringToQASM(qureg, line, len);
 }
@@ -420,7 +415,7 @@ void qasm_recordMeasurement(Qureg qureg, int measureQubit) {
         
     // check whether we overflowed buffer
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     addStringToQASM(qureg, line, len);
 }
@@ -435,7 +430,7 @@ void qasm_recordInitZero(Qureg qureg) {
     
     // check whether we overflowed buffer
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     addStringToQASM(qureg, line, len);
 }
@@ -457,7 +452,7 @@ void qasm_recordInitPlus(Qureg qureg) {
         buf, MAX_LINE_LEN, "%s %s;\n", 
         qasmGateLabels[GATE_HADAMARD], QUREG_LABEL);
     if (charsWritten >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, buf, charsWritten);
     
     // old code (before above QASM shortcut)
@@ -513,7 +508,7 @@ void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncod
     len += snprintf(line+len, MAX_LINE_LEN-len, "))\n");
 
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, line, len);
 
     char encBuf[MAX_LINE_LEN];
@@ -529,7 +524,7 @@ void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncod
         len += snprintf(line+len, MAX_LINE_LEN-len, (q < numQubits-1)? "%d, ":"%d}\n", qubits[q]);
 
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, line, len);
 
     if (numOverrides > 0) {
@@ -564,7 +559,7 @@ char getPhaseFuncSymbol(int numSymbs, int ind) {
         return abc[ind];
 
     // we should never reach here, since caller should handle when numSymbs > 24
-    bufferOverflow();
+    raiseQASMBufferOverflow(__func__);
     return 'x';
 }
 
@@ -592,7 +587,7 @@ void addMultiVarRegsToQASM(Qureg qureg, int* qubits, int* numQubitsPerReg, int n
             len += snprintf(line+len, MAX_LINE_LEN-len, (q < numQubitsPerReg[r]-1)? "%d, ":"%d}\n", qubits[qInd++]);
 
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 }
@@ -634,7 +629,7 @@ void addMultiVarOverridesToQASM(Qureg qureg, int numRegs, long long int* overrid
                 overridePhases[v]);
 
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 }
@@ -657,7 +652,7 @@ void addShiftValuesToQASM(Qureg qureg, enum phaseFunc funcName, int numRegs, qre
         len = 0;
         len += snprintf(line+len, MAX_LINE_LEN-len, "//     delta%d = " REAL_QASM_FORMAT "\n", k, params[2+k]);
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 
@@ -713,7 +708,7 @@ void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg
             len += snprintf(line+len, MAX_LINE_LEN-len, " ))\n");
 
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 
@@ -849,7 +844,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
     }
 
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, line, len);
 
     addMultiVarRegsToQASM(qureg, qubits, numQubitsPerReg, numRegs, encoding);

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -116,7 +116,8 @@ typedef enum {
     E_QUREG_NOT_ALLOCATED_ON_GPU,
     E_DIAGONAL_OP_NOT_ALLOCATED,
     E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU,
-    E_NO_GPU
+    E_NO_GPU,
+    E_QASM_BUFFER_OVERFLOW
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -205,7 +206,8 @@ static const char* errorMessages[] = {
     [E_QUREG_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for Qureg on GPU. Possibly insufficient memory.",
     [E_DIAGONAL_OP_NOT_ALLOCATED] = "Could not allocate memory for DiagonalOp. Possibly insufficient memory.",
     [E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for DiagonalOp on GPU. Possibly insufficient memory.",
-    [E_NO_GPU] = "Trying to run GPU code with no GPU available."
+    [E_NO_GPU] = "Trying to run GPU code with no GPU available.",
+    [E_QASM_BUFFER_OVERFLOW] = "QASM line buffer filled."
 };
 
 void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
@@ -1037,6 +1039,11 @@ void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller) {
 void validateGPUExists(int GPUPresent, const char* caller) {
     QuESTAssert(GPUPresent, E_NO_GPU, caller);
 }
+
+void raiseQASMBufferOverflow(const char* caller) {
+    invalidQuESTInputError(errorMessages[E_QASM_BUFFER_OVERFLOW], caller);
+}
+
 
 #ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -113,7 +113,10 @@ typedef enum {
     E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC,
     E_NOT_ENOUGH_ADDRESSABLE_MEMORY,
     E_QUREG_NOT_ALLOCATED,
+    E_QUREG_NOT_ALLOCATED_ON_GPU,
     E_DIAGONAL_OP_NOT_ALLOCATED,
+    E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU,
+    E_NO_GPU
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -199,7 +202,10 @@ static const char* errorMessages[] = {
     [E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC] = "Phase functions DISTANCE, INVERSE_DISTANCE, SCALED_DISTANCE and SCALED_INVERSE_DISTANCE require a strictly even number of sub-registers.",
     [E_NOT_ENOUGH_ADDRESSABLE_MEMORY] = "Could not allocate memory. Requested more memory than system can address.",
     [E_QUREG_NOT_ALLOCATED] = "Could not allocate memory for Qureg. Possibly insufficient memory.",
+    [E_QUREG_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for Qureg on GPU. Possibly insufficient memory.",
     [E_DIAGONAL_OP_NOT_ALLOCATED] = "Could not allocate memory for DiagonalOp. Possibly insufficient memory.",
+    [E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for DiagonalOp on GPU. Possibly insufficient memory.",
+    [E_NO_GPU] = "Trying to run GPU code with no GPU available."
 };
 
 void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
@@ -1014,8 +1020,22 @@ void validateQuregAllocation(Qureg* qureg, const char* caller) {
     }
 }
 
+void validateQuregGPUAllocation(Qureg* qureg, const char* caller) {
+    QuESTAssert(qureg->deviceStateVec.real && qureg->deviceStateVec.imag, E_QUREG_NOT_ALLOCATED_ON_GPU, caller);
+}
+
 void validateDiagonalOpAllocation(DiagonalOp op, const char* caller) {
     QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED, caller);
+}
+
+void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller) {
+    QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU, caller);
+}
+
+// This is really just a dummy shim, because the scope of GPUExists()
+// is limited to the QuEST_gpu.cu file.
+void validateGPUExists(int GPUPresent, const char* caller) {
+    QuESTAssert(GPUPresent, E_NO_GPU, caller);
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -1013,25 +1013,62 @@ void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* call
     QuESTAssert(numAmpsPerRank <= SIZE_MAX, E_NOT_ENOUGH_ADDRESSABLE_MEMORY, caller);
 }
 
-void validateQuregAllocation(Qureg* qureg, const char* caller) {
+void validateQuregAllocation(Qureg* qureg, QuESTEnv env, const char* caller) {
+    int allocationSuccessful = 1;
     if (qureg->numAmpsPerChunk) {
-        QuESTAssert(qureg->stateVec.real && qureg->stateVec.imag, E_QUREG_NOT_ALLOCATED, caller);
-        if (qureg->numChunks>1) {
-            QuESTAssert(qureg->pairStateVec.real && qureg->pairStateVec.imag, E_QUREG_NOT_ALLOCATED, caller);
-        }
+        allocationSuccessful &= qureg->stateVec.real && qureg->stateVec.imag;
+        if (qureg->numChunks>1)
+            allocationSuccessful &= qureg->pairStateVec.real && qureg->pairStateVec.imag;
     }
+    if (!allocationSuccessful) {  // no memory leaks for partial allocations
+        destroyQureg(*qureg, env);
+        // Just in case the user somehow retrieves the Qureg after unsuccessful allocation,
+        // remove the dangling pointers.
+        qureg->stateVec.real = NULL;
+        qureg->stateVec.imag = NULL;
+        qureg->pairStateVec.real = NULL;
+        qureg->pairStateVec.imag = NULL;
+    }
+    QuESTAssert(allocationSuccessful, E_QUREG_NOT_ALLOCATED, caller);
 }
 
-void validateQuregGPUAllocation(Qureg* qureg, const char* caller) {
-    QuESTAssert(qureg->deviceStateVec.real && qureg->deviceStateVec.imag, E_QUREG_NOT_ALLOCATED_ON_GPU, caller);
+void validateQuregGPUAllocation(Qureg* qureg, QuESTEnv env, const char* caller) {
+    int allocationSuccessful = (qureg->deviceStateVec.real && qureg->deviceStateVec.imag
+                                && qureg->firstLevelReduction && qureg->secondLevelReduction);
+    if (!allocationSuccessful) {
+        destroyQureg(*qureg, env);
+        qureg->stateVec.real = NULL;
+        qureg->stateVec.imag = NULL;
+        qureg->pairStateVec.real = NULL;
+        qureg->pairStateVec.imag = NULL;
+        qureg->deviceStateVec.real = NULL;
+        qureg->deviceStateVec.imag = NULL;
+        qureg->firstLevelReduction = NULL;
+        qureg->secondLevelReduction = NULL;
+    }
+    QuESTAssert(allocationSuccessful, E_QUREG_NOT_ALLOCATED_ON_GPU, caller);
 }
 
-void validateDiagonalOpAllocation(DiagonalOp op, const char* caller) {
-    QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED, caller);
+void validateDiagonalOpAllocation(DiagonalOp* op, QuESTEnv env, const char* caller) {
+    int allocationSuccessful = op->real && op->imag;
+    if (!allocationSuccessful) {
+        destroyDiagonalOp(*op, env);
+        op->real = NULL;
+        op->imag = NULL;
+    }
+    QuESTAssert(allocationSuccessful, E_DIAGONAL_OP_NOT_ALLOCATED, caller);
 }
 
-void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller) {
-    QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU, caller);
+void validateDiagonalOpGPUAllocation(DiagonalOp* op, QuESTEnv env, const char* caller) {
+    int allocationSuccessful = op->deviceOperator.real && op->deviceOperator.imag;
+    if (!allocationSuccessful) {
+        destroyDiagonalOp(*op, env);
+        op->real = NULL;
+        op->imag = NULL;
+        op->deviceOperator.real = NULL;
+        op->deviceOperator.imag = NULL;
+    }
+    QuESTAssert(allocationSuccessful, E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU, caller);
 }
 
 // This is really just a dummy shim, because the scope of GPUExists()

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -110,7 +110,10 @@ typedef enum {
     E_FRACTIONAL_EXPONENT_WITHOUT_NEG_OVERRIDE,
     E_NEGATIVE_EXPONENT_MULTI_VAR,
     E_FRACTIONAL_EXPONENT_MULTI_VAR,
-    E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC
+    E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC,
+    E_NOT_ENOUGH_ADDRESSABLE_MEMORY,
+    E_QUREG_NOT_ALLOCATED,
+    E_DIAGONAL_OP_NOT_ALLOCATED,
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -193,7 +196,10 @@ static const char* errorMessages[] = {
     [E_FRACTIONAL_EXPONENT_WITHOUT_NEG_OVERRIDE] = "The phase function contained a fractional exponent, which in TWOS_COMPLEMENT encoding, requires all negative indices are overriden. However, one or more negative indices were not overriden.",
     [E_NEGATIVE_EXPONENT_MULTI_VAR] = "The phase function contained an illegal negative exponent. One must instead call applyPhaseFuncOverrides() once for each register, so that the zero index of each register is overriden, independent of the indices of all other registers.",
     [E_FRACTIONAL_EXPONENT_MULTI_VAR] = "The phase function contained a fractional exponent, which is illegal in TWOS_COMPLEMENT encoding, since it cannot be (efficiently) checked that all negative indices were overriden. One must instead call applyPhaseFuncOverrides() once for each register, so that each register's negative indices can be overriden, independent of the indices of all other registers.",
-    [E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC] = "Phase functions DISTANCE, INVERSE_DISTANCE, SCALED_DISTANCE and SCALED_INVERSE_DISTANCE require a strictly even number of sub-registers."
+    [E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC] = "Phase functions DISTANCE, INVERSE_DISTANCE, SCALED_DISTANCE and SCALED_INVERSE_DISTANCE require a strictly even number of sub-registers.",
+    [E_NOT_ENOUGH_ADDRESSABLE_MEMORY] = "Could not allocate memory. Requested more memory than system can address.",
+    [E_QUREG_NOT_ALLOCATED] = "Could not allocate memory for Qureg. Possibly insufficient memory.",
+    [E_DIAGONAL_OP_NOT_ALLOCATED] = "Could not allocate memory for DiagonalOp. Possibly insufficient memory.",
 };
 
 void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
@@ -201,7 +207,7 @@ void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
     printf("QuEST Error in function %s: %s\n", errFunc, errMsg);
     printf("!!!\n");
     printf("exiting..\n");
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 #ifndef _WIN32
@@ -993,6 +999,23 @@ void validateMultiRegBitEncoding(int* numQubitsPerReg, int numRegs, enum bitEnco
     if (encoding == TWOS_COMPLEMENT)
         for (int r=0; r<numRegs; r++)
             QuESTAssert(numQubitsPerReg[r] > 1, E_INVALID_NUM_QUBITS_TWOS_COMPLEMENT, caller);
+}
+
+void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* caller) {
+    QuESTAssert(numAmpsPerRank <= SIZE_MAX, E_NOT_ENOUGH_ADDRESSABLE_MEMORY, caller);
+}
+
+void validateQuregAllocation(Qureg* qureg, const char* caller) {
+    if (qureg->numAmpsPerChunk) {
+        QuESTAssert(qureg->stateVec.real && qureg->stateVec.imag, E_QUREG_NOT_ALLOCATED, caller);
+        if (qureg->numChunks>1) {
+            QuESTAssert(qureg->pairStateVec.real && qureg->pairStateVec.imag, E_QUREG_NOT_ALLOCATED, caller);
+        }
+    }
+}
+
+void validateDiagonalOpAllocation(DiagonalOp op, const char* caller) {
+    QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED, caller);
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -152,6 +152,12 @@ void validateBitEncoding(int numQubits, enum bitEncoding encoding, const char* c
 
 void validateMultiRegBitEncoding(int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, const char* caller);
 
+void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* caller);
+
+void validateQuregAllocation(Qureg* qureg, const char* caller);
+
+void validateDiagonalOpAllocation(DiagonalOp op, const char* caller);
+
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -156,7 +156,15 @@ void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* call
 
 void validateQuregAllocation(Qureg* qureg, const char* caller);
 
+void validateQuregGPUAllocation(Qureg* qureg, const char* caller);
+
 void validateDiagonalOpAllocation(DiagonalOp op, const char* caller);
+
+void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller);
+
+// This is really just a dummy shim, because the scope of GPUExists()
+// is limited to the QuEST_gpu.cu file.
+void validateGPUExists(int GPUPresent, const char* caller);
 
 # ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -126,7 +126,7 @@ void validateHamilFilePauliCode(enum pauliOpType code, PauliHamil h, FILE* file,
 
 void validateTrotterParams(int order, int reps, const char* caller);
 
-void validateDiagOpInit(DiagonalOp, const char* caller);
+void validateDiagOpInit(DiagonalOp op, const char* caller);
 
 void validateDiagonalOp(Qureg qureg, DiagonalOp op, const char* caller);
 
@@ -154,13 +154,13 @@ void validateMultiRegBitEncoding(int* numQubitsPerReg, int numRegs, enum bitEnco
 
 void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* caller);
 
-void validateQuregAllocation(Qureg* qureg, const char* caller);
+void validateQuregAllocation(Qureg* qureg, QuESTEnv env, const char* caller);
 
-void validateQuregGPUAllocation(Qureg* qureg, const char* caller);
+void validateQuregGPUAllocation(Qureg* qureg, QuESTEnv env, const char* caller);
 
-void validateDiagonalOpAllocation(DiagonalOp op, const char* caller);
+void validateDiagonalOpAllocation(DiagonalOp* op, QuESTEnv env, const char* caller);
 
-void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller);
+void validateDiagonalOpGPUAllocation(DiagonalOp* op, QuESTEnv env, const char* caller);
 
 // This is really just a dummy shim, because the scope of GPUExists()
 // is limited to the QuEST_gpu.cu file.

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -166,6 +166,8 @@ void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller);
 // is limited to the QuEST_gpu.cu file.
 void validateGPUExists(int GPUPresent, const char* caller);
 
+void raiseQASMBufferOverflow(const char* caller);
+
 # ifdef __cplusplus
 }
 # endif


### PR DESCRIPTION
For most cases, when QuEST receives invalid input, it will exit through the overridable function `invalidQuESTInputError()`. In some instances, however, QuEST calls `exit(1)` directly and immediately kills the process. This is undesirable if it is running as part of a larger application, because it prevents printing tracebacks by the parent process (as is the case e.g. for pyQuEST in Python).

This PR seeks to funnel _all_ calls to `exit()` through `invalidQuESTInputError`, in an effort to never exit QuEST unexpectedly and always give the user the option to detect when something has gone wrong and act accordingly.

There are valid points to be raised about the design approach used. The exit-gateway function `invalidQuESTInputError` mentions an invalid input and thus hints at user error, even if that is not the case for some of the newly introduced uses (e.g. a QASM buffer overflow). However, adding a separate mechanism to exit on internal errors through a different gateway would make the API unnecessarily bloated, as they would serve an equivalent purpose and require the user to override two functions instead of one. 