### PR TITLE
Improve precision agnosticism

### DIFF
--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -1714,16 +1714,8 @@ int statevec_initStateFromSingleFile(Qureg *qureg, char filename[200], QuESTEnv 
                 if (line[0]!='#'){
                     int chunkId = (int) (totalIndex/chunkSize);
                     if (chunkId==qureg->chunkId){
-                        # if QuEST_PREC==1
-                        sscanf(line, "%f, %f", &(stateVecReal[indexInChunk]), 
+                        sscanf(line, REAL_SPECIFIER ", " REAL_SPECIFIER, &(stateVecReal[indexInChunk]),
                                 &(stateVecImag[indexInChunk])); 
-                        # elif QuEST_PREC==2                    
-                        sscanf(line, "%lf, %lf", &(stateVecReal[indexInChunk]), 
-                                &(stateVecImag[indexInChunk]));
-                        # elif QuEST_PREC==4
-                        sscanf(line, "%Lf, %Lf", &(stateVecReal[indexInChunk]), 
-                                &(stateVecImag[indexInChunk]));
-                        # endif
                         indexInChunk += 1;
                     }
                     totalIndex += 1;

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -746,16 +746,8 @@ int statevec_initStateFromSingleFile(Qureg *qureg, char filename[200], QuESTEnv 
         if (line[0]!='#'){
             int chunkId = totalIndex/chunkSize;
             if (chunkId==qureg->chunkId){
-                # if QuEST_PREC==1
-                    sscanf(line, "%f, %f", &(stateVecReal[indexInChunk]),
-                            &(stateVecImag[indexInChunk]));
-                # elif QuEST_PREC==2
-                    sscanf(line, "%lf, %lf", &(stateVecReal[indexInChunk]),
-                            &(stateVecImag[indexInChunk]));
-                # elif QuEST_PREC==4
-                    sscanf(line, "%lf, %lf", &(stateVecReal[indexInChunk]),
-                            &(stateVecImag[indexInChunk]));
-                # endif
+                sscanf(line, REAL_SPECIFIER ", " REAL_SPECIFIER, &(stateVecReal[indexInChunk]),
+                        &(stateVecImag[indexInChunk]));
                 indexInChunk += 1;
             }
             totalIndex += 1;

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -661,7 +661,7 @@ void multiRotateZ(Qureg qureg, int* qubits, int numQubits, qreal angle) {
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-qubit multiRotateZ of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-qubit multiRotateZ of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numQubits, angle);
 }
 
@@ -678,7 +678,7 @@ void multiControlledMultiRotateZ(Qureg qureg, int* controlQubits, int numControl
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-control %d-target multiControlledMultiRotateZ of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-control %d-target multiControlledMultiRotateZ of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numControls, numTargets, angle);
 }
 
@@ -698,7 +698,7 @@ void multiRotatePauli(Qureg qureg, int* targetQubits, enum pauliOpType* targetPa
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-qubit multiRotatePauli of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-qubit multiRotatePauli of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numTargets, angle);
 }
 
@@ -719,7 +719,7 @@ void multiControlledMultiRotatePauli(Qureg qureg, int* controlQubits, int numCon
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-control %d-target multiControlledMultiRotatePauli of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-control %d-target multiControlledMultiRotatePauli of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numControls, numTargets, angle);
 }
 
@@ -1076,7 +1076,7 @@ void applyTrotterCircuit(Qureg qureg, PauliHamil hamil, qreal time, int order, i
     validateMatchingQuregPauliHamilDims(qureg, hamil, __func__);
     
     qasm_recordComment(qureg, 
-        "Beginning of Trotter circuit (time %g, order %d, %d repetitions).",
+        "Beginning of Trotter circuit (time " REAL_QASM_FORMAT ", order %d, %d repetitions).",
         time, order, reps);
         
     agnostic_applyTrotterCircuit(qureg, hamil, time, order, reps);
@@ -1257,7 +1257,7 @@ void mixDephasing(Qureg qureg, int targetQubit, qreal prob) {
     
     densmatr_mixDephasing(qureg, targetQubit, 2*prob);
     qasm_recordComment(qureg, 
-        "Here, a phase (Z) error occured on qubit %d with probability %g", targetQubit, prob);
+        "Here, a phase (Z) error occured on qubit %d with probability " REAL_QASM_FORMAT, targetQubit, prob);
 }
 
 void mixTwoQubitDephasing(Qureg qureg, int qubit1, int qubit2, qreal prob) {
@@ -1269,7 +1269,7 @@ void mixTwoQubitDephasing(Qureg qureg, int qubit1, int qubit2, qreal prob) {
     densmatr_mixTwoQubitDephasing(qureg, qubit1, qubit2, (4*prob)/3.0);
     qasm_recordComment(qureg,
         "Here, a phase (Z) error occured on either or both of qubits "
-        "%d and %d with total probability %g", qubit1, qubit2, prob);
+        "%d and %d with total probability " REAL_QASM_FORMAT, qubit1, qubit2, prob);
 }
 
 void mixDepolarising(Qureg qureg, int targetQubit, qreal prob) {
@@ -1280,7 +1280,7 @@ void mixDepolarising(Qureg qureg, int targetQubit, qreal prob) {
     densmatr_mixDepolarising(qureg, targetQubit, (4*prob)/3.0);
     qasm_recordComment(qureg,
         "Here, a homogeneous depolarising error (X, Y, or Z) occured on "
-        "qubit %d with total probability %g", targetQubit, prob);
+        "qubit %d with total probability " REAL_QASM_FORMAT, targetQubit, prob);
 }
 
 void mixDamping(Qureg qureg, int targetQubit, qreal prob) {
@@ -1300,7 +1300,7 @@ void mixTwoQubitDepolarising(Qureg qureg, int qubit1, int qubit2, qreal prob) {
     densmatr_mixTwoQubitDepolarising(qureg, qubit1, qubit2, (16*prob)/15.0);
     qasm_recordComment(qureg,
         "Here, a homogeneous depolarising error occured on qubits %d and %d "
-        "with total probability %g", qubit1, qubit2, prob);
+        "with total probability " REAL_QASM_FORMAT, qubit1, qubit2, prob);
 }
 
 void mixPauli(Qureg qureg, int qubit, qreal probX, qreal probY, qreal probZ) {
@@ -1311,7 +1311,7 @@ void mixPauli(Qureg qureg, int qubit, qreal probX, qreal probY, qreal probZ) {
     densmatr_mixPauli(qureg, qubit, probX, probY, probZ);
     qasm_recordComment(qureg,
         "Here, X, Y and Z errors occured on qubit %d with probabilities "
-        "%g, %g and %g respectively", qubit, probX, probY, probZ);
+        REAL_QASM_FORMAT ", " REAL_QASM_FORMAT " and " REAL_QASM_FORMAT " respectively", qubit, probX, probY, probZ);
 }
 
 void mixKrausMap(Qureg qureg, int target, ComplexMatrix2 *ops, int numOps) {

--- a/QuEST/src/QuEST_common.c
+++ b/QuEST/src/QuEST_common.c
@@ -225,11 +225,7 @@ void reportState(Qureg qureg){
     if (qureg.chunkId==0) fprintf(state, "real, imag\n");
 
     for(index=0; index<qureg.numAmpsPerChunk; index++){
-        # if QuEST_PREC==1 || QuEST_PREC==2
-        fprintf(state, "%.12f, %.12f\n", qureg.stateVec.real[index], qureg.stateVec.imag[index]);
-        # elif QuEST_PREC == 4
-        fprintf(state, "%.12Lf, %.12Lf\n", qureg.stateVec.real[index], qureg.stateVec.imag[index]);
-        #endif
+        fprintf(state, REAL_STRING_FORMAT ", " REAL_STRING_FORMAT "\n", qureg.stateVec.real[index], qureg.stateVec.imag[index]);
     }
     fclose(state);
 }
@@ -812,7 +808,7 @@ void applyExponentiatedPauliHamil(Qureg qureg, PauliHamil hamil, qreal fac, int 
         buff[b] = '\0';
         
         qasm_recordComment(qureg, 
-            "Here, a multiRotatePauli with angle %g and paulis %s was applied.",
+            "Here, a multiRotatePauli with angle " REAL_QASM_FORMAT " and paulis %s was applied.",
             angle, buff);
     }
 }

--- a/QuEST/src/QuEST_qasm.c
+++ b/QuEST/src/QuEST_qasm.c
@@ -763,7 +763,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
                         (params[2+r] < 0)?
                             "(%c^2+" REAL_QASM_FORMAT ")" :
                             "(%c^2-" REAL_QASM_FORMAT ")",
-                        getPhaseFuncSymbol(numRegs,r), fabs(params[2+r]));
+                        getPhaseFuncSymbol(numRegs,r), absReal(params[2+r]));
                 else
                     len += snprintf(line+len, MAX_LINE_LEN-len, "%c^2", getPhaseFuncSymbol(numRegs,r));
                 len += snprintf(line+len, MAX_LINE_LEN-len, (r < numRegs - 1)? " + ":"))\n");
@@ -834,7 +834,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
                         (params[2+r/2] < 0)?
                             "(%c-%c+" REAL_QASM_FORMAT ")^2":
                             "(%c-%c-" REAL_QASM_FORMAT ")^2", 
-                        getPhaseFuncSymbol(numRegs,r), getPhaseFuncSymbol(numRegs,r+1), fabs(params[2+r/2]));
+                        getPhaseFuncSymbol(numRegs,r), getPhaseFuncSymbol(numRegs,r+1), absReal(params[2+r/2]));
                 else
                     len += snprintf(line+len, MAX_LINE_LEN-len, "(%c-%c)^2", 
                         getPhaseFuncSymbol(numRegs,r), getPhaseFuncSymbol(numRegs,r+1));

--- a/examples/bernstein_vazirani_circuit.c
+++ b/examples/bernstein_vazirani_circuit.c
@@ -38,7 +38,7 @@
 
      qreal prob = getProbAmp(qureg, ind);
 
-     printf("success probability: %g \n", prob);
+     printf("success probability: " REAL_QASM_FORMAT " \n", prob);
  }
 
 

--- a/examples/grovers_search.c
+++ b/examples/grovers_search.c
@@ -108,7 +108,7 @@ int main() {
         applyDiffuser(qureg, numQubits);
         
         // monitor the probability of the solution state
-        printf("prob of solution |%d> = %g\n", 
+        printf("prob of solution |%d> = " REAL_STRING_FORMAT "\n",
             solElem, getProbAmp(qureg, solElem));
     }
     

--- a/examples/tutorial_example.c
+++ b/examples/tutorial_example.c
@@ -91,16 +91,16 @@ int main (int narg, char *varg[]) {
 
     qreal prob;
     prob = getProbAmp(qubits, 7);
-    printf("Probability amplitude of |111>: %g\n", prob);
+    printf("Probability amplitude of |111>: " REAL_STRING_FORMAT "\n", prob);
 
     prob = calcProbOfOutcome(qubits, 2, 1);
-    printf("Probability of qubit 2 being in state 1: %g\n", prob);
+    printf("Probability of qubit 2 being in state 1: " REAL_STRING_FORMAT "\n", prob);
 
     int outcome = measure(qubits, 0);
     printf("Qubit 0 was measured in state %d\n", outcome);
 
     outcome = measureWithStats(qubits, 2, &prob);
-    printf("Qubit 2 collapsed to %d with probability %g\n", outcome, prob);
+    printf("Qubit 2 collapsed to %d with probability " REAL_STRING_FORMAT "\n", outcome, prob);
 
 
 


### PR DESCRIPTION
For precision agnosticism, QuEST provides macros for format specifiers and function calls in `QuEST_precision.h`, which should be used in place of hard-coded `%f` and the like, as well as calls to `fabs()`. This PR replaces instances of such specific function calls and string formats with their precision-agonstic equivalent.