### PR TITLE
improved getRandomUnitary in testing

### DIFF
--- a/QuEST/src/GPU/QuEST_cuQuantum.cu
+++ b/QuEST/src/GPU/QuEST_cuQuantum.cu
@@ -990,7 +990,7 @@ void statevec_applySubDiagonalOp(Qureg qureg, int* targs, SubDiagonalOp op, int 
     // (as separate arrays op.real and op.imag) into cuAmp*
     cuAmp* elems = qureg.cuStateVec;
     for (long long int i=0; i<op.numElems; i++)
-        elems[i] = TO_CU_AMP(op.real[i], op.imag[i]);
+        elems[i] = TO_CU_AMP(op.real[i], ((conj)? -1 : 1) * op.imag[i]);
 
     std::vector<int> t(targs, targs + op.numQubits); 
     custatevec_applyDiagonal(qureg, {}, t, elems);

--- a/tests/test_decoherence.cpp
+++ b/tests/test_decoherence.cpp
@@ -389,7 +389,7 @@ TEST_CASE( "mixMultiQubitKrausMap", "[decoherence]" ) {
             }
             
             // make only one invalid
-            ops[GENERATE_REF( range(0,numOps) )].real[0][0] = 0;
+            ops[GENERATE_REF( range(0,numOps) )].real[0][0] = -123456789;
             
             // make valid targets to avoid triggering target validation
             VLA(int, targs, numTargs);

--- a/tests/utilities.cpp
+++ b/tests/utilities.cpp
@@ -445,18 +445,14 @@ bool areEqual(QVector a, QVector b) {
     return true;
 }
 
-bool areEqual(QMatrix a, QMatrix b, qreal precision) {
+bool areEqual(QMatrix a, QMatrix b) {
     DEMAND( a.size() == b.size() );
     
     for (size_t i=0; i<a.size(); i++)
         for (size_t j=0; j<b.size(); j++)
-            if (abs(a[i][j] - b[i][j]) > precision)
+            if (abs(a[i][j] - b[i][j]) > REAL_EPS)
                 return false;
     return true;
-}
-
-bool areEqual(QMatrix a, QMatrix b) {
-    return areEqual(a, b, REAL_EPS);
 }
 
 qcomp expI(qreal phase) {


### PR DESCRIPTION
Previously, the random unitaries used by unit tests were generated through direct Gram-Schmidt orthonormalisation of the rows of random complex matrices. This was numerically unstable, often leading to non-negligibly non-unitary matrices which were then replaced with the identity matrix as a last resort.

Now, the random unitaries are produced by QR decomposition (leveraging the existing Gram-Schmidt orthonormalisation), and the prescription at pg 11 of [this work](https://arxiv.org/pdf/math-ph/0609050.pdf). This is significantly more stable - the identity failsafe is now completely removed - and better tests the API functions which require unitaries and Kraus maps.