### PR TITLE
Support for AMD GPUs 

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -33,6 +33,9 @@ option(GPUACCELERATED "Whether to program will run on GPU. Set to 1 to enable" 0
 
 set(GPU_COMPUTE_CAPABILITY 30 CACHE STRING "GPU hardware dependent, lookup at https://developer.nvidia.com/cuda-gpus. Write without fullstop")
 
+option(USE_HIP "Whether to use HIP for GPU code compilation for AMD GPUs. Set to 1 to enable" 0)
+
+set(GPU_ARCH gfx90 CACHE STRING "GPU hardware dependent, used for AMD GPUs when USE_HIP=1. Lookup at https://llvm.org/docs/AMDGPUUsage.html#amdgpu-processor-table. Write without fullstop")
 
 
 # *****************************************************************************
@@ -44,6 +47,9 @@ message(STATUS "Precision is ${PRECISION}")
 message(STATUS "GPU acceleration is ${GPUACCELERATED}")
 message(STATUS "OMP acceleration is ${MULTITHREADED}")
 message(STATUS "MPI distribution is ${DISTRIBUTED}")
+if (${GPUACCELERATED})
+  message(STATUS "HIP compilation is ${USE_HIP}")
+endif()
 
 
 # -----------------------------------------------------------------------------
@@ -111,7 +117,30 @@ if (DISTRIBUTED)
 endif()
 
 if (GPUACCELERATED)
+  if (USE_HIP)
+
+  if(NOT DEFINED HIP_PATH)
+    if(NOT DEFINED ENV{HIP_PATH})
+      message(WARNING "WARNING: HIP_PATH is not defiend. Using default HIP_PATH=/opt/rocm/hip    " ${HIP_VERSION})
+      set(HIP_PATH "/opt/rocm/hip" CACHE PATH "Path to which HIP has been installed")
+    else()
+      set(HIP_PATH $ENV{HIP_PATH}	CACHE PATH "Path to which HIP has been installed")
+    endif()
+  endif()
+
+  if(EXISTS "${HIP_PATH}")
+    set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
+    find_package(HIP REQUIRED)
+    message(STATUS "Found HIP: " ${HIP_VERSION})
+    message(STATUS "HIP PATH: " ${HIP_PATH})
+  endif()
+    
+  ADD_DEFINITIONS( -DUSE_HIP )
+  ADD_DEFINITIONS( -D__HIP_PLATFORM_AMD__ )
+
+  else()
     find_package(CUDA REQUIRED)
+  endif()  
 endif()
 
 
@@ -147,6 +176,26 @@ endif ()
 # ----- CUDA FLAGS ------------------------------------------------------------
 
 if (GPUACCELERATED)
+  if (USE_HIP)
+    if( NOT DEFINED GPU_ARCH AND DEFINED GPU_COMPUTE_CAPABILITY )
+      set ( GPU_ARCH ${GPU_COMPUTE_CAPABILITY})
+    endif()
+
+    set(HIP_HIPCC_FLAGS "${HIP_HIPCC_FLAGS} -fPIC  --offload-arch=${GPU_ARCH}" )
+    if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+      set (HIP_HIPCC_FLAGS "${HIP_HIPCC_FLAGS} \
+          -O2"
+      )
+    elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+      set (HIP_HIPCC_FLAGS "${HIP_HIPCC_FLAGS} \
+          -G -g -lineinfo"
+      )
+    else()
+      set (HIP_HIPCC_FLAGS "${HIP_HIPCC_FLAGS} \
+          -O2"
+      )
+    endif()
+  else()
     set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \
         -arch=compute_${GPU_COMPUTE_CAPABILITY} -code=sm_${GPU_COMPUTE_CAPABILITY}"
     )
@@ -169,6 +218,7 @@ if (GPUACCELERATED)
             -O2"
         )
     endif()
+  endif()  
 endif()
 
 
@@ -286,6 +336,7 @@ if (VERBOSE_CMAKE)
     message("   C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
     message("   C compilation flags: ${CMAKE_C_FLAGS}")
     message("   CUDA compilation flags: ${CUDA_NVCC_FLAGS}")
+    message("   HIP compilation flags: ${HIP_HIPCC_FLAGS}")
     message("   C++ compilation flags: ${CMAKE_CXX_FLAGS}")
 
     message("-- Build type: ${CMAKE_BUILD_TYPE}")
@@ -314,9 +365,15 @@ endif ()
 
 
 if (GPUACCELERATED)
+  if (USE_HIP)
+    hip_add_library(QuEST
+        ${QuEST_SRC} 
+    )
+  else()
     cuda_add_library(QuEST
         ${QuEST_SRC}
     )
+  endif()  
 else ()
     add_library(QuEST
         ${QuEST_SRC}
@@ -353,9 +410,11 @@ endif ()
 target_link_libraries(QuEST PUBLIC ${MPI_C_LIBRARIES})
 
 # ----- GPU -------------------------------------------------------------------
-
-target_link_libraries(QuEST ${CUDA_LIBRARIES})
-
+if (USE_HIP)
+  target_link_libraries(QuEST PUBLIC  ${HIP_PATH}/lib/libamdhip64.so )
+else()
+  target_link_libraries(QuEST ${CUDA_LIBRARIES})
+endif()
 
 # ----- Coverage testing with GCC or Clang ------------------------------------
 option(QUEST_ENABLE_COVERAGE "Enable coverage reporting for GCC or Clang" FALSE)

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -17,6 +17,11 @@
 # include <stdio.h>
 # include <math.h>
 
+#ifdef USE_HIP
+// Translate CUDA calls into HIP calls 
+#include "cuda_to_hip.h"
+#endif
+
 # define REDUCE_SHARED_SIZE 512
 # define DEBUG 0
 

--- a/QuEST/src/GPU/cuda_to_hip.h
+++ b/QuEST/src/GPU/cuda_to_hip.h
@@ -1,0 +1,69 @@
+#ifndef CUDA_TO_HIP_H
+#define CUDA_TO_HIP_H
+
+#include <hip/hip_runtime.h>
+
+// Set of macros pointing CUDA functions to their analogous HIP function.
+
+#define WARPSIZE 64
+static constexpr int maxWarpsPerBlock = 1024/WARPSIZE;
+
+#define CUFFT_D2Z HIPFFT_D2Z
+#define CUFFT_FORWARD HIPFFT_FORWARD
+#define CUFFT_INVERSE HIPFFT_BACKWARD
+#define CUFFT_Z2D HIPFFT_Z2D
+#define CUFFT_Z2Z HIPFFT_Z2Z
+
+#define cudaDeviceSynchronize hipDeviceSynchronize
+#define cudaError hipError_t
+#define cudaError_t hipError_t
+#define cudaErrorInsufficientDriver hipErrorInsufficientDriver
+#define cudaErrorNoDevice hipErrorNoDevice
+#define cudaEvent_t hipEvent_t
+#define cudaEventCreate hipEventCreate
+#define cudaEventElapsedTime hipEventElapsedTime
+#define cudaEventRecord hipEventRecord
+#define cudaEventSynchronize hipEventSynchronize
+#define cudaFree hipFree
+#define cudaFreeHost hipHostFree
+#define cudaGetDevice hipGetDevice
+#define cudaGetDeviceCount hipGetDeviceCount
+#define cudaGetErrorString hipGetErrorString
+#define cudaGetLastError hipGetLastError
+#define cudaHostAlloc hipHostMalloc
+#define cudaHostAllocDefault hipHostMallocDefault
+#define cudaMalloc hipMalloc
+#define cudaMemcpy hipMemcpy
+#define cudaMemcpyAsync hipMemcpyAsync
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemGetInfo hipMemGetInfo
+#define cudaMemset hipMemset
+#define cudaReadModeElementType hipReadModeElementType
+#define cudaSetDevice hipSetDevice
+#define cudaSuccess hipSuccess
+#define cudaDeviceProp hipDeviceProp_t
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#define cudaThreadSynchronize hipDeviceSynchronize
+
+
+#define cufftDestroy hipfftDestroy
+#define cufftDoubleComplex hipfftDoubleComplex
+#define cufftDoubleReal hipfftDoubleReal
+#define cufftExecD2Z hipfftExecD2Z
+#define cufftExecZ2D hipfftExecZ2D
+#define cufftExecZ2Z hipfftExecZ2Z
+#define cufftHandle hipfftHandle
+#define cufftPlan3d hipfftPlan3d
+#define cufftPlanMany hipfftPlanMany
+
+static void __attribute__((unused)) check(const hipError_t err, const char *const file, const int line)
+{
+  if (err == hipSuccess) return;
+  fprintf(stderr,"HIP ERROR AT LINE %d OF FILE '%s': %s %s\n",line,file,hipGetErrorName(err),hipGetErrorString(err));
+  fflush(stderr);
+  exit(err);
+}
+
+#endif //CUDA_TO_HIP_H

--- a/examples/README.md
+++ b/examples/README.md
@@ -244,7 +244,7 @@ If your project contains multiple source files, separate them with semi-colons. 
   ```console
    -DGPUACCELERATED=1 -DGPU_COMPUTE_CAPABILITY=[CC] ..
   ```
-  were `[CC]` is the compute cabability of your GPU, written without a decimal point. This can can be looked up at the [NVIDIA website](https://developer.nvidia.com/cuda-gpus).
+  where `[CC]` is the compute cabability of your GPU, written without a decimal point. This can can be looked up at the [NVIDIA website](https://developer.nvidia.com/cuda-gpus).
   > Note that CUDA is not compatible with all compilers. To force `cmake` to use a 
   > compatible compiler, override `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER`.  
   > For example, to compile for the [Quadro P6000](https://www.pny.com/nvidia-quadro-p6000)

--- a/examples/README.md
+++ b/examples/README.md
@@ -254,6 +254,13 @@ If your project contains multiple source files, separate them with semi-colons. 
   >          -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
   > ```
 
+  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see: [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html)
+  To compile for AMD GPUs, use
+    ```console
+    -DGPUACCELERATED=1 -DUSE_HIP=1 -DGPU_ARCH=[ARCH] ..
+    ```
+  where `[ARCH]` is the architecture of your GPU, for example `gfx90a`. A table for AMD GPU architectures can be looked up [HERE](https://llvm.org/docs/AMDGPUUsage.html#amdgpu-processor-table) 
+
 - You can additionally customise the floating point precision used by QuEST's `qreal` type, via
   ```console
    -DPRECISION=1

--- a/examples/README.md
+++ b/examples/README.md
@@ -254,11 +254,11 @@ If your project contains multiple source files, separate them with semi-colons. 
   >          -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
   > ```
 
-  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see: [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html). To compile for AMD GPUs, use
+  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html). To compile for AMD GPUs, use
     ```console
     -DGPUACCELERATED=1 -DUSE_HIP=1 -DGPU_ARCH=[ARCH] ..
     ```
-  where `[ARCH]` is the architecture of your GPU, for example `gfx90a`. A table for AMD GPU architectures can be looked up [HERE](https://llvm.org/docs/AMDGPUUsage.html#amdgpu-processor-table) 
+  where `[ARCH]` is the architecture of your GPU, for example `gfx90a`. A table for AMD GPU architectures can be looked up [here](https://llvm.org/docs/AMDGPUUsage.html#amdgpu-processor-table) 
 
 - You can additionally customise the floating point precision used by QuEST's `qreal` type, via
   ```console

--- a/examples/README.md
+++ b/examples/README.md
@@ -258,7 +258,7 @@ If your project contains multiple source files, separate them with semi-colons. 
     ```console
     -DGPUACCELERATED=1 -DUSE_HIP=1 -DGPU_ARCH=[ARCH] ..
     ```
-  where `[ARCH]` is the architecture of your GPU, for example `gfx90a`. A table for AMD GPU architectures can be looked up [here](https://llvm.org/docs/AMDGPUUsage.html#amdgpu-processor-table) 
+  where `[ARCH]` is the architecture of your GPU, for example `gfx90a`. A table for AMD GPU architectures can be looked up [here](https://llvm.org/docs/AMDGPUUsage.html#amdgpu-processor-table). 
 
 - You can additionally customise the floating point precision used by QuEST's `qreal` type, via
   ```console

--- a/examples/README.md
+++ b/examples/README.md
@@ -254,7 +254,8 @@ If your project contains multiple source files, separate them with semi-colons. 
   >          -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
   > ```
 
-  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see: [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html)
+  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see: [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html).
+  
   To compile for AMD GPUs, use
     ```console
     -DGPUACCELERATED=1 -DUSE_HIP=1 -DGPU_ARCH=[ARCH] ..

--- a/examples/README.md
+++ b/examples/README.md
@@ -254,9 +254,7 @@ If your project contains multiple source files, separate them with semi-colons. 
   >          -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
   > ```
 
-  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see: [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html).
-  
-  To compile for AMD GPUs, use
+  QuEST can also run on AMD GPUs using HIP. For the HIP documentation see: [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.3/page/Introduction_to_HIP_Programming_Guide.html). To compile for AMD GPUs, use
     ```console
     -DGPUACCELERATED=1 -DUSE_HIP=1 -DGPU_ARCH=[ARCH] ..
     ```


### PR DESCRIPTION
This pull request includes lightweight modification to support the use of HIP to run on AM GPUs when GPUACCELERATED=1.

I added brief instructions on how to compile with HIP in the "Compile for GPUs" section of the tutorial.

After my additions, all the tests from the unit testing passed when running on an AMD GPU.

I hope this is useful.