### PR TITLE
added CompMatr initialisers

### DIFF
--- a/quest/include/structures.h
+++ b/quest/include/structures.h
@@ -156,16 +156,32 @@ typedef struct CompMatrN
  * LITERAL FIXED-SIZE MATRIX INITIALISERS
  *
  * which enable C users to give inline 2D array literals without having to use the
- * compound literal syntax. We expose these macros to C++ too for API consistency,
- * although C++'s getCompMatr1 vector overload achieves the same thing
+ * compound literal syntax. We expose these macros to C++ too for API consistency.
+ * although C++'s getCompMatr1 vector overload achieves the same thing, and cannot
+ * use C-style temporary arrays.
  */
 
+#ifdef __cplusplus
 
-#define getLiteralCompMatr1(...) \
-    getCompMatr1FromArr((qcomp[2][2]) __VA_ARGS__)
+    // C++ merely invokes the std::vector initialiser overload
 
-#define getLiteralCompMatr2(...) \
-    getCompMatr2FromArr((qcomp[4][4]) __VA_ARGS__)
+    #define getLiteralCompMatr1(...) \
+        getCompMatr1(__VA_ARGS__)
+
+    #define getLiteralCompMatr2(...) \
+        getCompMatr2FromArr(__VA_ARGS__)
+
+#else
+
+    // C adds compound literal syntax to make a temporary array
+
+    #define getLiteralCompMatr1(...) \
+        getCompMatr1FromArr((qcomp[2][2]) __VA_ARGS__)
+
+    #define getLiteralCompMatr2(...) \
+        getCompMatr2FromArr((qcomp[4][4]) __VA_ARGS__)
+
+#endif
 
 
 

--- a/quest/include/structures.h
+++ b/quest/include/structures.h
@@ -2,12 +2,42 @@
  * Signatures of API data structures like gate matrices. 
  * Note QuESTEnv and Qureg structs have their own signatures 
  * in environment.h and qureg.h respectively.
+ * 
+ * This file uses extensive preprocessor trickery to achieve platform agnostic,
+ * C and C++ compatible, type agnostic, getters and setters of complex matrices.
+ * First, we define C and C++ "explicit" functions like getCompMatr1FromArr()
+ * (though C must wrap these with wrappers.h due to bad qcomp interoperability).
+ * These explicitly disambiguate the input types in the function name.
+ * Next, we define getCompMatr1() as a generic C macro and C++ overloads, so
+ * that users can agnostically pass 2D pointers, arrays of pointers, or 2D arrays,
+ * including compound literals like (qcomp[2][2]) {{...}}. So far, only the C++ 
+ * overloads accept literals without the declaration like {{...}} via std::vector.
+ * So, we next define getLiteralCompMatr1() as a C and C++ (for consistency) macro 
+ * which accepts direct, concise literals like getLiteralCompMatr1({{...}}). Viola! 
+ * 
+ * We employ similar tricks to make setCompMatrN(), but define setCompMatrNFromArr()
+ * in this header (exposed only to C) because it requires C++-incompatible VLAs;
+ * this definition must invoke a bespoke validation function (gross). Also, our
+ * implementation of setLiteralCompMatrN has to resort to preprocessor stringifying 
+ * and runtime parsing - blegh!
+ * 
+ * All of these "intermediate" CompMatr initialisations are exposed to users.
+ * Keep in mind that definitions herein will lead to symbol duplication unless 
+ * specified as 'static inline', but macros are fine.
+ * 
+ * You're moving in a land of both shadow and substance, of things and ideas.
+ * You've just crossed over into the Twilight Zone.
  */
 
 #ifndef STRUCTURES_H
 #define STRUCTURES_H
 
 #include "quest/include/types.h"
+
+// C++ gets vector initialiser overloads, whereas C gets a macro
+#ifdef __cplusplus
+    #include <vector>
+#endif
 
 
 
@@ -53,9 +83,9 @@ typedef struct CompMatrN
 
 
 /*
- * MATRIX CONSTRUCTORS
+ * EXPLICIT FIXED-SIZE MATRIX INITIALISERS
  *
- * some of which are exposed only to C++ because they are incompatile with C binaries
+ * which are exposed directly only to C++ because they are incompatile with C binaries
  * due to returning qcomp (or fixed size arrays thereof) by-value through their structs.
  * The incompatibility arises because C++'s' std::complex and C's complex.h type are
  * distinct in the application binary interface (ABI), so a C binary cannot directly call
@@ -66,13 +96,76 @@ typedef struct CompMatrN
  * the same memory layout.
  */
 
+
 #ifdef __cplusplus
 
-    CompMatr1 getCompMatr1(qcomp in[2][2]);
+    CompMatr1 getCompMatr1FromArr(qcomp in[2][2]);
+    CompMatr1 getCompMatr1FromPtr(qcomp** in);
 
-    CompMatr2 getCompMatr2(qcomp in[4][4]);
+    CompMatr2 getCompMatr2FromArr(qcomp in[4][4]);
+    CompMatr2 getCompMatr2FromPtr(qcomp** in);
 
 #endif
+
+
+
+/*
+ * OVERLOADED FIXED-SIZE MATRIX INITIALISERS
+ */
+
+
+#ifdef __cplusplus
+
+    // C++ uses overloads, accepting even vector initialiser lists
+
+    CompMatr1 getCompMatr1(qcomp in[2][2]);
+    CompMatr1 getCompMatr1(qcomp** in);
+    CompMatr1 getCompMatr1(std::vector<std::vector<qcomp>> in);
+
+    CompMatr2 getCompMatr2(qcomp in[4][4]);
+    CompMatr2 getCompMatr2(qcomp** in);
+    CompMatr2 getCompMatr2(std::vector<std::vector<qcomp>> in);
+
+#else
+
+    // C uses C11 compile-time type inspection, but literals must have compound syntax.
+    // Explicit qcomp[2][2] type isn't necessary because it decays to qcomp(*)[2].
+    // Use of __VA_ARGS__ is necessary to accept multiple-token compound literals.
+    // Sadly we cannot use _Generic 'default' to catch unrecognised types at compile time.
+
+    // Using type qcomp(*) below would erroneously invoke the qcomp(re,im) macro.
+    // Preventing expansion using (qcomp)(*) leads to _Generic not recognising the type.
+    // So, in desperation, we alias the type qcomp with a name that has no colliding macro.
+    typedef qcomp qalias;
+
+    #define getCompMatr1(...) _Generic((__VA_ARGS__), \
+        qalias(*)[2] : getCompMatr1FromArr, \
+        qcomp**      : getCompMatr1FromPtr  \
+        )((__VA_ARGS__))
+
+    #define getCompMatr2(...) _Generic((__VA_ARGS__), \
+        qalias(*)[4] : getCompMatr2FromArr, \
+        qcomp**      : getCompMatr2FromPtr  \
+        )((__VA_ARGS__))
+
+#endif
+
+
+
+/*
+ * LITERAL FIXED-SIZE MATRIX INITIALISERS
+ *
+ * which enable C users to give inline 2D array literals without having to use the
+ * compound literal syntax. We expose these macros to C++ too for API consistency,
+ * although C++'s getCompMatr1 vector overload achieves the same thing
+ */
+
+
+#define getLiteralCompMatr1(...) \
+    getCompMatr1FromArr((qcomp[2][2]) __VA_ARGS__)
+
+#define getLiteralCompMatr2(...) \
+    getCompMatr2FromArr((qcomp[4][4]) __VA_ARGS__)
 
 
 
@@ -80,7 +173,8 @@ typedef struct CompMatrN
  * VARIABLE-SIZE MATRIX CONSTRUCTORS
  */
 
-// de-mangle so below are directly callable by C binary
+
+// de-mangle so below are directly callable by C and C++ binary
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -91,10 +185,133 @@ extern "C" {
 
     void syncCompMatrN(CompMatrN matr);
 
-    void setCompMatrN(CompMatrN matr, qcomp** vals);
+#ifdef __cplusplus
+}
+#endif
+
+
+
+/*
+ * EXPLICIT VARIABLE-SIZE MATRIX INITIALISERS
+ */
+
+
+// de-mangle so below are directly callable by C and C++ binary
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void setCompMatrNFromPtr(CompMatrN matr, qcomp** vals);
 
 #ifdef __cplusplus
 }
+#endif
+
+
+// permit only C compilers to have a VLA version (not supported nor needed by C++)
+#ifndef __cplusplus
+
+    // expose this function's bespoke validation
+    extern void validate_setCompMatrNFromArr(CompMatrN out);
+
+     // static inline to avoid header-symbol duplication
+    static inline void setCompMatrNFromArr(CompMatrN matr, qcomp arr[matr.numRows][matr.numRows]) {
+
+        // this function will allocate stack memory of size matr.numRows, but that field could
+        // be invalid since matr hasn't been validated, so we must invoke bespoke validation
+        validate_setCompMatrNFromArr(matr);
+
+        // new ptrs array safely fits in stack, since it's sqrt-smaller than user's passed stack array
+        qcomp* ptrs[matr.numRows];
+
+        // collect pointers to each row of arr
+        for (qindex r=0; r<matr.numRows; r++)
+            ptrs[r] = arr[r];
+
+        // array decays to qcomp**, and *FromPtr function re-performs validation (eh)
+        setCompMatrNFromPtr(matr, ptrs);
+    }
+
+#endif
+
+
+
+/*
+ * OVERLOADED VARIABLE-SIZE MATRIX INITIALISERS
+ */
+
+
+#ifdef __cplusplus
+
+    // C++ uses overloads, accepting even vector initialiser lists, but cannot ever accept 2D arrays
+
+    void setCompMatrN(CompMatrN out, qcomp** in);
+
+    void setCompMatrN(CompMatrN out, std::vector<std::vector<qcomp>> in);
+
+#else
+
+    // C uses C11 compile-time type inspection, but literals must have compound syntax.
+    // Explicit qcomp[][] type isn't necessary because it decays to qcomp(*)[].
+    // Use of __VA_ARGS__ is necessary to accept multiple-token compound literals.
+    // Sadly we cannot use _Generic 'default' to catch unrecognised types at compile time.
+
+    // Using type qcomp(*) below would erroneously invoke the qcomp(re,im) macro.
+    // Preventing expansion using (qcomp)(*) leads to _Generic not recognising the type.
+    // So, in desperation, we re-use the qcomp alias made by the previous _Generic use.
+
+    #define setCompMatrN(matr, ...) _Generic((__VA_ARGS__),   \
+        qalias(*)[] : setCompMatrNFromArr, \
+        qcomp**     : setCompMatrNFromPtr  \
+        )((matr), (__VA_ARGS__))
+
+#endif
+
+
+
+/*
+ * STRING PARSING VARIABLE-SIZE MATRIX INITIALISERS
+ */
+
+
+// de-mangle for both C and C++ invocation
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void setStringCompMatrN(CompMatrN matr, char* string);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+/*
+ * LITERAL VARIABLE-SIZE MATRIX INITIALISERS
+ *
+ * which enable C users to give inline 2D array literals without having to use the
+ * VLA compound literal syntax. We expose these macros to C++ too for API consistency,
+ * although C++'s getCompMatr1 vector overload achieves the same thing
+ */
+
+
+#ifdef __cplusplus
+
+    // C++ gets an explicit redirect to setCompMatrN(std::vector...), since it's faster than stringifying
+
+    #define setLiteralCompMatrN(matr, ...) \
+        setCompMatrN(matr, __VA_ARGS__)
+
+#else 
+
+    // C VLAs cannot be initialized, so we cannot use the same trick as used for the fixed-size
+    // arrays, and i.e. invoke setCompMatrNFromArr() with inline array (qcomp(*)[matr.numRows]) __VA_ARGS__.
+    // Instead, we must diabolically convert the expression to a compile-time string and parse it. Eep!
+
+    #define setLiteralCompMatrN(matr, ...) \
+        setStringCompMatrN(matr, #__VA_ARGS__)
+
 #endif
 
 

--- a/quest/include/structures.h
+++ b/quest/include/structures.h
@@ -169,7 +169,7 @@ typedef struct CompMatrN
         getCompMatr1(__VA_ARGS__)
 
     #define getLiteralCompMatr2(...) \
-        getCompMatr2FromArr(__VA_ARGS__)
+        getCompMatr2(__VA_ARGS__)
 
 #else
 

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -23,22 +23,42 @@
 
 
 
-void wrap_getCompMatr1(CompMatr1* out, qcomp in[2][2]);
+void wrap_getCompMatr1FromArr(CompMatr1* out, qcomp in[2][2]);
 
-CompMatr1 getCompMatr1(qcomp in[2][2]) {
+CompMatr1 getCompMatr1FromArr(qcomp in[2][2]) {
 
     CompMatr1 out;
-    wrap_getCompMatr1(&out, in);
+    wrap_getCompMatr1FromArr(&out, in);
     return out;
 }
 
 
-void wrap_getCompMatr2(CompMatr2* out, qcomp in[4][4]);
+void wrap_getCompMatr1FromPtr(CompMatr1* out, qcomp** in);
 
-CompMatr2 getCompMatr2(qcomp in[4][4]) {
+CompMatr1 getCompMatr1FromPtr(qcomp** in) {
+
+    CompMatr1 out;
+    wrap_getCompMatr1FromPtr(&out, in);
+    return out;
+}
+
+
+void wrap_getCompMatr2FromArr(CompMatr2* out, qcomp in[4][4]);
+
+CompMatr2 getCompMatr2FromArr(qcomp in[4][4]) {
 
     CompMatr2 out;
-    wrap_getCompMatr2(&out, in);
+    wrap_getCompMatr2FromArr(&out, in);
+    return out;
+}
+
+
+void wrap_getCompMatr2FromPtr(CompMatr2* out, qcomp** in);
+
+CompMatr2 getCompMatr2FromPtr(qcomp** in) {
+
+    CompMatr2 out;
+    wrap_getCompMatr2FromPtr(&out, in);
     return out;
 }
 

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -30,7 +30,7 @@ using namespace form_substrings;
 
 Qureg validateAndCreateCustomQureg(int numQubits, int isDensMatr, int useDistrib, int useGpuAccel, int useMultithread, const char* caller) {
 
-    validate_envInit(__func__);
+    validate_envInit(caller);
     QuESTEnv env = getQuESTEnv();
 
     // ensure deployment is compatible with environment, considering available hardware and their memory capacities

--- a/quest/src/api/structures.cpp
+++ b/quest/src/api/structures.cpp
@@ -254,7 +254,7 @@ void setCompMatrN(CompMatrN out, std::vector<std::vector<qcomp>> in) {
 
     // we validate dimension of 'in', which first requires validating 'out' fields
     validate_matrixInit(out, __func__);
-    validate_numMatrixElems(1, in, __func__);
+    validate_numMatrixElems(out.numQubits, in, __func__);
 
     validateAndSetCompMatrNElems(out, in, __func__);
 }

--- a/quest/src/api/structures.cpp
+++ b/quest/src/api/structures.cpp
@@ -2,6 +2,9 @@
  * Definitions of API data structures like gate matrices. 
  * Note QuESTEnv and Qureg structs have their own definitions 
  * in environment.cpp and qureg.cpp respectively.
+ * 
+ * This file defines many "layers" of initialisation of complex
+ * matrices, as explained in the header file.
  */
 
 #include "quest/include/structures.h"
@@ -18,6 +21,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <vector>
 
 
 // for concise reporters
@@ -26,63 +30,114 @@ using namespace form_substrings;
 
 
 /*
- * C++-ONLY MATRIX 1&2 CONSTRUCTORS
- * 
- * and their corresponding C-compatible alternatives which are wrapped by wrappers.h.
- * These are necessary because of the non-interchangeable C and C++ qcomp types.
- * See structures.h for an explanation.
+ * PRIVATE UTILITES 
  */
 
+// A and B can both be qcomp** or qcomp[][] (mixed)
+template<typename A, typename B> 
+void populateCompMatrElems(A out, B in, qindex dim) {
 
-CompMatr1 getCompMatr1(qcomp in[2][2]) {
+    for (qindex r=0; r<dim; r++)
+        for (qindex c=0; c<dim; c++)
+            out[r][c] = in[r][c];
+}
 
-    CompMatr1 out = {
-        .numQubits = 1,
-        .numRows = 2,
-        .elems = {
-            in[0][0], in[0][1],
-            in[1][0], in[1][1]
-        }
-    };
+// T can be CompMatr1/2, B can be qcomp** or qcomp[][]
+template<class T, typename B>
+T getCompMatrFromElems(B in, int num) {
 
+    T out;
+    out.numQubits = num;
+    out.numRows = powerOf2(num);
+    populateCompMatrElems(out.elems, in, out.numRows);
     return out;
-}
-extern "C" void wrap_getCompMatr1(CompMatr1* out, qcomp in[2][2]) {
-
-    *out = getCompMatr1(in);
-}
-
-
-CompMatr2 getCompMatr2(qcomp in[4][4]) {
-
-    CompMatr2 out = {
-        .numQubits = 2,
-        .numRows = 4,
-        .elems = {
-            in[0][0], in[0][1], in[0][2], in[0][3],
-            in[1][0], in[1][1], in[1][2], in[1][3],
-            in[2][0], in[2][1], in[2][2], in[2][3],
-            in[3][0], in[3][1], in[3][2], in[3][3]
-        }
-    };
-    
-    return out;
-}
-extern "C" void wrap_getCompMatr2(CompMatr2* out, qcomp in[4][4]) {
-
-    *out = getCompMatr2(in);
 }
 
 
 
 /*
- * C & C++ MATRIX N CONSTRUCTORS
+ * EXPLICIT FIXED-SIZE MATRIX INITIALISERS
+ * 
+ * and their corresponding C-compatible alternatives which are wrapped by wrappers.h.
+ * The wrappers are necessary because of the non-interchangeable C and C++ qcomp types.
+ * See structures.h for an explanation. These definitions will always exist (even when
+ * the user compiles their own code in C), but will be name-mangled.
+ * 
+ * The separate *FromArr an *FromPtr definitions are so that we can safe and simply
+ * wrap these in a C-compatible param-agnostic macro, and C++-compatible overloads,
+ * so that users can avoid having to use compound literals and pass {{...}} in-place.
+ */
+
+CompMatr1 getCompMatr1FromArr(qcomp in[2][2]) {
+    return getCompMatrFromElems<CompMatr1>(in, 1);
+}
+CompMatr1 getCompMatr1FromPtr(qcomp** in) {
+    return getCompMatrFromElems<CompMatr1>(in, 1);
+}
+CompMatr2 getCompMatr2FromArr(qcomp in[4][4]) {
+    return getCompMatrFromElems<CompMatr2>(in, 2);
+}
+CompMatr2 getCompMatr2FromPtr(qcomp** in) {
+    return getCompMatrFromElems<CompMatr2>(in, 2);
+}
+
+extern "C" void wrap_getCompMatr1FromArr(CompMatr1* out, qcomp in[2][2]) {
+    *out = getCompMatr1FromArr(in);
+}
+extern "C" void wrap_getCompMatr1FromPtr(CompMatr1* out, qcomp** in) {
+    *out = getCompMatr1FromPtr(in);
+}
+extern "C" void wrap_getCompMatr2FromArr(CompMatr2* out, qcomp in[4][4]) {
+    *out = getCompMatr2FromArr(in);
+}
+extern "C" void wrap_getCompMatr2FromPtr(CompMatr2* out, qcomp** in) {
+    *out = getCompMatr2FromPtr(in);
+}
+
+
+
+/*
+ * OVERLOADED FIXED-SIZE MATRIX INITIALISERS
  *
- * all of which are de-mangled for C-compatibility
+ * Only exposed to C++; equivalent C macros are defined in the header.
+ * Only the C++ vector overloads can validate their literal dimensions.
+ */
+
+CompMatr1 getCompMatr1(qcomp in[2][2]) {
+    return getCompMatrFromElems<CompMatr1>(in, 1);
+}
+CompMatr1 getCompMatr1(qcomp** in) {
+    return getCompMatrFromElems<CompMatr1>(in, 1);
+}
+CompMatr1 getCompMatr1(std::vector<std::vector<qcomp>> in) {
+    validate_numMatrixElems(1, in, __func__);
+
+    return getCompMatrFromElems<CompMatr1>(in, 1);
+}
+
+CompMatr2 getCompMatr2(qcomp in[4][4]) {
+    return getCompMatrFromElems<CompMatr2>(in, 2);
+}
+CompMatr2 getCompMatr2(qcomp** in) {
+    return getCompMatrFromElems<CompMatr2>(in, 2);
+}
+CompMatr2 getCompMatr2(std::vector<std::vector<qcomp>> in) {
+    validate_numMatrixElems(2, in, __func__);
+
+    return getCompMatrFromElems<CompMatr2>(in, 2);
+}
+
+
+
+/*
+ * VARIABLE SIZE MATRIX CONSTRUCTORS
+ *
+ * all of which are de-mangled for both C++ and C compatibility
  */
 
 
 extern "C" CompMatrN createCompMatrN(int numQubits) {
+    validate_envInit(__func__);
     validate_newMatrixNumQubits(numQubits, __func__);
 
     // allocate GPU memory if the env is GPU-accelerated, regardless of (unknown) Qureg allocations
@@ -132,28 +187,92 @@ extern "C" void destroyCompMatrN(CompMatrN matrix) {
 }
 
 
-
-/*
- * MATRIX N INITIALISER
- */
-
 extern "C" void syncCompMatrN(CompMatrN matr) {
     validate_matrixInit(matr, __func__);
-    validate_matrixElemsDontContainUnsyncFlag(matr.elems, __func__);
+    validate_matrixElemsDontContainUnsyncFlag(matr.elems[0][0], __func__);
 
     gpu_copyCpuToGpu(matr);
 }
 
-extern "C" void setCompMatrN(CompMatrN matr, qcomp** vals) {
-    validate_matrixInit(matr, __func__);
-    validate_matrixElemsDontContainUnsyncFlag(vals, __func__);
+
+
+/*
+ * EXPLICIT VARIABLE-SIZE MATRIX INITIALISERS
+ *
+ * all of which are demangled for C and C++ compatibility
+ */
+
+
+template <typename T> 
+void validateAndSetCompMatrNElems(CompMatrN out, T elems, const char* caller) {
+    validate_matrixInit(out, __func__);
+    validate_matrixElemsDontContainUnsyncFlag(elems[0][0], caller);
 
     // serially copy values to CPU memory
-    populateCompMatrElems(matr.elems, vals, matr.numRows);
+    populateCompMatrElems(out.elems, elems, out.numRows);
 
-    // overwrite GPU elements
-    if (matr.gpuElems != NULL)
-        gpu_copyCpuToGpu(matr);
+    // overwrite GPU elements (including unsync flag)
+    if (out.gpuElems != NULL)
+        gpu_copyCpuToGpu(out);
+}
+
+extern "C" void setCompMatrNFromPtr(CompMatrN out, qcomp** elems) {
+
+    validateAndSetCompMatrNElems(out, elems, __func__);
+}
+
+// the corresponding setCompMatrNFromArr() function must use VLAs and so
+// is C++ incompatible, and is subsequently defined inline in the header file.
+// Because it needs to create stack memory with size given by a CompMatrN field,
+// we need to first validate that field via this exposed validation function. Blegh!
+
+extern "C" void validate_setCompMatrNFromArr(CompMatrN out) {
+
+    // the user likely invoked this function from the setLiteralCompMatrN()
+    // macro, but we cannot know for sure so it's better to fall-back to
+    // reporting the definitely-involved inner function, as we do elsewhere
+    validate_matrixInit(out, "setCompMatrNFromArr");
+}
+
+
+
+/*
+ * OVERLOADED VARIABLE-SIZE MATRIX INITIALISERS
+ *
+ * which are C++ only; equivalent C overloads are defined using
+ * macros in the header file. Note the explicit overloads below
+ * excludes a 2D qcomp[][] array because VLA is not supported by C++.
+ */
+
+
+void setCompMatrN(CompMatrN out, qcomp** in) {
+
+    validateAndSetCompMatrNElems(out, in, __func__);
+}
+
+void setCompMatrN(CompMatrN out, std::vector<std::vector<qcomp>> in) {
+
+    // we validate dimension of 'in', which first requires validating 'out' fields
+    validate_matrixInit(out, __func__);
+    validate_numMatrixElems(1, in, __func__);
+
+    validateAndSetCompMatrNElems(out, in, __func__);
+}
+
+
+
+/*
+ * STRING PARSING VARIABLE-SIZE MATRIX INITIALISERS
+ */
+
+
+// de-mangle for both C and C++ invocation
+extern "C" void setStringCompMatrN(CompMatrN matr, char* string) {
+    validate_matrixInit(matr, __func__);
+
+    // TODO: validate post-parsed string doesn't contain unsync flag
+
+    // TODO: invoke parser
 }
 
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -10,6 +10,8 @@
 #include "quest/include/qureg.h"
 #include "quest/include/structures.h"
 
+#include <vector>
+
 
 
 /*
@@ -72,7 +74,9 @@ void validate_matrixInit(CompMatr1 matr, const char* caller);
 void validate_matrixInit(CompMatr2 matr, const char* caller);
 void validate_matrixInit(CompMatrN matr, const char* caller);
 
-void validate_matrixElemsDontContainUnsyncFlag(qcomp** elems, const char* caller);
+void validate_numMatrixElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller);
+
+void validate_matrixElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller);
 
 void validate_matrixIsSynced(CompMatrN matr, const char* caller);
 

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -73,8 +73,7 @@ qcomp* gpu_allocAmps(qindex numLocalAmps);
 
 void gpu_deallocAmps(qcomp* amps);
 
-bool gpu_doCpuAmpsHaveUnsyncMemFlag(qcomp*  cpuArr);
-bool gpu_doCpuAmpsHaveUnsyncMemFlag(qcomp** cpuMatr);
+bool gpu_doCpuAmpsHaveUnsyncMemFlag(qcomp  firstCpuAmp);
 
 void gpu_copyCpuToGpu(Qureg qureg, qcomp* cpuArr, qcomp* gpuArr, qindex numElems);
 void gpu_copyCpuToGpu(Qureg qureg);

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -48,7 +48,7 @@ USER_C_COMPILER=gcc
 USER_CXX_COMPILER=g++
 
 # user code language-specific compiler flags
-USER_C_COMP_FLAGS='-std=c99'
+USER_C_COMP_FLAGS='-std=c11'
 USER_CXX_COMP_FLAGS='-std=c++14'
 
 # user linker flags


### PR DESCRIPTION
which required bumping up the user's C standard from C99 to C11 (in order to make use of _Generic)

Remaining changes needed:

- test initialisers with ~~GNU and~~ dreaded MSVC
- add CompMatrN parsing from string (to complete C's setLiteralCompMatrN)
- update matrix-is-unitary validation to use hardware acceleration, depending on size, and whether matrix has persistent GPU memory
- add example files of all the wonderful initialisation paradigms now possible

Those preprocessors are _gruesome_