### PR TITLE
Catch update: MINSIGSTKSZ not longer const for glibc>2.33

### DIFF
--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -10614,7 +10614,16 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+
+    #if defined(_SC_SIGSTKSZ_SOURCE) || defined(_GNU_SOURCE)
+    // on glibc > 2.33 this is no longer constant, see
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=85e84fe53699fe9e392edffa993612ce08b2954a;hb=HEAD
+        static constexpr std::size_t sigStackSize = 32768;
+    #else
+        static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    #endif
+
+
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },


### PR DESCRIPTION
Chatch needs update.  Test suite won't compile because of issue related to: https://github.com/catchorg/Catch2/issues/2421

A quick fix taken from:
https://github.com/catchorg/Catch2/pull/2480

This issue has been fixed in Catch v2.13.5:
https://github.com/catchorg/Catch2/blob/devel/docs/release-notes.md#2135