### PR TITLE
added unit-test init-state check

### DIFF
--- a/tests/test_decoherence.cpp
+++ b/tests/test_decoherence.cpp
@@ -9,7 +9,8 @@
 #define PREPARE_TEST(qureg, ref) \
     Qureg qureg = createDensityQureg(NUM_QUBITS, QUEST_ENV); \
     initDebugState(qureg); \
-    QMatrix ref = toQMatrix(qureg);
+    QMatrix ref = toQMatrix(qureg); \
+    assertQuregAndRefInDebugState(qureg, ref);
 
 /* allows concise use of Contains in catch's REQUIRE_THROWS_WITH */
 using Catch::Matchers::Contains;

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -13,7 +13,9 @@
     initDebugState(quregVec); \
     initDebugState(quregMatr); \
     QVector refVec = toQVector(quregVec); \
-    QMatrix refMatr = toQMatrix(quregMatr);
+    QMatrix refMatr = toQMatrix(quregMatr); \
+    assertQuregAndRefInDebugState(quregVec, refVec); \
+    assertQuregAndRefInDebugState(quregMatr, refMatr);
 
 /** Destroys the data structures made by PREPARE_TEST */
 #define CLEANUP_TEST(quregVec, quregMatr) \

--- a/tests/test_unitaries.cpp
+++ b/tests/test_unitaries.cpp
@@ -27,7 +27,9 @@
     initDebugState(quregVec); \
     initDebugState(quregMatr); \
     QVector refVec = toQVector(quregVec); \
-    QMatrix refMatr = toQMatrix(quregMatr);
+    QMatrix refMatr = toQMatrix(quregMatr); \
+    assertQuregAndRefInDebugState(quregVec, refVec); \
+    assertQuregAndRefInDebugState(quregMatr, refMatr);
 
 /** Destroys the data structures made by PREPARE_TEST */
 #define CLEANUP_TEST(quregVec, quregMatr) \

--- a/tests/utilities.cpp
+++ b/tests/utilities.cpp
@@ -140,6 +140,38 @@ QVector operator * (const QMatrix& m, const QVector& v) {
     return prod;
 }
 
+void assertQuregAndRefInDebugState(Qureg qureg, QVector ref) {
+    DEMAND( qureg.isDensityMatrix == 0 );
+    DEMAND( qureg.numAmpsTotal == (long long int) ref.size() );
+
+    // assert ref is in the debug state (else initDebugState failed)
+    for (size_t i=0; i<ref.size(); i++) {
+        qcomp val = qcomp(.2*i, .2*i+.1);
+        DEMAND( abs(ref[i] - val) < REAL_EPS );
+    }
+
+    // check qureg and ref agree
+    DEMAND( areEqual(qureg, ref) );
+}
+
+void assertQuregAndRefInDebugState(Qureg qureg, QMatrix ref) {
+    DEMAND( qureg.isDensityMatrix == 1 );
+    DEMAND( (1LL << qureg.numQubitsRepresented) == (long long int) ref.size() );
+
+    // assert ref is in the (column-wise) debug state (else initDebugState failed)
+    size_t i = 0;
+    for (size_t c=0; c<ref.size(); c++) {
+        for (size_t r=0; r<ref.size(); r++) {
+            qcomp val = qcomp(.2*i, .2*i+.1);
+            DEMAND( abs(ref[r][c] - val) < REAL_EPS );
+            i++;
+        }
+    }
+
+    // check qureg and ref agree
+    DEMAND( areEqual(qureg, ref) );
+}
+
 QVector getKroneckerProduct(QVector b, QVector a) {
 
     QVector prod = QVector(a.size() * b.size());

--- a/tests/utilities.hpp
+++ b/tests/utilities.hpp
@@ -76,6 +76,26 @@ typedef std::vector<std::vector<qcomp>> QMatrix;
  */
 typedef std::vector<qcomp> QVector;
 
+/** Asserts the given statevector qureg and reference agree, and are properly initialised in the debug state.
+ * Assertion uses the DEMAND() macro, calling Catch2's FAIL() if unsatisfied, so does not contribute
+ * toward unit test statistics. This should be called within every PREPARE_TEST macro, to ensure that
+ * the test states themselves are initially correct, and do not accidentally agree by (e.g.) being all-zero.
+ * 
+ * @ingroup testutilities
+ * @author Tyson Jones
+ */
+void assertQuregAndRefInDebugState(Qureg qureg, QVector ref);
+
+/** Asserts the given density qureg and reference agree, and are properly initialised in the debug state.
+ * Assertion uses the DEMAND() macro, calling Catch2's FAIL() if unsatisfied, so does not contribute
+ * toward unit test statistics. This should be called within every PREPARE_TEST macro, to ensure that
+ * the test states themselves are initially correct, and do not accidentally agree by (e.g.) being all-zero.
+ * 
+ * @ingroup testutilities
+ * @author Tyson Jones
+ */
+void assertQuregAndRefInDebugState(Qureg qureg, QMatrix ref);
+
 /* (Excluded from Doxygen doc)
  *
  * Define QVector and QMatrix operator overloads.


### PR DESCRIPTION
Before each unit test, the initial state of the registers (assumed to be in the result of initDebugState) is now explicitly checked.

This prevents passing tests when initDebugState() itself is failing, and (for example) yielding an all-zero state which sneakily satisfies some unit tests.

This will likely noticeably increase the total unit-tests runtime, but will gaurantee tests visibly, instantly fail when (for example) the GPU configuration is wrong and produces all-zero states