### PR TITLE
tweaked CompMatrN initialisers

### DIFF
--- a/quest/src/api/structures.cpp
+++ b/quest/src/api/structures.cpp
@@ -228,7 +228,7 @@ extern "C" void setCompMatrNFromPtr(CompMatrN out, qcomp** elems) {
 
 extern "C" void validate_setCompMatrNFromArr(CompMatrN out) {
 
-    // the user likely invoked this function from the setLiteralCompMatrN()
+    // the user likely invoked this function from the setInlineCompMatrN()
     // macro, but we cannot know for sure so it's better to fall-back to
     // reporting the definitely-involved inner function, as we do elsewhere
     validate_matrixInit(out, "setCompMatrNFromArr");
@@ -257,22 +257,6 @@ void setCompMatrN(CompMatrN out, std::vector<std::vector<qcomp>> in) {
     validate_numMatrixElems(out.numQubits, in, __func__);
 
     validateAndSetCompMatrNElems(out, in, __func__);
-}
-
-
-
-/*
- * STRING PARSING VARIABLE-SIZE MATRIX INITIALISERS
- */
-
-
-// de-mangle for both C and C++ invocation
-extern "C" void setStringCompMatrN(CompMatrN matr, char* string) {
-    validate_matrixInit(matr, __func__);
-
-    // TODO: validate post-parsed string doesn't contain unsync flag
-
-    // TODO: invoke parser
 }
 
 


### PR DESCRIPTION
- renamed `*Literal*` to `*Inline*` to better reflect that functions like `getInlineCompMatrN` (formerly `getLiteralCompMatrN`) accept inline instantiations of 2D arrays, and don't require any every element therein to be a literal. Instead, these arrays can contain variables, arithmetic expressions, etc.

- removed `setStringCompMatrN` since it wouldn't flawlessly enable 2D array inline initialisation in C (without the compound literal syntax). Instead, it would restrict us to initialisations with only complex literals, precluding variables or arithmetic expressions

- added a compile-time size parameter to macro `setInlineCompMatr` necessary for C compatibility without the above mentioned limitations of stringifying the literal