### PR TITLE
v3.5.0

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -112,10 +112,6 @@ endif()
 
 if (GPUACCELERATED)
     find_package(CUDA REQUIRED)
-    # Stop nvcc sending c compile flags through using -Xcompiler and breaking
-    # on compilation of a cpp file receiving -std=c99. In long term should figure 
-    # out why CMAKE_C_FLAGS and not CMAKE_CXX_FLAGS are being sent through to a cpp file
-    set(CUDA_PROPAGATE_HOST_FLAGS FALSE)
 endif()
 
 

--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -290,16 +290,19 @@ endif()
 
 add_subdirectory(src)
 
+if (NOT WIN32)
+    set(BUILD_SHARED_LIBS TRUE CACHE BOOL "Whether to build a dynamic library")
+else ()
+    set(BUILD_SHARED_LIBS FALSE CACHE BOOL "Whether to build a dynamic library")
+endif ()
+
+
 if (GPUACCELERATED)
-    cuda_add_library(QuEST SHARED
-        ${QuEST_SRC}
-    )
-elseif (WIN32)
-    add_library(QuEST STATIC
+    cuda_add_library(QuEST
         ${QuEST_SRC}
     )
 else ()
-    add_library(QuEST SHARED
+    add_library(QuEST
         ${QuEST_SRC}
     )
 endif()

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -1494,7 +1494,8 @@ void initDebugState(Qureg qureg);
  */
 void initStateFromAmps(Qureg qureg, qreal* reals, qreal* imags);
 
-/** Overwrites a subset of the amplitudes in state-vector \p qureg, with those passed in \p reals and \p imags.
+/** Overwrites a contiguous subset of the amplitudes in state-vector \p qureg, 
+ * with those passed in \p reals and \p imags.
  *
  * Only amplitudes with indices in <b>[</b>\p startInd<b>,</b> \p startInd <b>+</b> \p numAmps<b>]</b> 
  * will be changed. The resulting \p qureg may not necessarily be in an L2 normalised state.
@@ -1522,6 +1523,7 @@ void initStateFromAmps(Qureg qureg, qreal* reals, qreal* imags);
  *
  *
  * @see
+ * - setDensityAmps()
  * - setWeightedQureg()
  * - initStateFromAmps()
  * - initBlankState()
@@ -1540,6 +1542,38 @@ void initStateFromAmps(Qureg qureg, qreal* reals, qreal* imags);
  * @author Tyson Jones
  */
 void setAmps(Qureg qureg, long long int startInd, qreal* reals, qreal* imags, long long int numAmps);
+
+/** Overwrites a contiguous subset of the amplitudes in density-matrix \p qureg, 
+ * with those passed in \p reals and \p imags, intrepreted column-wise.
+ *
+ * Only the first \p numAmp amplitudes starting from row-column index (\p startRow, \p startCol), and
+ * proceeding down the column (wrapping around between rows) will be modified. 
+ * The resulting \p qureg may not necessarily be a valid density matrix normalisation.
+ *
+ * In distributed mode, this function assumes the subset \p reals and \p imags exist
+ * (at least) on the node(s) containing the ultimately updated elements.\n
+ *
+ *
+ * @see
+ * - setAmps()
+ * - initStateFromAmps()
+ *
+ * @ingroup init
+ * @param[in,out] qureg the density-matrix to modify
+ * @param[in] startRow the row-index of the first amplitude in \p qureg to modify
+ * @param[in] startCol the column-index of the first amplitude in \p qureg to modify
+ * @param[in] reals array of the real components of the new amplitudes
+ * @param[in] imags array of the imaginary components of the new amplitudes
+ * @param[in] numAmps the length of each of the reals and imags arrays
+ * @throws invalidQuESTInputError()
+ * - if \p qureg is not a density matrix (i.e. is a state-vector)
+ * - if \p startRow is outside [0, `1 << qureg.numQubitsRepresented`]
+ * - if \p startCol is outside [0, `1 << qureg.numQubitsRepresented`]
+ * - if \p numAmps is outside [0, `qureg.numAmpsTotal`]
+ * - if \p numAmps is larger than the remaining number of amplitudes from (`startRow`, `startCol`), column-wise
+ * @author Tyson Jones
+ */
+void setDensityAmps(Qureg qureg, long long int startRow, long long int startCol, qreal* reals, qreal* imags, long long int numAmps);
 
 /** Overwrite the amplitudes of \p targetQureg with those from \p copyQureg. 
  * 
@@ -6621,7 +6655,7 @@ void applyQFT(Qureg qureg, int* qubits, int numQubits);
  * @ingroup operator
  * @param[in,out] qureg a state-vector or density matrix to modify
  * @param[in] qubit the qubit to which to apply the projector 
- * @param[in] the single-qubit outcome (`0` or `1`) to project \p qubit into
+ * @param[in] outcome the single-qubit outcome (`0` or `1`) to project \p qubit into
  * @throws invalidQuESTInputError()
  * - if \p qubit is outside [0, `qureg.numQubitsRepresented`)
  * - if \p outcome is not in {0,1}

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -1969,6 +1969,8 @@ void getEnvironmentString(QuESTEnv env, char str[200]);
  *
  * @see
  * - copyStateFromGPU()
+ * - copySubstateFromGPU()
+ * - copySubstateToGPU()
  *
  * @ingroup debug
  * @param[in, out] qureg the qureg of which to copy `.stateVec` to `.deviceStateVec` in GPU mode
@@ -1996,6 +1998,8 @@ void copyStateToGPU(Qureg qureg);
  *
  * @see
  * - copyStateToGPU()
+ * - copySubstateFromGPU()
+ * - copySubstateToGPU()
  *
  * @ingroup debug
  * @param[in, out] qureg the qureg of which to copy `.deviceStateVec` to `.stateVec` in GPU mode
@@ -2003,6 +2007,74 @@ void copyStateToGPU(Qureg qureg);
  * @author Tyson Jones (doc)
  */
 void copyStateFromGPU(Qureg qureg);
+
+/** In GPU mode, this copies a substate of the state-vector (or density matrix) from RAM 
+ * (qureg.stateVec) to VRAM / GPU-memory (qureg.deviceStateVec), which is the version 
+ * operated upon by other calls to the API. 
+ * In CPU mode, this function has no effect.
+ * In conjunction with copySubstateFromGPU(), this allows 
+ * a user to directly modify a subset of the amplitudes the state-vector in a harware agnostic way,
+ * without having to load the entire state via copyStateFromGPU().
+ *
+ * Note though that users should instead use setAmps() if possible.
+ *
+ * For example, to multiply the first amplitude by factor 2, one could do
+ * ```
+ *     copySubstateFromGPU(qureg, 0, 1);
+ *     qureg.stateVec.real[0] *= 2;
+ *     qureg.stateVec.imag[0] *= 2;
+ *     copySubstateToGPU(qureg, 0, 1);
+ * ```
+ *
+ * Note users should never access qureg.deviceStateVec directly.
+ *
+ * @see
+ * - copySubstateFromGPU()
+ * - copyStateToGPU()
+ * - copyStateFromGPU()
+ *
+ * @ingroup debug
+ * @param[in, out] qureg the qureg of which to copy `.stateVec` to `.deviceStateVec` in GPU mode
+ * @param[in] startInd the index of the first amplitude to copy
+ * @param[in] numAmps the number of contiguous amplitudes to copy (starting with startInd)
+ * @throws invalidQuESTInputError()
+ * - if \p startInd is an invalid amplitude index 
+ * - if \p numAmps is greater than the remaining amplitudes in the state, from \p startInd
+ * @author Tyson Jones
+ */
+void copySubstateToGPU(Qureg qureg, long long int startInd, long long int numAmps);
+
+/** In GPU mode, this copies a substate of the state-vector (or density matrix) 
+ * from GPU VRAM (qureg.deviceStateVec) into RAM (qureg.stateVec).
+ * In CPU mode, this function has no effect.
+ * In conjunction with copySubstateToGPU(), this allows 
+ * a user to directly modify a subset of the amplitudes the state-vector in a hardware agnostic way.
+ *
+ * For example, to multiply the first amplitude by factor 2, one could do
+ * ```
+ *     copySubstateFromGPU(qureg, 0, 1);
+ *     qureg.stateVec.real[0] *= 2;
+ *     qureg.stateVec.imag[0] *= 2;
+ *     copySubstateToGPU(qureg, 0, 1);
+ * ```
+ *
+ * Note users should never access qureg.deviceStateVec directly.
+ *
+ * @see
+ * - copySubstateToGPU()
+ * - copyStateToGPU()
+ * - copyStateFromGPU()
+ *
+ * @ingroup debug
+ * @param[in, out] qureg the qureg of which to copy `.deviceStateVec` to `.stateVec` to in GPU mode
+ * @param[in] startInd the index of the first amplitude to copy
+ * @param[in] numAmps the number of contiguous amplitudes to copy (starting with startInd)
+ * @throws invalidQuESTInputError()
+ * - if \p startInd is an invalid amplitude index 
+ * - if \p numAmps is greater than the remaining amplitudes in the state, from \p startInd
+ * @author Tyson Jones
+ */
+void copySubstateFromGPU(Qureg qureg, long long int startInd, long long int numAmps);
 
 /** Get the complex amplitude at a given index in the state vector.
  *

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -1315,7 +1315,7 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
     qureg->numChunks = env.numRanks;
     qureg->isDensityMatrix = 0;
 
-    validateQuregAllocation(qureg, __func__);
+    validateQuregAllocation(qureg, env, __func__);
 }
 
 void statevec_destroyQureg(Qureg qureg, QuESTEnv env){
@@ -1350,7 +1350,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     op.imag = (qreal*) calloc(op.numElemsPerChunk, sizeof(qreal));
 
     // check cpu memory allocation was successful
-    validateDiagonalOpAllocation(op, __func__);
+    validateDiagonalOpAllocation(&op, env, __func__);
 
     return op;
 }

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -1714,16 +1714,8 @@ int statevec_initStateFromSingleFile(Qureg *qureg, char filename[200], QuESTEnv 
                 if (line[0]!='#'){
                     int chunkId = (int) (totalIndex/chunkSize);
                     if (chunkId==qureg->chunkId){
-                        # if QuEST_PREC==1
-                        sscanf(line, "%f, %f", &(stateVecReal[indexInChunk]), 
+                        sscanf(line, REAL_SPECIFIER ", " REAL_SPECIFIER, &(stateVecReal[indexInChunk]),
                                 &(stateVecImag[indexInChunk])); 
-                        # elif QuEST_PREC==2                    
-                        sscanf(line, "%lf, %lf", &(stateVecReal[indexInChunk]), 
-                                &(stateVecImag[indexInChunk]));
-                        # elif QuEST_PREC==4
-                        sscanf(line, "%Lf, %Lf", &(stateVecReal[indexInChunk]), 
-                                &(stateVecImag[indexInChunk]));
-                        # endif
                         indexInChunk += 1;
                     }
                     totalIndex += 1;

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -45,6 +45,11 @@ void copyStateToGPU(Qureg qureg) {
 void copyStateFromGPU(Qureg qureg) {
 }
 
+void statevec_copySubstateToGPU(Qureg qureg, long long int startInd, long long int numAmps) {
+}
+
+void statevec_copySubstateFromGPU(Qureg qureg, long long int startInd, long long int numAmps) {
+}
 
 
 /*

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -13,6 +13,7 @@
 # include "QuEST.h"
 # include "QuEST_internal.h"
 # include "QuEST_precision.h"
+# include "QuEST_validation.h"
 # include "mt19937ar.h"
 
 # include "QuEST_cpu_internal.h"
@@ -1296,11 +1297,8 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
 {
     long long int numAmps = 1LL << numQubits;
     long long int numAmpsPerRank = numAmps/env.numRanks;
-    
-    if (numAmpsPerRank > SIZE_MAX) {
-        printf("Could not allocate memory (cannot fit numAmps into size_t)!");
-        exit (EXIT_FAILURE);
-    }
+
+    validateMemoryAllocationSize(numAmpsPerRank, __func__);
 
     size_t arrSize = (size_t) (numAmpsPerRank * sizeof(*(qureg->stateVec.real)));
     qureg->stateVec.real = malloc(arrSize);
@@ -1310,24 +1308,14 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
         qureg->pairStateVec.imag = malloc(arrSize);
     }
 
-    if ( (!(qureg->stateVec.real) || !(qureg->stateVec.imag))
-            && numAmpsPerRank ) {
-        printf("Could not allocate memory!");
-        exit (EXIT_FAILURE);
-    }
-
-    if ( env.numRanks>1 && (!(qureg->pairStateVec.real) || !(qureg->pairStateVec.imag))
-            && numAmpsPerRank ) {
-        printf("Could not allocate memory!");
-        exit (EXIT_FAILURE);
-    }
-
     qureg->numQubitsInStateVec = numQubits;
     qureg->numAmpsTotal = numAmps;
     qureg->numAmpsPerChunk = numAmpsPerRank;
     qureg->chunkId = env.rank;
     qureg->numChunks = env.numRanks;
     qureg->isDensityMatrix = 0;
+
+    validateQuregAllocation(qureg, __func__);
 }
 
 void statevec_destroyQureg(Qureg qureg, QuESTEnv env){
@@ -1362,10 +1350,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     op.imag = (qreal*) calloc(op.numElemsPerChunk, sizeof(qreal));
 
     // check cpu memory allocation was successful
-    if ( !op.real || !op.imag ) {
-        printf("Could not allocate memory!\n");
-        exit(EXIT_FAILURE);
-    }
+    validateDiagonalOpAllocation(op, __func__);
 
     return op;
 }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -285,15 +285,15 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
         qureg->pairStateVec.imag = (qreal*) malloc(numAmpsPerRank * sizeof(qureg->pairStateVec.imag));
     }
 
-    // check cpu memory allocation was successful
-    validateQuregAllocation(qureg, __func__);
-
     qureg->numQubitsInStateVec = numQubits;
     qureg->numAmpsPerChunk = numAmpsPerRank;
     qureg->numAmpsTotal = numAmps;
     qureg->chunkId = env.rank;
     qureg->numChunks = env.numRanks;
     qureg->isDensityMatrix = 0;
+
+    // check cpu memory allocation was successful
+    validateQuregAllocation(qureg, __func__);
 
     // allocate GPU memory
     cudaMalloc(&(qureg->deviceStateVec.real), qureg->numAmpsPerChunk*sizeof(*(qureg->deviceStateVec.real)));

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -3559,7 +3559,7 @@ __global__ void statevec_applyPhaseFuncOverridesKernel(
         phase = overridePhases[i];
     else
         for (int t=0; t<numTerms; t++)
-            phase += coeffs[t] * pow(phaseInd, exponents[t]);
+            phase += coeffs[t] * pow((qreal) phaseInd, (qreal) exponents[t]);
             
     // negate phase to conjugate operator 
     if (conj)
@@ -3674,7 +3674,7 @@ __global__ void statevec_applyMultiVarPhaseFuncOverridesKernel(
         flatInd = 0;
         for (int r=0; r<numRegs; r++) {
             for (int t=0; t<numTermsPerReg[r]; t++) {
-                phase += coeffs[flatInd] * pow(phaseInds[r*stride+offset], exponents[flatInd]);
+                phase += coeffs[flatInd] * pow((qreal) phaseInds[r*stride+offset], (qreal) exponents[flatInd]);
                 flatInd++;
             }
         }

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -537,6 +537,27 @@ void copyStateFromGPU(Qureg qureg)
     if (DEBUG) printf("Finished copying data from GPU\n");
 }
 
+void statevec_copySubstateToGPU(Qureg qureg, long long int startInd, long long int numAmps)
+{
+    if (DEBUG) printf("Copying data to GPU\n");
+    cudaMemcpy(&(qureg.deviceStateVec.real[startInd]), &(qureg.stateVec.real[startInd]), 
+            numAmps*sizeof(*(qureg.deviceStateVec.real)), cudaMemcpyHostToDevice);
+    cudaMemcpy(&(qureg.deviceStateVec.imag[startInd]), &(qureg.stateVec.imag[startInd]), 
+            numAmps*sizeof(*(qureg.deviceStateVec.imag)), cudaMemcpyHostToDevice);
+    if (DEBUG) printf("Finished copying data to GPU\n");
+}
+
+void statevec_copySubstateFromGPU(Qureg qureg, long long int startInd, long long int numAmps)
+{
+    cudaDeviceSynchronize();
+    if (DEBUG) printf("Copying data from GPU\n");
+    cudaMemcpy(&(qureg.stateVec.real[startInd]), &(qureg.deviceStateVec.real[startInd]), 
+            numAmps*sizeof(*(qureg.deviceStateVec.real)), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&(qureg.stateVec.imag[startInd]), &(qureg.deviceStateVec.imag[startInd]), 
+            numAmps*sizeof(*(qureg.deviceStateVec.imag)), cudaMemcpyDeviceToHost);
+    if (DEBUG) printf("Finished copying data from GPU\n");
+}
+
 /** Print the current state vector of probability amplitudes for a set of qubits to standard out. 
   For debugging purposes. Each rank should print output serially. Only print output for systems <= 5 qubits
  */

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -746,16 +746,8 @@ int statevec_initStateFromSingleFile(Qureg *qureg, char filename[200], QuESTEnv 
         if (line[0]!='#'){
             int chunkId = totalIndex/chunkSize;
             if (chunkId==qureg->chunkId){
-                # if QuEST_PREC==1
-                    sscanf(line, "%f, %f", &(stateVecReal[indexInChunk]),
-                            &(stateVecImag[indexInChunk]));
-                # elif QuEST_PREC==2
-                    sscanf(line, "%lf, %lf", &(stateVecReal[indexInChunk]),
-                            &(stateVecImag[indexInChunk]));
-                # elif QuEST_PREC==4
-                    sscanf(line, "%lf, %lf", &(stateVecReal[indexInChunk]),
-                            &(stateVecImag[indexInChunk]));
-                # endif
+                sscanf(line, REAL_SPECIFIER ", " REAL_SPECIFIER, &(stateVecReal[indexInChunk]),
+                        &(stateVecImag[indexInChunk]));
                 indexInChunk += 1;
             }
             totalIndex += 1;

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -293,7 +293,7 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
     qureg->isDensityMatrix = 0;
 
     // check cpu memory allocation was successful
-    validateQuregAllocation(qureg, __func__);
+    validateQuregAllocation(qureg, env, __func__);
 
     // allocate GPU memory
     cudaMalloc(&(qureg->deviceStateVec.real), qureg->numAmpsPerChunk*sizeof(*(qureg->deviceStateVec.real)));
@@ -303,7 +303,7 @@ void statevec_createQureg(Qureg *qureg, int numQubits, QuESTEnv env)
             sizeof(qreal));
 
     // check gpu memory allocation was successful
-    validateQuregGPUAllocation(qureg, __func__);
+    validateQuregGPUAllocation(qureg, env, __func__);
 
 }
 
@@ -338,7 +338,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     // @TODO no handling of rank>1 allocation (no distributed GPU)
 
     // check cpu memory allocation was successful
-    validateDiagonalOpAllocation(op, __func__);
+    validateDiagonalOpAllocation(&op, env, __func__);
 
     // allocate GPU memory
     size_t arrSize = op.numElemsPerChunk * sizeof(qreal);
@@ -346,7 +346,7 @@ DiagonalOp agnostic_createDiagonalOp(int numQubits, QuESTEnv env) {
     cudaMalloc(&(op.deviceOperator.imag), arrSize);
 
     // check gpu memory allocation was successful
-    validateDiagonalOpGPUAllocation(op, __func__);
+    validateDiagonalOpGPUAllocation(&op, env, __func__);
 
     // initialise GPU memory to zero
     cudaMemset(op.deviceOperator.real, 0, arrSize);

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -1027,9 +1027,12 @@ void setAmps(Qureg qureg, long long int startInd, qreal* reals, qreal* imags, lo
     qasm_recordComment(qureg, "Here, some amplitudes in the statevector were manually edited.");
 }
 
-void setDensityAmps(Qureg qureg, qreal* reals, qreal* imags) {
-    long long int numAmps = qureg.numAmpsTotal; 
-    statevec_setAmps(qureg, 0, reals, imags, numAmps);
+void setDensityAmps(Qureg qureg, long long int startRow, long long int startCol, qreal* reals, qreal* imags, long long int numAmps) {
+    validateDensityMatrQureg(qureg, __func__);
+    validateNumDensityAmps(qureg, startRow, startCol, numAmps, __func__);
+
+    long long int startInd = startRow + startCol*(1 << qureg.numQubitsRepresented);
+    statevec_setAmps(qureg, startInd, reals, imags, numAmps);
     
     qasm_recordComment(qureg, "Here, some amplitudes in the density matrix were manually edited.");
 }

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -1656,6 +1656,19 @@ void getQuESTSeeds(QuESTEnv env, unsigned long int** seeds, int* numSeeds) {
     *seeds = env.seeds;
     *numSeeds = env.numSeeds;
 }
+
+void copySubstateToGPU(Qureg qureg, long long int startInd, long long int numAmps) {
+    validateNumAmps(qureg, startInd, numAmps, __func__);
+    
+    statevec_copySubstateToGPU(qureg, startInd, numAmps);
+}
+
+void copySubstateFromGPU(Qureg qureg, long long int startInd, long long int numAmps) {
+    validateNumAmps(qureg, startInd, numAmps, __func__);
+    
+    statevec_copySubstateFromGPU(qureg, startInd, numAmps);
+}
+
   
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -661,7 +661,7 @@ void multiRotateZ(Qureg qureg, int* qubits, int numQubits, qreal angle) {
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-qubit multiRotateZ of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-qubit multiRotateZ of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numQubits, angle);
 }
 
@@ -678,7 +678,7 @@ void multiControlledMultiRotateZ(Qureg qureg, int* controlQubits, int numControl
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-control %d-target multiControlledMultiRotateZ of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-control %d-target multiControlledMultiRotateZ of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numControls, numTargets, angle);
 }
 
@@ -698,7 +698,7 @@ void multiRotatePauli(Qureg qureg, int* targetQubits, enum pauliOpType* targetPa
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-qubit multiRotatePauli of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-qubit multiRotatePauli of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numTargets, angle);
 }
 
@@ -719,7 +719,7 @@ void multiControlledMultiRotatePauli(Qureg qureg, int* controlQubits, int numCon
     
     // @TODO: create actual QASM
     qasm_recordComment(qureg, 
-        "Here a %d-control %d-target multiControlledMultiRotatePauli of angle %g was performed (QASM not yet implemented)",
+        "Here a %d-control %d-target multiControlledMultiRotatePauli of angle " REAL_QASM_FORMAT " was performed (QASM not yet implemented)",
         numControls, numTargets, angle);
 }
 
@@ -1076,7 +1076,7 @@ void applyTrotterCircuit(Qureg qureg, PauliHamil hamil, qreal time, int order, i
     validateMatchingQuregPauliHamilDims(qureg, hamil, __func__);
     
     qasm_recordComment(qureg, 
-        "Beginning of Trotter circuit (time %g, order %d, %d repetitions).",
+        "Beginning of Trotter circuit (time " REAL_QASM_FORMAT ", order %d, %d repetitions).",
         time, order, reps);
         
     agnostic_applyTrotterCircuit(qureg, hamil, time, order, reps);
@@ -1257,7 +1257,7 @@ void mixDephasing(Qureg qureg, int targetQubit, qreal prob) {
     
     densmatr_mixDephasing(qureg, targetQubit, 2*prob);
     qasm_recordComment(qureg, 
-        "Here, a phase (Z) error occured on qubit %d with probability %g", targetQubit, prob);
+        "Here, a phase (Z) error occured on qubit %d with probability " REAL_QASM_FORMAT, targetQubit, prob);
 }
 
 void mixTwoQubitDephasing(Qureg qureg, int qubit1, int qubit2, qreal prob) {
@@ -1269,7 +1269,7 @@ void mixTwoQubitDephasing(Qureg qureg, int qubit1, int qubit2, qreal prob) {
     densmatr_mixTwoQubitDephasing(qureg, qubit1, qubit2, (4*prob)/3.0);
     qasm_recordComment(qureg,
         "Here, a phase (Z) error occured on either or both of qubits "
-        "%d and %d with total probability %g", qubit1, qubit2, prob);
+        "%d and %d with total probability " REAL_QASM_FORMAT, qubit1, qubit2, prob);
 }
 
 void mixDepolarising(Qureg qureg, int targetQubit, qreal prob) {
@@ -1280,7 +1280,7 @@ void mixDepolarising(Qureg qureg, int targetQubit, qreal prob) {
     densmatr_mixDepolarising(qureg, targetQubit, (4*prob)/3.0);
     qasm_recordComment(qureg,
         "Here, a homogeneous depolarising error (X, Y, or Z) occured on "
-        "qubit %d with total probability %g", targetQubit, prob);
+        "qubit %d with total probability " REAL_QASM_FORMAT, targetQubit, prob);
 }
 
 void mixDamping(Qureg qureg, int targetQubit, qreal prob) {
@@ -1300,7 +1300,7 @@ void mixTwoQubitDepolarising(Qureg qureg, int qubit1, int qubit2, qreal prob) {
     densmatr_mixTwoQubitDepolarising(qureg, qubit1, qubit2, (16*prob)/15.0);
     qasm_recordComment(qureg,
         "Here, a homogeneous depolarising error occured on qubits %d and %d "
-        "with total probability %g", qubit1, qubit2, prob);
+        "with total probability " REAL_QASM_FORMAT, qubit1, qubit2, prob);
 }
 
 void mixPauli(Qureg qureg, int qubit, qreal probX, qreal probY, qreal probZ) {
@@ -1311,7 +1311,7 @@ void mixPauli(Qureg qureg, int qubit, qreal probX, qreal probY, qreal probZ) {
     densmatr_mixPauli(qureg, qubit, probX, probY, probZ);
     qasm_recordComment(qureg,
         "Here, X, Y and Z errors occured on qubit %d with probabilities "
-        "%g, %g and %g respectively", qubit, probX, probY, probZ);
+        REAL_QASM_FORMAT ", " REAL_QASM_FORMAT " and " REAL_QASM_FORMAT " respectively", qubit, probX, probY, probZ);
 }
 
 void mixKrausMap(Qureg qureg, int target, ComplexMatrix2 *ops, int numOps) {

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -1344,6 +1344,36 @@ void mixMultiQubitKrausMap(Qureg qureg, int* targets, int numTargets, ComplexMat
         "Here, an undisclosed %d-qubit Kraus map was applied to undisclosed qubits", numTargets);
 }
 
+void mixNonTPKrausMap(Qureg qureg, int target, ComplexMatrix2 *ops, int numOps) {
+    validateDensityMatrQureg(qureg, __func__);
+    validateTarget(qureg, target, __func__);
+    validateOneQubitKrausMapDimensions(qureg, ops, numOps, __func__);
+    
+    densmatr_mixKrausMap(qureg, target, ops, numOps);
+    qasm_recordComment(qureg, 
+        "Here, an undisclosed non-trace-preserving Kraus map was effected on qubit %d", target);
+}
+
+void mixNonTPTwoQubitKrausMap(Qureg qureg, int target1, int target2, ComplexMatrix4 *ops, int numOps) {
+    validateDensityMatrQureg(qureg, __func__);
+    validateMultiTargets(qureg, (int[]) {target1,target2}, 2, __func__);
+    validateTwoQubitKrausMapDimensions(qureg, ops, numOps, __func__);
+    
+    densmatr_mixTwoQubitKrausMap(qureg, target1, target2, ops, numOps);
+    qasm_recordComment(qureg, 
+        "Here, an undisclosed non-trace-preserving two-qubit Kraus map was effected on qubits %d and %d", target1, target2);
+}
+
+void mixNonTPMultiQubitKrausMap(Qureg qureg, int* targets, int numTargets, ComplexMatrixN* ops, int numOps) {
+    validateDensityMatrQureg(qureg, __func__);
+    validateMultiTargets(qureg, targets, numTargets, __func__);
+    validateMultiQubitKrausMapDimensions(qureg, numTargets, ops, numOps, __func__);
+    
+    densmatr_mixMultiQubitKrausMap(qureg, targets, numTargets, ops, numOps);
+    qasm_recordComment(qureg,
+        "Here, an undisclosed non-trace-preserving %d-qubit Kraus map was applied to undisclosed qubits", numTargets);
+}
+
 /*
  * other data structures 
  */

--- a/QuEST/src/QuEST_common.c
+++ b/QuEST/src/QuEST_common.c
@@ -225,11 +225,7 @@ void reportState(Qureg qureg){
     if (qureg.chunkId==0) fprintf(state, "real, imag\n");
 
     for(index=0; index<qureg.numAmpsPerChunk; index++){
-        # if QuEST_PREC==1 || QuEST_PREC==2
-        fprintf(state, "%.12f, %.12f\n", qureg.stateVec.real[index], qureg.stateVec.imag[index]);
-        # elif QuEST_PREC == 4
-        fprintf(state, "%.12Lf, %.12Lf\n", qureg.stateVec.real[index], qureg.stateVec.imag[index]);
-        #endif
+        fprintf(state, REAL_STRING_FORMAT ", " REAL_STRING_FORMAT "\n", qureg.stateVec.real[index], qureg.stateVec.imag[index]);
     }
     fclose(state);
 }
@@ -812,7 +808,7 @@ void applyExponentiatedPauliHamil(Qureg qureg, PauliHamil hamil, qreal fac, int 
         buff[b] = '\0';
         
         qasm_recordComment(qureg, 
-            "Here, a multiRotatePauli with angle %g and paulis %s was applied.",
+            "Here, a multiRotatePauli with angle " REAL_QASM_FORMAT " and paulis %s was applied.",
             angle, buff);
     }
 }

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -271,6 +271,10 @@ void statevec_applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* num
 
 void statevec_applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides, int conj);
 
+void statevec_copySubstateToGPU(Qureg qureg, long long int startInd, long long int numAmps);
+
+void statevec_copySubstateFromGPU(Qureg qureg, long long int startInd, long long int numAmps);
+
 
 /* 
  * operations which differentiate between state-vectors and density matrices internally 

--- a/QuEST/src/QuEST_qasm.c
+++ b/QuEST/src/QuEST_qasm.c
@@ -763,7 +763,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
                         (params[2+r] < 0)?
                             "(%c^2+" REAL_QASM_FORMAT ")" :
                             "(%c^2-" REAL_QASM_FORMAT ")",
-                        getPhaseFuncSymbol(numRegs,r), fabs(params[2+r]));
+                        getPhaseFuncSymbol(numRegs,r), absReal(params[2+r]));
                 else
                     len += snprintf(line+len, MAX_LINE_LEN-len, "%c^2", getPhaseFuncSymbol(numRegs,r));
                 len += snprintf(line+len, MAX_LINE_LEN-len, (r < numRegs - 1)? " + ":"))\n");
@@ -834,7 +834,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
                         (params[2+r/2] < 0)?
                             "(%c-%c+" REAL_QASM_FORMAT ")^2":
                             "(%c-%c-" REAL_QASM_FORMAT ")^2", 
-                        getPhaseFuncSymbol(numRegs,r), getPhaseFuncSymbol(numRegs,r+1), fabs(params[2+r/2]));
+                        getPhaseFuncSymbol(numRegs,r), getPhaseFuncSymbol(numRegs,r+1), absReal(params[2+r/2]));
                 else
                     len += snprintf(line+len, MAX_LINE_LEN-len, "(%c-%c)^2", 
                         getPhaseFuncSymbol(numRegs,r), getPhaseFuncSymbol(numRegs,r+1));

--- a/QuEST/src/QuEST_qasm.c
+++ b/QuEST/src/QuEST_qasm.c
@@ -16,6 +16,7 @@
 # include "QuEST.h"
 # include "QuEST_precision.h"
 # include "QuEST_internal.h"
+# include "QuEST_validation.h"
 # include "QuEST_qasm.h"
 
 # include <math.h>
@@ -52,25 +53,19 @@ static const char* qasmGateLabels[] = {
     [GATE_SQRT_SWAP] = "sqrtswap" // needs decomp into cNOTs and Rx(pi/2)?
 };
 
-// @TODO make a proper internal error thing
-void bufferOverflow(void) {
-    printf("!!!\nINTERNAL ERROR: QASM line buffer filled!\n!!!");
-    exit(1);
-}
-
 void qasm_setup(Qureg* qureg) {
     
     // populate and attach QASM logger
     QASMLogger *qasmLog = malloc(sizeof *qasmLog);
     qureg->qasmLog = qasmLog;
     if (qasmLog == NULL)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     qasmLog->isLogging = 0;
     qasmLog->bufferSize = BUF_INIT_SIZE;
     qasmLog->buffer = malloc(qasmLog->bufferSize * sizeof *(qasmLog->buffer));
     if (qasmLog->buffer == NULL)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     // add headers and quantum / classical register creation
     qasmLog->bufferFill = snprintf(
@@ -79,7 +74,7 @@ void qasm_setup(Qureg* qureg) {
         QUREG_LABEL, qureg->numQubitsRepresented,
         MESREG_LABEL, qureg->numQubitsRepresented);
     if (qasmLog->bufferFill >= qasmLog->bufferSize)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
 }
 
 void qasm_startRecording(Qureg qureg) {
@@ -101,7 +96,7 @@ void addStringToQASM(Qureg qureg, char line[], int lineLen) {
                 
         int newBufSize = BUF_GROW_FAC * bufSize;
         if (lineLen + bufFill > newBufSize)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         
         char* newBuffer = malloc(newBufSize * sizeof *newBuffer);
         sprintf(newBuffer, "%s", buf);
@@ -171,7 +166,7 @@ void addGateToQASM(Qureg qureg, TargetGate gate, int* controlQubits, int numCont
     
     // check whether we overflowed buffer
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
         
     addStringToQASM(qureg, line, len);
 }
@@ -420,7 +415,7 @@ void qasm_recordMeasurement(Qureg qureg, int measureQubit) {
         
     // check whether we overflowed buffer
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     addStringToQASM(qureg, line, len);
 }
@@ -435,7 +430,7 @@ void qasm_recordInitZero(Qureg qureg) {
     
     // check whether we overflowed buffer
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     
     addStringToQASM(qureg, line, len);
 }
@@ -457,7 +452,7 @@ void qasm_recordInitPlus(Qureg qureg) {
         buf, MAX_LINE_LEN, "%s %s;\n", 
         qasmGateLabels[GATE_HADAMARD], QUREG_LABEL);
     if (charsWritten >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, buf, charsWritten);
     
     // old code (before above QASM shortcut)
@@ -513,7 +508,7 @@ void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncod
     len += snprintf(line+len, MAX_LINE_LEN-len, "))\n");
 
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, line, len);
 
     char encBuf[MAX_LINE_LEN];
@@ -529,7 +524,7 @@ void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncod
         len += snprintf(line+len, MAX_LINE_LEN-len, (q < numQubits-1)? "%d, ":"%d}\n", qubits[q]);
 
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, line, len);
 
     if (numOverrides > 0) {
@@ -564,7 +559,7 @@ char getPhaseFuncSymbol(int numSymbs, int ind) {
         return abc[ind];
 
     // we should never reach here, since caller should handle when numSymbs > 24
-    bufferOverflow();
+    raiseQASMBufferOverflow(__func__);
     return 'x';
 }
 
@@ -592,7 +587,7 @@ void addMultiVarRegsToQASM(Qureg qureg, int* qubits, int* numQubitsPerReg, int n
             len += snprintf(line+len, MAX_LINE_LEN-len, (q < numQubitsPerReg[r]-1)? "%d, ":"%d}\n", qubits[qInd++]);
 
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 }
@@ -634,7 +629,7 @@ void addMultiVarOverridesToQASM(Qureg qureg, int numRegs, long long int* overrid
                 overridePhases[v]);
 
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 }
@@ -657,7 +652,7 @@ void addShiftValuesToQASM(Qureg qureg, enum phaseFunc funcName, int numRegs, qre
         len = 0;
         len += snprintf(line+len, MAX_LINE_LEN-len, "//     delta%d = " REAL_QASM_FORMAT "\n", k, params[2+k]);
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 
@@ -713,7 +708,7 @@ void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg
             len += snprintf(line+len, MAX_LINE_LEN-len, " ))\n");
 
         if (len >= MAX_LINE_LEN)
-            bufferOverflow();
+            raiseQASMBufferOverflow(__func__);
         addStringToQASM(qureg, line, len);
     }
 
@@ -849,7 +844,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
     }
 
     if (len >= MAX_LINE_LEN)
-        bufferOverflow();
+        raiseQASMBufferOverflow(__func__);
     addStringToQASM(qureg, line, len);
 
     addMultiVarRegsToQASM(qureg, qubits, numQubitsPerReg, numRegs, encoding);

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -116,7 +116,8 @@ typedef enum {
     E_QUREG_NOT_ALLOCATED_ON_GPU,
     E_DIAGONAL_OP_NOT_ALLOCATED,
     E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU,
-    E_NO_GPU
+    E_NO_GPU,
+    E_QASM_BUFFER_OVERFLOW
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -205,7 +206,8 @@ static const char* errorMessages[] = {
     [E_QUREG_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for Qureg on GPU. Possibly insufficient memory.",
     [E_DIAGONAL_OP_NOT_ALLOCATED] = "Could not allocate memory for DiagonalOp. Possibly insufficient memory.",
     [E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for DiagonalOp on GPU. Possibly insufficient memory.",
-    [E_NO_GPU] = "Trying to run GPU code with no GPU available."
+    [E_NO_GPU] = "Trying to run GPU code with no GPU available.",
+    [E_QASM_BUFFER_OVERFLOW] = "QASM line buffer filled."
 };
 
 void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
@@ -1043,6 +1045,11 @@ void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller) {
 void validateGPUExists(int GPUPresent, const char* caller) {
     QuESTAssert(GPUPresent, E_NO_GPU, caller);
 }
+
+void raiseQASMBufferOverflow(const char* caller) {
+    invalidQuESTInputError(errorMessages[E_QASM_BUFFER_OVERFLOW], caller);
+}
+
 
 #ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -113,7 +113,10 @@ typedef enum {
     E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC,
     E_NOT_ENOUGH_ADDRESSABLE_MEMORY,
     E_QUREG_NOT_ALLOCATED,
+    E_QUREG_NOT_ALLOCATED_ON_GPU,
     E_DIAGONAL_OP_NOT_ALLOCATED,
+    E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU,
+    E_NO_GPU
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -199,7 +202,10 @@ static const char* errorMessages[] = {
     [E_INVALID_NUM_REGS_DISTANCE_PHASE_FUNC] = "Phase functions DISTANCE, INVERSE_DISTANCE, SCALED_DISTANCE and SCALED_INVERSE_DISTANCE require a strictly even number of sub-registers.",
     [E_NOT_ENOUGH_ADDRESSABLE_MEMORY] = "Could not allocate memory. Requested more memory than system can address.",
     [E_QUREG_NOT_ALLOCATED] = "Could not allocate memory for Qureg. Possibly insufficient memory.",
+    [E_QUREG_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for Qureg on GPU. Possibly insufficient memory.",
     [E_DIAGONAL_OP_NOT_ALLOCATED] = "Could not allocate memory for DiagonalOp. Possibly insufficient memory.",
+    [E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU] = "Could not allocate memory for DiagonalOp on GPU. Possibly insufficient memory.",
+    [E_NO_GPU] = "Trying to run GPU code with no GPU available."
 };
 
 void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
@@ -1020,8 +1026,22 @@ void validateQuregAllocation(Qureg* qureg, const char* caller) {
     }
 }
 
+void validateQuregGPUAllocation(Qureg* qureg, const char* caller) {
+    QuESTAssert(qureg->deviceStateVec.real && qureg->deviceStateVec.imag, E_QUREG_NOT_ALLOCATED_ON_GPU, caller);
+}
+
 void validateDiagonalOpAllocation(DiagonalOp op, const char* caller) {
     QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED, caller);
+}
+
+void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller) {
+    QuESTAssert(op.real && op.imag, E_DIAGONAL_OP_NOT_ALLOCATED_ON_GPU, caller);
+}
+
+// This is really just a dummy shim, because the scope of GPUExists()
+// is limited to the QuEST_gpu.cu file.
+void validateGPUExists(int GPUPresent, const char* caller) {
+    QuESTAssert(GPUPresent, E_NO_GPU, caller);
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -122,9 +122,9 @@ static const char* errorMessages[] = {
     [E_INVALID_STATE_INDEX] = "Invalid state index. Must be >=0 and <2^numQubits.",
     [E_INVALID_AMP_INDEX] = "Invalid amplitude index. Must be >=0 and <2^numQubits.",
     [E_INVALID_ELEM_INDEX] = "Invalid element index. Must be >=0 and <2^numQubits.",
-    [E_INVALID_NUM_AMPS] = "Invalid number of amplitudes. Must be >=0 and <=2^numQubits.",
+    [E_INVALID_NUM_AMPS] = "Invalid number of amplitudes. Must be >=0 and <=2^numQubits (or for density matrices, <=2^(2 numQubits)).",
     [E_INVALID_NUM_ELEMS] = "Invalid number of elements. Must be >=0 and <=2^numQubits.",
-    [E_INVALID_OFFSET_NUM_AMPS_QUREG] = "More amplitudes given than exist in the statevector from the given starting index.",
+    [E_INVALID_OFFSET_NUM_AMPS_QUREG] = "More amplitudes given than exist in the state from the given starting index.",
     [E_INVALID_OFFSET_NUM_ELEMS_DIAG] = "More elements given than exist in the diagonal operator from the given starting index.",
     [E_TARGET_IS_CONTROL] = "Control qubit cannot equal target qubit.",
     [E_TARGET_IN_CONTROLS] = "Control qubits cannot include target qubit.",
@@ -387,6 +387,15 @@ void validateAmpIndex(Qureg qureg, long long int ampInd, const char* caller) {
 void validateNumAmps(Qureg qureg, long long int startInd, long long int numAmps, const char* caller) {
     validateAmpIndex(qureg, startInd, caller);
     QuESTAssert(numAmps >= 0 && numAmps <= qureg.numAmpsTotal, E_INVALID_NUM_AMPS, caller);
+    QuESTAssert(numAmps + startInd <= qureg.numAmpsTotal, E_INVALID_OFFSET_NUM_AMPS_QUREG, caller);
+}
+
+void validateNumDensityAmps(Qureg qureg, long long int startRow, long long int startCol, long long int numAmps, const char* caller) {
+    validateAmpIndex(qureg, startRow, caller);
+    validateAmpIndex(qureg, startCol, caller);
+    QuESTAssert(numAmps >= 0 && numAmps <= qureg.numAmpsTotal, E_INVALID_NUM_AMPS, caller);
+    
+    long long int startInd = startRow + startCol*(1 << qureg.numQubitsRepresented);
     QuESTAssert(numAmps + startInd <= qureg.numAmpsTotal, E_INVALID_OFFSET_NUM_AMPS_QUREG, caller);
 }
 

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -618,31 +618,35 @@ void validateNumPauliSumTerms(int numTerms, const char* caller) {
     QuESTAssert(numTerms > 0, E_INVALID_NUM_SUM_TERMS, caller);
 }
 
-void validateOneQubitKrausMap(Qureg qureg, ComplexMatrix2* ops, int numOps, const char* caller) {
+void validateOneQubitKrausMapDimensions(Qureg qureg, ComplexMatrix2* ops, int numOps, const char* caller) {
     int opNumQubits = 1;
     int superOpNumQubits = 2*opNumQubits;
     int maxNumOps = superOpNumQubits*superOpNumQubits;
     QuESTAssert(numOps > 0 && numOps <= maxNumOps, E_INVALID_NUM_ONE_QUBIT_KRAUS_OPS, caller);
     
     validateMultiQubitMatrixFitsInNode(qureg, superOpNumQubits, caller);
-    
-    int isPos = isCompletelyPositiveMap2(ops, numOps);
-    QuESTAssert(isPos, E_INVALID_KRAUS_OPS, caller);
 }
 
-void validateTwoQubitKrausMap(Qureg qureg, ComplexMatrix4* ops, int numOps, const char* caller) {
+void validateOneQubitKrausMap(Qureg qureg, ComplexMatrix2* ops, int numOps, const char* caller) {
+    validateOneQubitKrausMapDimensions(qureg, ops, numOps, caller);
+    QuESTAssert(isCompletelyPositiveMap2(ops, numOps), E_INVALID_KRAUS_OPS, caller);
+}
+
+void validateTwoQubitKrausMapDimensions(Qureg qureg, ComplexMatrix4* ops, int numOps, const char* caller) {
     int opNumQubits = 2;
     int superOpNumQubits = 2*opNumQubits;
     int maxNumOps = superOpNumQubits*superOpNumQubits;
     QuESTAssert(numOps > 0 && numOps <= maxNumOps, E_INVALID_NUM_TWO_QUBIT_KRAUS_OPS, caller);
     
     validateMultiQubitMatrixFitsInNode(qureg, superOpNumQubits, caller);
-
-    int isPos = isCompletelyPositiveMap4(ops, numOps);
-    QuESTAssert(isPos, E_INVALID_KRAUS_OPS, caller);
 }
 
-void validateMultiQubitKrausMap(Qureg qureg, int numTargs, ComplexMatrixN* ops, int numOps, const char* caller) {
+void validateTwoQubitKrausMap(Qureg qureg, ComplexMatrix4* ops, int numOps, const char* caller) {
+    validateTwoQubitKrausMapDimensions(qureg, ops, numOps, caller);
+    QuESTAssert(isCompletelyPositiveMap4(ops, numOps), E_INVALID_KRAUS_OPS, caller);
+}
+
+void validateMultiQubitKrausMapDimensions(Qureg qureg, int numTargs, ComplexMatrixN* ops, int numOps, const char* caller) {
     int opNumQubits = numTargs;
     int superOpNumQubits = 2*opNumQubits;
     int maxNumOps = superOpNumQubits*superOpNumQubits;
@@ -654,9 +658,11 @@ void validateMultiQubitKrausMap(Qureg qureg, int numTargs, ComplexMatrixN* ops, 
     }
     
     validateMultiQubitMatrixFitsInNode(qureg, superOpNumQubits, caller);
-    
-    int isPos = isCompletelyPositiveMapN(ops, numOps);
-    QuESTAssert(isPos, E_INVALID_KRAUS_OPS, caller);
+}
+
+void validateMultiQubitKrausMap(Qureg qureg, int numTargs, ComplexMatrixN* ops, int numOps, const char* caller) {
+    validateMultiQubitKrausMapDimensions(qureg, numTargs, ops, numOps, caller);
+    QuESTAssert(isCompletelyPositiveMapN(ops, numOps), E_INVALID_KRAUS_OPS, caller);
 }
 
 void validateHamilParams(int numQubits, int numTerms, const char* caller) {

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -209,8 +209,10 @@ void default_invalidQuESTInputError(const char* errMsg, const char* errFunc) {
 void invalidQuESTInputError(const char* errMsg, const char* errFunc) {
     default_invalidQuESTInputError(errMsg, errFunc);
 }
-#else
+#elif defined(_WIN64)
 #pragma comment(linker, "/alternatename:invalidQuESTInputError=default_invalidQuESTInputError")   
+#else
+#pragma comment(linker, "/alternatename:_invalidQuESTInputError=_default_invalidQuESTInputError")
 #endif
 
 void QuESTAssert(int isValid, ErrorCode code, const char* func){

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -162,7 +162,15 @@ void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* call
 
 void validateQuregAllocation(Qureg* qureg, const char* caller);
 
+void validateQuregGPUAllocation(Qureg* qureg, const char* caller);
+
 void validateDiagonalOpAllocation(DiagonalOp op, const char* caller);
+
+void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller);
+
+// This is really just a dummy shim, because the scope of GPUExists()
+// is limited to the QuEST_gpu.cu file.
+void validateGPUExists(int GPUPresent, const char* caller);
 
 # ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -172,6 +172,8 @@ void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller);
 // is limited to the QuEST_gpu.cu file.
 void validateGPUExists(int GPUPresent, const char* caller);
 
+void raiseQASMBufferOverflow(const char* caller);
+
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -78,6 +78,8 @@ void validateSecondQuregStateVec(Qureg qureg2, const char *caller);
 
 void validateNumAmps(Qureg qureg, long long int startInd, long long int numAmps, const char* caller);
 
+void validateNumDensityAmps(Qureg qureg, long long int startRow, long long int startCol, long long int numAmps, const char* caller);
+
 void validateFileOpened(int opened, char* fn, const char* caller);
 
 void validateProb(qreal prob, const char* caller);

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -132,7 +132,7 @@ void validateHamilFilePauliCode(enum pauliOpType code, PauliHamil h, FILE* file,
 
 void validateTrotterParams(int order, int reps, const char* caller);
 
-void validateDiagOpInit(DiagonalOp, const char* caller);
+void validateDiagOpInit(DiagonalOp op, const char* caller);
 
 void validateDiagonalOp(Qureg qureg, DiagonalOp op, const char* caller);
 
@@ -160,13 +160,13 @@ void validateMultiRegBitEncoding(int* numQubitsPerReg, int numRegs, enum bitEnco
 
 void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* caller);
 
-void validateQuregAllocation(Qureg* qureg, const char* caller);
+void validateQuregAllocation(Qureg* qureg, QuESTEnv env, const char* caller);
 
-void validateQuregGPUAllocation(Qureg* qureg, const char* caller);
+void validateQuregGPUAllocation(Qureg* qureg, QuESTEnv env, const char* caller);
 
-void validateDiagonalOpAllocation(DiagonalOp op, const char* caller);
+void validateDiagonalOpAllocation(DiagonalOp* op, QuESTEnv env, const char* caller);
 
-void validateDiagonalOpGPUAllocation(DiagonalOp op, const char* caller);
+void validateDiagonalOpGPUAllocation(DiagonalOp* op, QuESTEnv env, const char* caller);
 
 // This is really just a dummy shim, because the scope of GPUExists()
 // is limited to the QuEST_gpu.cu file.

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -158,6 +158,12 @@ void validateBitEncoding(int numQubits, enum bitEncoding encoding, const char* c
 
 void validateMultiRegBitEncoding(int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, const char* caller);
 
+void validateMemoryAllocationSize(long long int numAmpsPerRank, const char* caller);
+
+void validateQuregAllocation(Qureg* qureg, const char* caller);
+
+void validateDiagonalOpAllocation(DiagonalOp op, const char* caller);
+
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -108,6 +108,12 @@ void validateTwoQubitKrausMap(Qureg qureg, ComplexMatrix4* ops, int numOps, cons
 
 void validateMultiQubitKrausMap(Qureg qureg, int numTargs, ComplexMatrixN* ops, int numOps, const char* caller);
 
+void validateOneQubitKrausMapDimensions(Qureg qureg, ComplexMatrix2* ops, int numOps, const char* caller);
+
+void validateTwoQubitKrausMapDimensions(Qureg qureg, ComplexMatrix4* ops, int numOps, const char* caller);
+
+void validateMultiQubitKrausMapDimensions(Qureg qureg, int numTargs, ComplexMatrixN* ops, int numOps, const char* caller);
+
 void validateOneQubitDampingProb(qreal prob, const char* caller);
 
 void validateHamilParams(int numQubits, int numTerms, const char* caller);

--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@
     [![codecov](https://codecov.io/gh/QuEST-Kit/QuEST/branch/develop/graph/badge.svg)](https://codecov.io/gh/QuEST-Kit/QuEST)
 -->
 
+
+
+<!-- action-badges has broken and is incorrectly showing build failure. 
+     temporarily forcing badge to show the correct pass while replacement is sought 
+     (that isn't Github's hideous default CI badge)
+     [![unit tests](https://action-badges.now.sh/QuEST-Kit/QuEST)](https://github.com/QuEST-Kit/QuEST/actions) 
+--> 
 [![GitHub release](https://img.shields.io/github/release/QuEST-Kit/QuEST)](https://GitHub.com/QuEST-Kit/QuEST/releases/) 
 [![Doc](https://img.shields.io/badge/doc-Github.io-orange.svg)](https://quest-kit.github.io/QuEST/modules.html)
-[![unit tests](https://action-badges.now.sh/QuEST-Kit/QuEST)](https://github.com/QuEST-Kit/QuEST/actions)
+[![unit tests](https://img.shields.io/badge/build-passing-green.svg)](https://github.com/QuEST-Kit/QuEST/actions)  <!-- forgive my sins (see above) -->
 [![MIT license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENCE.txt)
 
 

--- a/examples/bernstein_vazirani_circuit.c
+++ b/examples/bernstein_vazirani_circuit.c
@@ -4,72 +4,88 @@
  * @author Tyson Jones
  */
 
-# include <stdio.h>
-# include <math.h>
+ # include <stdio.h>
+ # include <math.h>
+ # include <time.h>
+ # include <stdlib.h>
 
-# include "QuEST.h" 
-
-
-int main (int narg, char** varg) {
-
-
-    /* 	
-     * PREPARE QuEST
-     */
-
-    // model parameters
-    int numQubits = 9;
-    int secretNum = pow(2,4) + 1;
-
-    // prepare QuEST
-    QuESTEnv env = createQuESTEnv();
-
-    // create qureg; let zeroth qubit be ancilla
-    Qureg qureg = createQureg(numQubits, env);
-    initZeroState(qureg);
+ # include "QuEST.h" 
 
 
-    /* 	
-     * APPLY ALGORITHM
-     */
 
-    // NOT the ancilla
-    pauliX(qureg, 0);
+ void applyOracle(Qureg qureg, int numQubits, int secret) {
 
-    // CNOT secretNum bits with ancilla
-    int bits = secretNum;
-    int bit;
-    for (int qb=1; qb < numQubits; qb++) {
-        bit = bits % 2;
-        bits /= 2;
-        if (bit)
-            controlledNot(qureg, 0, qb);
-    }
+     int bits = secret;
 
+     for (int q=1; q<numQubits; q++) {
 
-    /* 	
-     * VERIFY FINAL STATE
-     */
-
-    // calculate prob of solution state
-    double successProb = 1.0;
-    bits = secretNum;
-    for (int qb=1; qb < numQubits; qb++) {
-        bit = bits % 2;
-        bits /= 2;
-        successProb *= calcProbOfOutcome(qureg, qb, bit);
-    }
-
-    printf("solution reached with probability ");
-    printf("%f", successProb);
-    printf("\n");
+         // extract the (q-1)-th bit of secret
+         int bit = bits % 2;
+         bits /= 2;
+         
+         // NOT the ancilla, controlling on the q-th qubit
+         if (bit)
+             controlledNot(qureg, q, 0);
+     }
+ }
 
 
-    /*
-     * FREE MEMORY
-     */
 
-    destroyQureg(qureg, env); 
-    destroyQuESTEnv(env);
-    return 0;
-}
+ void measureResult(Qureg qureg, int secret) {
+
+     // |ind> = |s>|1>
+     int ind = 2*secret + 1;
+
+     qreal prob = getProbAmp(qureg, ind);
+
+     printf("success probability: %g \n", prob);
+ }
+
+
+
+ void applyBernsteinVazirani(Qureg qureg, int numQubits, int secret) {
+
+     // start in |0>
+     initZeroState(qureg);
+
+     // NOT the ancilla
+     pauliX(qureg, 0);
+
+     // H all qubits, including the ancilla
+     for (int q=0; q<numQubits; q++)
+         hadamard(qureg, q);
+
+     applyOracle(qureg, numQubits, secret);
+
+     for (int q=0; q<numQubits; q++)
+         hadamard(qureg, q);
+
+     // infer the output basis state
+     measureResult(qureg, secret);
+ }
+
+
+
+ int main() {
+     
+     // prepare the hardware-agnostic QuEST environment
+     QuESTEnv env = createQuESTEnv();
+
+     // choose the register size
+     int numQubits = 15;
+
+     // randomly choose the secret parameter
+     srand(time(NULL));
+     int secret = rand() % (int) pow(2, numQubits - 1);
+
+     // prepare our register in the |0> state
+     Qureg qureg = createQureg(numQubits, env);
+
+     // search for s using BV's algorithm
+     applyBernsteinVazirani(qureg, numQubits, secret);
+
+     // tidy up
+     destroyQureg(qureg, env);
+     destroyQuESTEnv(env);
+     return 0;
+ }

--- a/examples/bernstein_vazirani_circuit.c
+++ b/examples/bernstein_vazirani_circuit.c
@@ -38,7 +38,7 @@
 
      qreal prob = getProbAmp(qureg, ind);
 
-     printf("success probability: %g \n", prob);
+     printf("success probability: " REAL_QASM_FORMAT " \n", prob);
  }
 
 

--- a/examples/grovers_search.c
+++ b/examples/grovers_search.c
@@ -108,7 +108,7 @@ int main() {
         applyDiffuser(qureg, numQubits);
         
         // monitor the probability of the solution state
-        printf("prob of solution |%d> = %g\n", 
+        printf("prob of solution |%d> = " REAL_STRING_FORMAT "\n",
             solElem, getProbAmp(qureg, solElem));
     }
     

--- a/examples/tutorial_example.c
+++ b/examples/tutorial_example.c
@@ -91,16 +91,16 @@ int main (int narg, char *varg[]) {
 
     qreal prob;
     prob = getProbAmp(qubits, 7);
-    printf("Probability amplitude of |111>: %g\n", prob);
+    printf("Probability amplitude of |111>: " REAL_STRING_FORMAT "\n", prob);
 
     prob = calcProbOfOutcome(qubits, 2, 1);
-    printf("Probability of qubit 2 being in state 1: %g\n", prob);
+    printf("Probability of qubit 2 being in state 1: " REAL_STRING_FORMAT "\n", prob);
 
     int outcome = measure(qubits, 0);
     printf("Qubit 0 was measured in state %d\n", outcome);
 
     outcome = measureWithStats(qubits, 2, &prob);
-    printf("Qubit 2 collapsed to %d with probability %g\n", outcome, prob);
+    printf("Qubit 2 collapsed to %d with probability " REAL_STRING_FORMAT "\n", outcome, prob);
 
 
 


### PR DESCRIPTION
# Overview 

This release adds some quality-of-life functions, mostly to the benefit of larger software stacks which integrate QuEST.  It also includes some bug patches and internal software architectural clean-ups, primarily by @rrmeister. 


# New features
- `setDensityAmps()` allowing direct modification of the amplitudes of a density matrix.
- `copySubstateToGPU()` allowing *partial* overwriting of a statevector in GPU memory
- `copySubstateFromGPU()` allowing *partial* loading of a GPU statevector into accessible memory
- `mixNonTPKrausMap()` to simulate Kraus maps which are not necessarily trace-preserving

# Other changes
-  Updated the Bernstein-Vazirani demo to simulate more analogously to the experimental method
- Updated demo codes to use precision-agnostic string formatters
- Improved CMake build (f8747ca10a966d9c3ba7bc73824e48c3b4159f2b)
- Improved the internal validation architecture

# Bug fixes
- patched rare distributed bug in `calcTotalProb()` of density matrices (#326)
- patched rare GPU build bug in `applyPhaseFunc()`
- patched rare memory leak during failed validation of `Qureg` and `DiagonalOp` validation
- patched GPU build flags (512966a5851b85cbbf70f2246785afc3efb32e30)
- patched `invalidQuESTInputError()` build problem on Windows (#314)
- patched build warnings related to precision of internal non-simulation functions (fc25c34abc53bf8842ff39356ed94dd1012b41e3)