### PR TITLE
made QuESTEnv a singleton

### DIFF
--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -16,7 +16,7 @@ extern "C" {
  * main instance, statically instantiated inside environment.cpp,
  * accessible anywhere via a getter, and which is consulted for
  * determining the deployment configuration. Users can obtain a
- * local copy of this struct for their own querying.
+ * local copy of this struct with getQuESTEnv().
  */
 
 typedef struct QuESTEnv {

--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -11,6 +11,13 @@ extern "C" {
 #endif
 
 
+/*
+ * QuESTEnv is a struct of which there will be a single, immutable
+ * main instance, statically instantiated inside environment.cpp,
+ * accessible anywhere via a getter, and which is consulted for
+ * determining the deployment configuration. Users can obtain a
+ * local copy of this struct for their own querying.
+ */
 
 typedef struct QuESTEnv {
 
@@ -29,13 +36,17 @@ typedef struct QuESTEnv {
 
 
 
-QuESTEnv createQuESTEnv();
+void initQuESTEnv();
 
-QuESTEnv createCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMultithread);
+void initCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMultithread);
 
-void destroyQuESTEnv(QuESTEnv env);
+void finalizeQuESTEnv();
 
-void reportQuESTEnv(QuESTEnv env);
+void reportQuESTEnv();
+
+int isQuESTEnvInit();
+
+QuESTEnv getQuESTEnv();
 
 
 

--- a/quest/include/qureg.h
+++ b/quest/include/qureg.h
@@ -6,7 +6,6 @@
 #define QUREG_H
 
 #include "quest/include/types.h"
-#include "quest/include/environment.h"
 
 // enable invocation by both C and C++ binaries
 #ifdef __cplusplus
@@ -46,11 +45,11 @@ typedef struct Qureg
 
 
 
-Qureg createQureg(int numQubits, QuESTEnv env);
+Qureg createQureg(int numQubits);
 
-Qureg createDensityQureg(int numQubits, QuESTEnv env);
+Qureg createDensityQureg(int numQubits);
 
-Qureg createCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread, QuESTEnv env);
+Qureg createCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread);
 
 void destroyQureg(Qureg qureg);
 

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -367,10 +367,6 @@ void finalizeQuESTEnv() {
 void reportQuESTEnv() {
     validate_envInit(__func__);
 
-    // we attempt to report properties of available hardware facilities
-    // (e.g. number of CPU cores, number of GPUs) even if the environment is not
-    // making use of them, to inform the user how they might change deployment.
-
     // TODO: add function to write this output to file (useful for HPC debugging)
 
     // only root node reports (but no synch necesary)
@@ -382,6 +378,9 @@ void reportQuESTEnv() {
     bool statevec = false;
     bool densmatr = true;
 
+    // we attempt to report properties of available hardware facilities
+    // (e.g. number of CPU cores, number of GPUs) even if the environment is not
+    // making use of them, to inform the user how they might change deployment.
     printPrecisionInfo();
     printCompilationInfo();
     printDeploymentInfo(questEnv);

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -28,7 +28,10 @@ using namespace form_substrings;
  * PRIVATE INNER FUNCTIONS (C++)
  */
 
-Qureg validateAndCreateCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread, QuESTEnv env, const char* caller) {
+Qureg validateAndCreateCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread, const char* caller) {
+
+    validate_envInit(__func__);
+    QuESTEnv env = getQuESTEnv();
 
     // ensure deployment is compatible with environment, considering available hardware and their memory capacities
     validate_newQuregParams(numQubits, isDensMatr, useDistrib, useGpuAccel, useMultithread, env, caller);
@@ -189,28 +192,25 @@ void printMemoryInfo(Qureg qureg) {
 extern "C" {
 
 
-Qureg createCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread, QuESTEnv env) {
-    validate_envInit(env, __func__);
+Qureg createCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread) {
 
-    return validateAndCreateCustomQureg(numQubits, isDensMatr, useDistrib, useGpuAccel, useMultithread, env, __func__);
+    return validateAndCreateCustomQureg(numQubits, isDensMatr, useDistrib, useGpuAccel, useMultithread, __func__);
 }
 
 
-Qureg createQureg(int numQubits, QuESTEnv env) {
-    validate_envInit(env, __func__);
+Qureg createQureg(int numQubits) {
 
     int isDensMatr = 0;
     int autoMode = modeflag::USE_AUTO;
-    return validateAndCreateCustomQureg(numQubits, isDensMatr, autoMode, autoMode, autoMode, env, __func__);
+    return validateAndCreateCustomQureg(numQubits, isDensMatr, autoMode, autoMode, autoMode, __func__);
 }
 
 
-Qureg createDensityQureg(int numQubits, QuESTEnv env) {
-    validate_envInit(env, __func__);
+Qureg createDensityQureg(int numQubits) {
 
     int isDensMatr = 1;
     int autoMode = modeflag::USE_AUTO;
-    return validateAndCreateCustomQureg(numQubits, isDensMatr, autoMode, autoMode, autoMode, env, __func__);
+    return validateAndCreateCustomQureg(numQubits, isDensMatr, autoMode, autoMode, autoMode, __func__);
 }
 
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -35,6 +35,13 @@ namespace report {
      *  ENVIRONMENT CREATION
      */
 
+    std::string QUEST_ENV_ALREADY_INIT =
+        "The QuEST environment has already been initialised. This can only be performed once during program execution.";
+
+    std::string QUEST_ENV_ALREADY_FINAL =
+        "The QuEST environment has already been finalised, and can thereafter never be re-initialised since this leads to undefined MPI behaviour.";
+
+
     std::string INVALID_OPTION_FOR_ENV_IS_DISTRIB =
         "Argument 'useDistribution' must be 1 or 0 to respectively indicate whether or not to distribute the new environment, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
@@ -63,6 +70,14 @@ namespace report {
 
     std::string CUQUANTUM_DEPLOYED_ON_GPU_WITHOUT_MEM_POOLS =
         "Cannot use cuQuantum since your GPU does not support memory pools. Please recompile with cuQuantum disabled to fall-back to using Thrust and custom kernels.";
+
+    
+    /*
+     * EXISTING QUESTENV
+     */
+
+    std::string QUEST_ENV_NOT_INIT =
+        "The QuEST environment is not initialised. Please first call initQuESTEnv() or initCustomQuESTEnv().";
 
 
     /*
@@ -314,10 +329,10 @@ void assertThat(bool valid, std::string msg, tokenSubs vars, const char* func) {
  * ENVIRONMENT CREATION
  */
 
-void validate_newEnvNotAlreadyInit(const char* caller) {
+void validate_envNeverInit(bool isQuESTInit, bool isQuESTFinal, const char* caller) {
 
-    // TODO:
-    // consult a comm/ singleton?
+    assertThat(!isQuESTInit, report::QUEST_ENV_ALREADY_INIT, caller);
+    assertThat(!isQuESTFinal, report::QUEST_ENV_ALREADY_FINAL, caller);
 }
 
 void validate_newEnvDeploymentMode(int isDistrib, int isGpuAccel, int isMultithread, const char* caller) {
@@ -374,10 +389,9 @@ void validate_gpuIsCuQuantumCompatible(const char* caller) {
  * EXISTING ENVIRONMENT
  */
 
-void validate_envInit(QuESTEnv env, const char* caller) {
+void validate_envInit(const char* caller) {
 
-    // TOOD:
-    // confirm all the mode settings are correct, etc
+    assertThat(isQuESTEnvInit(), report::QUEST_ENV_NOT_INIT, caller);
 }
 
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -16,7 +16,7 @@
  * ENVIRONMENT CREATION
  */
 
-void validate_newEnvNotAlreadyInit(const char* caller);
+void validate_envNeverInit(bool isQuESTInit, bool isQuESTFinal, const char* caller);
 
 void validate_newEnvDeploymentMode(int isDistrib, int isGpuAccel, int isMultithread, const char* caller);
 
@@ -30,7 +30,7 @@ void validate_gpuIsCuQuantumCompatible(const char* caller);
  * EXISTING ENVIRONMENT
  */
 
-void validate_envInit(QuESTEnv env, const char* caller);
+void validate_envInit(const char* caller);
 
 
 


### PR DESCRIPTION
replacing...
- `QuESTEnv createQuESTEnv()`
- `void destroyQuESTEnv(QuESTEnv env)`

with (yes, using US spelling...)
- `void initQuESTEnv()`
- `void finalizeQuESTEnv()`

All other functions which received `QuESTEnv` as an argument, now do not. 

Also added
- `QuESTEnv getQuESTEnv()`

to get a copy of the internal `QuESTEnv` single instance, which may be useful for stacks or debugging.