### PR TITLE
made structs const

### DIFF
--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -17,9 +17,16 @@ extern "C" {
  * accessible anywhere via a getter, and which is consulted for
  * determining the deployment configuration. Users can obtain a
  * local copy of this struct with getQuESTEnv().
+ * 
+ * QuESTEnv is not declared const, because it is impossible to 
+ * runtime initialise a const global variable like a singleton.
+ * A shame, but this poses no risk; the internal singleton is not 
+ * obtainable nor modifiable outside of environment.cpp since its 
+ * getter returns a copy. 
  */
 
-typedef struct QuESTEnv {
+
+typedef struct {
 
     // deployment mode
     int isGpuAccelerated;

--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -29,13 +29,13 @@ extern "C" {
 typedef struct {
 
     // deployment mode
-    int isGpuAccelerated;
-    int isDistributed;
-    int isMultithreaded;
+    const int isGpuAccelerated;
+    const int isDistributed;
+    const int isMultithreaded;
 
     // distributed configuration
-    int rank;
-    int numNodes;
+    const int rank;
+    const int numNodes;
 
     // TODO: RNG seeds
 

--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -29,9 +29,9 @@ extern "C" {
 typedef struct {
 
     // deployment mode
+    const int isMultithreaded;
     const int isGpuAccelerated;
     const int isDistributed;
-    const int isMultithreaded;
 
     // distributed configuration
     const int rank;

--- a/quest/include/qureg.h
+++ b/quest/include/qureg.h
@@ -14,24 +14,24 @@ extern "C" {
 
 
 
-typedef struct Qureg
-{
+typedef struct {
+
     // deployment configuration
-    int isGpuAccelerated;
-    int isDistributed;
-    int isMultithreaded;
+    const int isGpuAccelerated;
+    const int isDistributed;
+    const int isMultithreaded;
 
     // distributed configuration
-    int rank;
-    int numNodes;
-    int logNumNodes;
+    const int rank;
+    const int numNodes;
+    const int logNumNodes;
 
     // dimension
-    int isDensityMatrix;
-    int numQubits;
-    qindex numAmps;
-    qindex numAmpsPerNode;
-    qindex logNumAmpsPerNode;
+    const int isDensityMatrix;
+    const int numQubits;
+    const qindex numAmps;
+    const qindex numAmpsPerNode;
+    const qindex logNumAmpsPerNode;
 
     // amplitudes in CPU and GPU memory
     qcomp* cpuAmps;

--- a/quest/include/qureg.h
+++ b/quest/include/qureg.h
@@ -17,9 +17,9 @@ extern "C" {
 typedef struct {
 
     // deployment configuration
+    const int isMultithreaded;
     const int isGpuAccelerated;
     const int isDistributed;
-    const int isMultithreaded;
 
     // distributed configuration
     const int rank;

--- a/quest/include/structures.h
+++ b/quest/include/structures.h
@@ -44,7 +44,8 @@
  *
  * which are visible to both C and C++, where qcomp resolves
  * to the native complex type. These are not de-mangled because
- * C++ structs are already C compatible.
+ * C++ structs are already C compatible. We define their fields
+ * as const to prevent users mangling them.
  */
 
 
@@ -78,13 +79,12 @@ typedef struct {
     const int numQubits;
     const qindex numRows;
 
-    // consts prevent overwriting mem address (of outer list, and each
-    // row therein) but permit modifying each element
-    qcomp* const* const elems;
+    // 2D CPU memory; not const, so users can overwrite addresses (e.g. with NULL)
+    qcomp** elems;
 
     // row-flattened elems in GPU memory, allocated only
-    // in GPU-enabled QuEST environments (regardless of Quregs)
-    qcomp* const gpuElems;
+    // and always in GPU-enabled QuEST environments
+    qcomp* gpuElems;
 
 } CompMatrN;
 

--- a/quest/include/structures.h
+++ b/quest/include/structures.h
@@ -1,13 +1,12 @@
 /** @file
- * Signatures of API data structures like gate matrices. 
- * Note QuESTEnv and Qureg structs have their own signatures 
- * in environment.h and qureg.h respectively.
+ * Signatures of API data structures like gate matrices. Note QuESTEnv and Qureg 
+ * structs have their own signatures in environment.h and qureg.h respectively.
  * 
  * This file uses extensive preprocessor trickery to achieve platform agnostic,
  * C and C++ compatible, type agnostic, getters and setters of complex matrices.
- * First, we define C and C++ "explicit" functions like getCompMatr1FromArr()
- * (though C must wrap these with wrappers.h due to bad qcomp interoperability).
- * These explicitly disambiguate the input types in the function name.
+ * First, we define C and C++ "explicit" functions like getCompMatr1FromArr();
+ * these definitions are in this header because of qcomp interoperability issues
+ * (see below). The function names explicitly disambiguate the input types.
  * Next, we define getCompMatr1() as a generic C macro and C++ overloads, so
  * that users can agnostically pass 2D pointers, arrays of pointers, or 2D arrays,
  * including compound literals like (qcomp[2][2]) {{...}}. So far, only the C++ 
@@ -49,33 +48,43 @@
  */
 
 
-typedef struct CompMatr1
-{
-    int numQubits;
-    qindex numRows;
+typedef struct {
+
+    // const to prevent user modification
+    const int numQubits;
+    const qindex numRows;
+
+    // elems are not const so that users can modify them after initialisation
     qcomp elems[2][2];
 
 } CompMatr1;
 
 
-typedef struct CompMatr2
-{
-    int numQubits;
-    qindex numRows;
+typedef struct {
+
+    // const to prevent user modification
+    const int numQubits;
+    const qindex numRows;
+
+    // elems are not const so that users can modify them after initialisation
     qcomp elems[4][4];
 
 } CompMatr2;
 
 
-typedef struct CompMatrN
-{
-    int numQubits;
-    qindex numRows;
-    qcomp** elems;
+typedef struct {
+
+    // const to prevent user modification
+    const int numQubits;
+    const qindex numRows;
+
+    // consts prevent overwriting mem address (of outer list, and each
+    // row therein) but permit modifying each element
+    qcomp* const* const elems;
 
     // row-flattened elems in GPU memory, allocated only
     // in GPU-enabled QuEST environments (regardless of Quregs)
-    qcomp* gpuElems;
+    qcomp* const gpuElems;
 
 } CompMatrN;
 
@@ -84,38 +93,89 @@ typedef struct CompMatrN
 /*
  * EXPLICIT FIXED-SIZE MATRIX INITIALISERS
  *
- * which are exposed directly only to C++ because they are incompatile with C binaries
- * due to returning qcomp (or fixed size arrays thereof) by-value through their structs.
- * The incompatibility arises because C++'s' std::complex and C's complex.h type are
- * distinct in the application binary interface (ABI), so a C binary cannot directly call
- * a C++ function which receives/returns a std::complex and interpret it as a complex.h type.
- * Equivalent and identical (to the user) C-compatible definitions of below's functions are
- * defined in wrappers.h, and wrap alternate C definitions which pass/receive C++ complex
- * through pointers, rather than by value, which is fine because the C & C++ types have
- * the same memory layout.
+ * which are defined here in the header because the 'qcomp' type is interpreted
+ * distinctly by C++ (the backend) and C (user code). The C and C++ ABIs do not
+ * agree on a complex type, so a qcomp (to C; a _Complex, and to C++; a std::complex)
+ * cannot be directly passed between C and C++ compiled binaries; nor can a CompMatr1
+ * struct which unwraps the qcomp[][] array. However, the C and C++ complex types have 
+ * identical memory layouts, so pointers to qcomp types can safely be passed between
+ * C and C++ binaries. Ordinarily we leverage this by defining all qcomp-handling API
+ * functions in C++, and defining additional C-only wrappers in wrappers.h, which
+ * pass only pointers to qcomp.
+ * 
+ * Alas, we cannot use this trick for CompMatr, because they are declared 'const';
+ * we cannot modify them through pointers, nor should we try to address them. Ergo
+ * we directly define these functions below (static inline to avoid symbol duplication),
+ * initializing the const CompMatr in one line. The functions are separately interpreted 
+ * by the C and C++ compilers, resolving to their individual native types.
  */
 
 
-#ifdef __cplusplus
+static inline CompMatr1 getCompMatr1FromArr(qcomp in[2][2]) {
 
-    CompMatr1 getCompMatr1FromArr(qcomp in[2][2]);
-    CompMatr1 getCompMatr1FromPtr(qcomp** in);
+    return (CompMatr1) {
+        .numQubits = 1,
+        .numRows = 2,
+        .elems = {
+            {in[0][0], in[0][1]}, 
+            {in[1][0], in[1][1]}}
+    };
+}
 
-    CompMatr2 getCompMatr2FromArr(qcomp in[4][4]);
-    CompMatr2 getCompMatr2FromPtr(qcomp** in);
+static inline CompMatr1 getCompMatr1FromPtr(qcomp** in) {
 
-#endif
+    return (CompMatr1) {
+        .numQubits = 1,
+        .numRows = 2,
+        .elems = {
+            {in[0][0], in[0][1]}, 
+            {in[1][0], in[1][1]}}
+    };
+}
+
+
+static inline CompMatr2 getCompMatr2FromArr(qcomp in[4][4]) {
+
+    return (CompMatr2) {
+        .numQubits = 2,
+        .numRows = 4,
+        .elems = {
+            {in[0][0], in[0][1], in[0][2], in[0][3]},
+            {in[1][0], in[1][1], in[1][2], in[1][3]},
+            {in[2][0], in[2][1], in[2][2], in[2][3]},
+            {in[3][0], in[3][1], in[3][2], in[3][3]}}
+    };
+}
+
+static inline CompMatr2 getCompMatr2FromPtr(qcomp** in) {
+
+    return (CompMatr2) {
+        .numQubits = 2,
+        .numRows = 4,
+        .elems = {
+            {in[0][0], in[0][1], in[0][2], in[0][3]},
+            {in[1][0], in[1][1], in[1][2], in[1][3]},
+            {in[2][0], in[2][1], in[2][2], in[2][3]},
+            {in[3][0], in[3][1], in[3][2], in[3][3]}}
+    };
+}
 
 
 
 /*
  * OVERLOADED FIXED-SIZE MATRIX INITIALISERS
+ *
+ * which permit both C and C++ users to call getCompMatr1() and pass
+ * arrays or pointers, without having to call the above specialised
+ * functions. We are effectively using macros to extend C++'s
+ * overloaded API to C, though C++ users can additionally pass vectors.
  */
 
 
 #ifdef __cplusplus
 
-    // C++ uses overloads, accepting even vector initialiser lists
+    // C++ uses overloads, accepting even vector initialiser lists,
+    // which are defined in structures.cpp.
 
     CompMatr1 getCompMatr1(qcomp in[2][2]);
     CompMatr1 getCompMatr1(qcomp** in);
@@ -127,24 +187,38 @@ typedef struct CompMatrN
 
 #else
 
-    // C uses C11 compile-time type inspection, but literals must have compound syntax.
-    // Explicit qcomp[2][2] type isn't necessary because it decays to qcomp(*)[2].
-    // Use of __VA_ARGS__ is necessary to accept multiple-token compound literals.
-    // Sadly we cannot use _Generic 'default' to catch unrecognised types at compile time.
+    // C uses a header macro with C11 compile-time type inspection to expand
+    // (at compile-time, rather than during pre-processing) with one of
+    // the above inlined definitions. Note:
+    // - we cannot accept C++ vectors (duh) so direct {{...}} initialisation
+    //   isn't possible; users have to use C99 compound literals instead,
+    //   which we address with a subsequent definition of getInlineCompMatr().
+    // - the _Generic does not require a map for the qcomp[2][2] type, because
+    //   a passed qcomp[2][2] decays to qcomp(*)[2], indistinguishable from
+    //   an array of pointers which is already in the map.
+    // - we use __VA_ARGS__ to accept multiple-token compound literals,
+    //   i.e. C99 temporary arrays of syntax (qcomp[][]) {{...}}
+    // - we cannot use _Generic's 'default' to catch unrecognised types at compile
+    //   time (although that would be lovely) because we must expand _Generic to a 
+    //   function (not a macro; preprocessing is finished by the time _Generic
+    //   evaluates). Such a function could only throw an error at runtime, which is
+    //   worse than letting _Generic throw an error at compile-time.
 
-    // Using type qcomp(*) below would erroneously invoke the qcomp(re,im) macro.
+    // Another problem: type qcomp(*) below would erroneously invoke the qcomp(re,im) macro.
     // Preventing expansion using (qcomp)(*) leads to _Generic not recognising the type.
     // So, in desperation, we alias the type qcomp with a name that has no colliding macro.
     typedef qcomp qalias;
 
-    #define getCompMatr1(...) _Generic((__VA_ARGS__), \
-        qalias(*)[2] : getCompMatr1FromArr, \
-        qcomp**      : getCompMatr1FromPtr  \
+    #define getCompMatr1(...) \
+        _Generic((__VA_ARGS__), \
+            qalias(*)[2] : getCompMatr1FromArr, \
+            qcomp**      : getCompMatr1FromPtr  \
         )((__VA_ARGS__))
 
-    #define getCompMatr2(...) _Generic((__VA_ARGS__), \
-        qalias(*)[4] : getCompMatr2FromArr, \
-        qcomp**      : getCompMatr2FromPtr  \
+    #define getCompMatr2(...) \
+        _Generic((__VA_ARGS__), \
+            qalias(*)[4] : getCompMatr2FromArr, \
+            qcomp**      : getCompMatr2FromPtr  \
         )((__VA_ARGS__))
 
 #endif
@@ -266,18 +340,30 @@ extern "C" {
 
 #else
 
-    // C uses C11 compile-time type inspection, but literals must have compound syntax.
-    // Explicit qcomp[][] type isn't necessary because it decays to qcomp(*)[].
-    // Use of __VA_ARGS__ is necessary to accept multiple-token compound literals.
-    // Sadly we cannot use _Generic 'default' to catch unrecognised types at compile time.
+    // C uses a header macro with C11 compile-time type inspection to expand
+    // (at compile-time, rather than during pre-processing) with one of
+    // the above inlined definitions. Note:
+    // - we cannot accept C++ vectors (duh) so direct {{...}} initialisation
+    //   isn't possible; users have to use C99 compound literals instead,
+    //   which we address with a subsequent definition of setInlineCompMatrN().
+    // - the _Generic does not require a map for the qcomp[][] type, because
+    //   a passed qcomp[][] decays to qcomp(*)[], indistinguishable from
+    //   an array of pointers which is already in the map.
+    // - we use __VA_ARGS__ to accept multiple-token compound literals,
+    //   i.e. C99 temporary arrays of syntax (qcomp[][]) {{...}}
+    // - we cannot use _Generic's 'default' to catch unrecognised types at compile
+    //   time (although that would be lovely) because we must expand _Generic to a 
+    //   function (not a macro; preprocessing is finished by the time _Generic
+    //   evaluates). Such a function could only throw an error at runtime, which is
+    //   worse than letting _Generic throw an error at compile-time.
 
-    // Using type qcomp(*) below would erroneously invoke the qcomp(re,im) macro.
-    // Preventing expansion using (qcomp)(*) leads to _Generic not recognising the type.
-    // So, in desperation, we re-use the qcomp alias made by the previous _Generic use.
+    // Another problem: type qcomp(*) below would erroneously invoke the qcomp(re,im) macro,
+    // so we re-use 'qalias = qcomp' as defined at getCompMatr1.
 
-    #define setCompMatrN(matr, ...) _Generic((__VA_ARGS__),   \
-        qalias(*)[] : setCompMatrNFromArr, \
-        qcomp**     : setCompMatrNFromPtr  \
+    #define setCompMatrN(matr, ...) \
+        _Generic((__VA_ARGS__),   \
+            qalias(*)[] : setCompMatrNFromArr, \
+            qcomp**     : setCompMatrNFromPtr  \
         )((matr), (__VA_ARGS__))
 
 #endif
@@ -304,7 +390,7 @@ extern "C" {
 
     // C creates a compile-time-sized temporary array via a compound literal. We sadly
     // cannot use (qcomp[matr.numRows][matr.numRows]) to preclude passing 'numQb' 
-    // because VLAs cannot be initialised
+    // because VLAs cannot be initialised inline.
 
     #define setInlineCompMatrN(matr, numQb, ...) \
         setCompMatrNFromArr(matr, (qcomp[1<<numQb][1<<numQb]) __VA_ARGS__)

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -3,12 +3,18 @@
  * functions, ultimately providing an identical interface. This is 
  * necessary because these functions otherwise pass qcomps by-value
  * which is prohibited between C and C++ compiled binaries (because
- * complex numbers are not specified in the ABI, despite having 
+ * complex numbers are not agreed upon in their ABI, despite having 
  * identical memory layouts in the C and C++ standard libraries).
  * Ergo this file defines no new API functions as far as the user/
- * documentation is aware, but secretly ensures C binaries receive
- * qcomps from the C++ backend only by-reference. It must be used
- * by C compilers which otherwise lack the C++-only API signatures.
+ * documentation is aware, but secretly ensures the backend C++ 
+ * binaries are send qcomps from the user's C code only by pointer.
+ * 
+ * Note that CompMatr getters and setters (like getCompMatr1()) are
+ * missing from this file, even though they contain qcomp[2][2] (which
+ * are NOT pointers) and cannot be directly passed between binaries.
+ * Those functions are instead defined in structures.h/.cpp because
+ * those structs are declared 'const'; they must be intiailised inline, 
+ * and can never be modified by pointer. We shouldn't even address them!
  */
 
 #ifndef WRAPPERS_H
@@ -23,44 +29,18 @@
 
 
 
-void wrap_getCompMatr1FromArr(CompMatr1* out, qcomp in[2][2]);
-
-CompMatr1 getCompMatr1FromArr(qcomp in[2][2]) {
-
-    CompMatr1 out;
-    wrap_getCompMatr1FromArr(&out, in);
-    return out;
-}
-
-
-void wrap_getCompMatr1FromPtr(CompMatr1* out, qcomp** in);
-
-CompMatr1 getCompMatr1FromPtr(qcomp** in) {
-
-    CompMatr1 out;
-    wrap_getCompMatr1FromPtr(&out, in);
-    return out;
-}
-
-
-void wrap_getCompMatr2FromArr(CompMatr2* out, qcomp in[4][4]);
-
-CompMatr2 getCompMatr2FromArr(qcomp in[4][4]) {
-
-    CompMatr2 out;
-    wrap_getCompMatr2FromArr(&out, in);
-    return out;
-}
-
-
-void wrap_getCompMatr2FromPtr(CompMatr2* out, qcomp** in);
-
-CompMatr2 getCompMatr2FromPtr(qcomp** in) {
-
-    CompMatr2 out;
-    wrap_getCompMatr2FromPtr(&out, in);
-    return out;
-}
+// TODO:
+//      this file will contain wrappers of functions like C++'s 
+//          qcomp getAmp(Qureg, i);
+//      which will (for C users) be secretly invoking something like:
+//
+// void wrap_getAmp(Qureg qureg, qindex i, qcomp* amp); // defined by C++ backend
+//
+// void getAmp(Qureg qureg, qindex i) {
+//     qcomp amp;
+//     wrap_getAmp(qureg, i, &amp);
+//     return amp;
+// }
 
 
 

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -17,8 +17,9 @@
 #include "quest/src/gpu/gpu_config.hpp"
 
 #include <iostream>
-#include <string>
 #include <typeinfo>
+#include <cstring>
+#include <string>
 #include <thread>
 #include <vector>
 #include <tuple>

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -7,6 +7,7 @@
 #include "quest/include/precision.h"
 #include "quest/include/modes.h"
 
+#include "quest/src/core/errors.hpp"
 #include "quest/src/core/memory.hpp"
 #include "quest/src/core/formatter.hpp"
 #include "quest/src/core/autodeployer.hpp"
@@ -30,35 +31,32 @@ using namespace form_substrings;
 /*
  * PRIVATE QUESTENV SINGLETON
  *
- * Global to this file, immutably accessible to other files only through 
- * getQuESTEnv() which returns a copy. Users can inconsequentially 
- * mutate the struct returned by getQuESTEnv(), which I would prefer to 
- * forbid at compile-time; this could be achieved by foregoing the global
- * questEnv instance and instead messily storing each field globally,
- * instantiating a new const struct at each invocation of getQuESTEnv().
- * That improves the user experience, but spaghettifies this file.
+ * Global to this file, accessible to other files only through 
+ * getQuESTEnv() which returns a copy, which also has const fields.
  * The use of static ensures we never accidentally expose the "true"
- * runtime single instance to other files.
+ * runtime single instance to other files. We allocate the env
+ * in heap memory (hence the pointer) so that we can defer 
+ * initialisation of the const fields. The address being NULL
+ * indicates the QuESTEnv is not currently initialised; perhaps never,
+ * or it was but has since been finalized.
  */
 
 
-static QuESTEnv questEnv;
+static QuESTEnv* globalEnvPtr = NULL;
 
 
 
 /*
  * PRIVATE QUESTENV INITIALISATION HISTORY
  *
- * These respectively indicate whether the QuEST environment is 
- * currently active (i.e. has been initialised but not yet finalised),
- * and whether it has been finalised. This difference is important, since 
+ * indicating whether QuEST has ever been finalized. This is important, since 
  * the QuEST environment can only ever be initialised once, and can never
- * be re-initialised after finalisation.
+ * be re-initialised after finalisation, due to re-initialisation of MPI 
+ * being undefined behaviour.
  */
 
 
-static bool isQuESTInit  = false;
-static bool isQuESTFinal = false;
+static bool hasEnvBeenFinalized = false;
 
 
 
@@ -71,7 +69,7 @@ void validateAndInitCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMulti
 
     // ensure that we are never re-initialising QuEST (even after finalize) because
     // this leads to undefined behaviour in distributed mode, as per the MPI
-    validate_envNeverInit(isQuESTInit, isQuESTFinal, caller);
+    validate_envNeverInit(globalEnvPtr != NULL, hasEnvBeenFinalized, caller);
 
     // ensure the chosen deployment is compiled and supported by hardware.
     // note that these error messages will be printed by every node because
@@ -86,34 +84,33 @@ void validateAndInitCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMulti
     if (useGpuAccel && gpu_isCuQuantumCompiled())
         validate_gpuIsCuQuantumCompatible(caller);
 
-    // create a local env (so we don't modify global env in case of validation error,
-    // although this is pedantic and unimportant due to forbidden re-initialisation)
-    QuESTEnv env;
-
-    // bind deployment info to QuESTEnv (may be overwritten still below)
-    env.isDistributed = useDistrib;
-    env.isGpuAccelerated = useGpuAccel;
-    env.isMultithreaded = useMultithread;
-
-    // assume no distribution, then revise below
-    env.rank = 0;
-    env.numNodes = 1;
-
-    // initialise distribution (even for a single node), though we may subsequently error and finalize
-    if (useDistrib) {
+    // optionally initialise MPI; necessary before completing validation
+    if (useDistrib)
         comm_init();
-        env.rank = comm_getRank();
-        env.numNodes = comm_getNumNodes();
+
+    validate_newEnvDistributedBetweenPower2Nodes(caller);
+
+    if (useGpuAccel && useDistrib) {
+
+        // TODO:
+        // validate 2^N local GPUs
     }
 
-    // validates numNodes=2^N and otherwise calls comm_end() before throwing error
-    validate_newEnvDistributedBetweenPower2Nodes(env.numNodes, caller);
+    // make a new, local env
+    QuESTEnv env = {
 
-    // TODO:
-    // validate 2^N local GPUs
+        // bind deployment info
+        .isMultithreaded  = useMultithread,
+        .isGpuAccelerated = useGpuAccel,
+        .isDistributed    = useDistrib,
+
+        // set distributed info
+        .rank     = (useDistrib)? comm_getRank()     : 0,
+        .numNodes = (useDistrib)? comm_getNumNodes() : 1,
+    };
 
     // in multi-GPU settings, bind each MPI process to one GPU
-    if (useDistrib && useGpuAccel)
+    if (useGpuAccel && useDistrib)
         gpu_bindLocalGPUsToNodes(env.rank);
 
     // in GPU settings, if cuQuantum is being used, initialise it
@@ -122,11 +119,15 @@ void validateAndInitCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMulti
 
     // TODO: setup RNG
 
-    // overwrite attributes of the global env
-    questEnv = env;
+    // allocate space for the global QuESTEnv singleton (overwriting NULL, unless malloc fails)
+    globalEnvPtr = (QuESTEnv*) malloc(sizeof(QuESTEnv));
 
-    // declare successful initialisation
-    isQuESTInit = true;
+    // pedantically check that teeny tiny malloc just succeeded
+    if (globalEnvPtr == NULL)
+        error_allocOfQuESTEnvFailed();
+
+    // initialise it to our local env
+    memcpy(globalEnvPtr, &env, sizeof(QuESTEnv));
 }
 
 
@@ -165,13 +166,13 @@ void printCompilationInfo() {
 }
 
 
-void printDeploymentInfo(QuESTEnv env) {
+void printDeploymentInfo() {
 
     form_printTable(
         "deployment", {
-        {"isMpiEnabled", env.isDistributed},
-        {"isGpuEnabled", env.isGpuAccelerated},
-        {"isOmpEnabled", env.isMultithreaded},
+        {"isMpiEnabled", globalEnvPtr->isDistributed},
+        {"isGpuEnabled", globalEnvPtr->isGpuAccelerated},
+        {"isOmpEnabled", globalEnvPtr->isMultithreaded},
     });
 }
 
@@ -215,17 +216,20 @@ void printGpuInfo() {
 }
 
 
-void printDistributionInfo(QuESTEnv env) {
+void printDistributionInfo() {
 
     form_printTable(
         "distribution", {
         {"isMpiGpuAware", (comm_isMpiCompiled())? form_str(comm_isMpiGpuAware()) : na},
-        {"numMpiNodes",   form_str(env.numNodes)},
+        {"numMpiNodes",   form_str(globalEnvPtr->numNodes)},
     });
 }
 
 
-void printQuregSizeLimits(bool isDensMatr, QuESTEnv env) {
+void printQuregSizeLimits(bool isDensMatr) {
+
+    // for brevity
+    int numNodes = globalEnvPtr->numNodes;
 
     // by default, CPU limits are unknown (because memory query might fail)
     std::string maxQbForCpu = un;
@@ -237,8 +241,8 @@ void printQuregSizeLimits(bool isDensMatr, QuESTEnv env) {
         maxQbForCpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, 1, cpuMem));
 
         // and the max MPI sizes are only relevant when env is distributed
-        if (env.isDistributed)
-            maxQbForMpiCpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, env.numNodes, cpuMem));
+        if (globalEnvPtr->isDistributed)
+            maxQbForMpiCpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, numNodes, cpuMem));
 
         // when MPI irrelevant, change their status from "unknown" to "N/A"
         else
@@ -252,13 +256,13 @@ void printQuregSizeLimits(bool isDensMatr, QuESTEnv env) {
     std::string maxQbForMpiGpu = na;
 
     // max GPU registers only relevant if env is GPU-accelerated
-    if (env.isGpuAccelerated) {
+    if (globalEnvPtr->isGpuAccelerated) {
         qindex gpuMem = gpu_getCurrentAvailableMemoryInBytes();
         maxQbForGpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, 1, gpuMem));
 
         // and the max MPI sizes are further only relevant when env is distributed 
-        if (env.isDistributed)
-            maxQbForMpiGpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, env.numNodes, gpuMem));
+        if (globalEnvPtr->isDistributed)
+            maxQbForMpiGpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, numNodes, gpuMem));
     }
 
     // tailor table title to type of Qureg
@@ -267,18 +271,18 @@ void printQuregSizeLimits(bool isDensMatr, QuESTEnv env) {
 
     form_printTable(
         title, {
-        {"minQubitsForMpi",     (env.numNodes>1)? form_str(mem_getMinNumQubitsForDistribution(env.numNodes)) : na},
+        {"minQubitsForMpi",     (numNodes>1)? form_str(mem_getMinNumQubitsForDistribution(numNodes)) : na},
         {"maxQubitsForCpu",     maxQbForCpu},
         {"maxQubitsForGpu",     maxQbForGpu},
         {"maxQubitsForMpiCpu",  maxQbForMpiCpu},
         {"maxQubitsForMpiGpu",  maxQbForMpiGpu},
-        {"maxQubitsForMemOverflow", form_str(mem_getMaxNumQubitsBeforeLocalMemSizeofOverflow(isDensMatr, env.numNodes))},
+        {"maxQubitsForMemOverflow", form_str(mem_getMaxNumQubitsBeforeLocalMemSizeofOverflow(isDensMatr, numNodes))},
         {"maxQubitsForIndOverflow", form_str(mem_getMaxNumQubitsBeforeIndexOverflow(isDensMatr))},
     });
 }
 
 
-void printQuregAutoDeployments(bool isDensMatr, QuESTEnv env) {
+void printQuregAutoDeployments(bool isDensMatr) {
 
     // build all table rows dynamically before print
     std::vector<std::tuple<std::string, std::string>> rows;
@@ -294,7 +298,7 @@ void printQuregAutoDeployments(bool isDensMatr, QuESTEnv env) {
 
     // test to theoretically max #qubits, surpassing max that can fit in RAM and GPUs, because
     // auto-deploy will still try to deploy there to (then subsequent validation will fail)
-    int maxQubits = mem_getMaxNumQubitsBeforeLocalMemSizeofOverflow(isDensMatr, env.numNodes);
+    int maxQubits = mem_getMaxNumQubitsBeforeLocalMemSizeofOverflow(isDensMatr, globalEnvPtr->numNodes);
 
     for (int numQubits=1; numQubits<maxQubits; numQubits++) {
 
@@ -302,7 +306,7 @@ void printQuregAutoDeployments(bool isDensMatr, QuESTEnv env) {
         useDistrib  = modeflag::USE_AUTO;
         useGpuAccel = modeflag::USE_AUTO;
         useMulti    = modeflag::USE_AUTO;;
-        autodep_chooseQuregDeployment(numQubits, isDensMatr, useDistrib, useGpuAccel, useMulti, env);
+        autodep_chooseQuregDeployment(numQubits, isDensMatr, useDistrib, useGpuAccel, useMulti, *globalEnvPtr);
 
         // skip if deployments are unchanged
         if (useDistrib  == prevDistrib  &&
@@ -359,28 +363,33 @@ void initQuESTEnv() {
 
 int isQuESTEnvInit() {
 
-    return (int) isQuESTInit;
+    return (int) (globalEnvPtr != NULL);
 }
 
 
 QuESTEnv getQuESTEnv() {
     validate_envInit(__func__);
 
-    return questEnv;
+    // returns a copy, so cheeky users calling memcpy() upon const struct still won't mutate
+    return *globalEnvPtr;
 }
 
 
 void finalizeQuESTEnv() {
     validate_envInit(__func__);
 
-    if (questEnv.isGpuAccelerated && gpu_isCuQuantumCompiled())
+    if (globalEnvPtr->isGpuAccelerated && gpu_isCuQuantumCompiled())
         gpu_finalizeCuQuantum();
 
-    if (questEnv.isDistributed)
+    if (globalEnvPtr->isDistributed)
         comm_end();
 
-    isQuESTInit = false;
-    isQuESTFinal = true;
+    // free global env's heap memory and flag as not active
+    free(globalEnvPtr);
+    globalEnvPtr = NULL;
+
+    // flag that the environment was finalised, to ensure it is never re-initialised
+    hasEnvBeenFinalized = true;
 }
 
 
@@ -390,7 +399,7 @@ void reportQuESTEnv() {
     // TODO: add function to write this output to file (useful for HPC debugging)
 
     // only root node reports (but no synch necesary)
-    if (questEnv.rank != 0)
+    if (globalEnvPtr->rank != 0)
         return;
 
     std::cout << "QuEST execution environment:" << std::endl;
@@ -403,14 +412,14 @@ void reportQuESTEnv() {
     // making use of them, to inform the user how they might change deployment.
     printPrecisionInfo();
     printCompilationInfo();
-    printDeploymentInfo(questEnv);
+    printDeploymentInfo();
     printCpuInfo();
     printGpuInfo();
-    printDistributionInfo(questEnv);
-    printQuregSizeLimits(statevec, questEnv);
-    printQuregSizeLimits(densmatr, questEnv);
-    printQuregAutoDeployments(statevec, questEnv);
-    printQuregAutoDeployments(densmatr, questEnv);
+    printDistributionInfo();
+    printQuregSizeLimits(statevec);
+    printQuregSizeLimits(densmatr);
+    printQuregAutoDeployments(statevec);
+    printQuregAutoDeployments(densmatr);
 }
 
 

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -53,9 +53,9 @@ Qureg validateAndCreateCustomQureg(int numQubits, int isDensMatr, int useDistrib
     Qureg qureg = {
 
         // bind deployment info
+        .isMultithreaded  = useMultithread,
         .isGpuAccelerated = useGpuAccel,
         .isDistributed    = useDistrib,
-        .isMultithreaded  = useMultithread,
 
         // optionally bind distributed info, but always etain the env's rank because non-distributed
         // quregs are still duplicated between every node, and have duplicate processes
@@ -71,15 +71,15 @@ Qureg validateAndCreateCustomQureg(int numQubits, int isDensMatr, int useDistrib
             powerOf2(  numQubits),
 
         // set dimensions per node (even if not distributed)
-        .logNumAmpsPerNode = logNumAmpsPerNode,
         .numAmpsPerNode = powerOf2(logNumAmpsPerNode),
+        .logNumAmpsPerNode = logNumAmpsPerNode,
 
         // always allocate CPU memory
-        .cpuAmps = cpu_allocAmps(qureg.numAmpsPerNode), // NULL if faied
+        .cpuAmps = cpu_allocAmps(qureg.numAmpsPerNode), // NULL if failed
 
         // conditionally allocate GPU memory and communication buffers (even if numNodes == 1)
-        .cpuCommBuffer = (useDistrib)?                cpu_allocAmps(qureg.numAmpsPerNode) : NULL,
         .gpuAmps       = (useGpuAccel)?               gpu_allocAmps(qureg.numAmpsPerNode) : NULL,
+        .cpuCommBuffer = (useDistrib)?                cpu_allocAmps(qureg.numAmpsPerNode) : NULL,
         .gpuCommBuffer = (useGpuAccel && useDistrib)? gpu_allocAmps(qureg.numAmpsPerNode) : NULL,
     };
 

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -42,62 +42,46 @@ Qureg validateAndCreateCustomQureg(int numQubits, int isDensMatr, int useDistrib
     // throw error if the user had forced multithreading but GPU accel was auto-chosen
     validate_newQuregNotBothMultithreadedAndGpuAccel(useGpuAccel, useMultithread, caller);
 
-    // bind deployment configuration
-    Qureg qureg;
-    qureg.isGpuAccelerated = useGpuAccel;
-    qureg.isDistributed = useDistrib;
-    qureg.isMultithreaded = useMultithread;
+    // pre-prepare some struct fields (to avoid circular initialisation)
+    int logNumNodes = (useDistrib)? 
+        logBase2(env.numNodes) : 0;
+    qindex logNumAmpsPerNode = (isDensMatr)? 
+        (2*numQubits - logNumNodes) :
+        (  numQubits - logNumNodes);
 
-    // if distributed, inherit config from env
-    if (useDistrib) {
-        qureg.rank = env.rank;
-        qureg.numNodes = env.numNodes;
-        qureg.logNumNodes = logBase2(env.numNodes);
+    // const struct fields must be initialised inline
+    Qureg qureg = {
 
-    // otherwise set config to single node
-    } else {
-        qureg.numNodes = 1;
-        qureg.logNumNodes = 0;
+        // bind deployment info
+        .isGpuAccelerated = useGpuAccel,
+        .isDistributed    = useDistrib,
+        .isMultithreaded  = useMultithread,
 
-        // but still retain the env's potentially unique rank
-        // because non-distributed quregs are still duplicated
-        // between every node, and have duplicate processes.
-        qureg.rank = env.rank;
-    }
+        // optionally bind distributed info, but always etain the env's rank because non-distributed
+        // quregs are still duplicated between every node, and have duplicate processes
+        .rank        = env.rank,
+        .numNodes    = (useDistrib)? env.numNodes : 1,
+        .logNumNodes = (useDistrib)? logBase2(env.numNodes) : 0, // duplicated for clarity
 
-    // set dimension
-    qureg.isDensityMatrix = isDensMatr;
-    qureg.numQubits = numQubits;
-    qureg.numAmps = (isDensMatr)? 
-        powerOf2(2*numQubits) : 
-        powerOf2(  numQubits);
+        // set dimensions
+        .isDensityMatrix = isDensMatr,
+        .numQubits = numQubits,
+        .numAmps = (isDensMatr)? 
+            powerOf2(2*numQubits) : 
+            powerOf2(  numQubits),
 
-    // set dimension per node (even if not distributed)
-    qureg.logNumAmpsPerNode = (isDensMatr)? 
-        (2*numQubits - qureg.logNumNodes) :
-        (  numQubits - qureg.logNumNodes);
-    qureg.numAmpsPerNode = powerOf2(qureg.logNumAmpsPerNode);
+        // set dimensions per node (even if not distributed)
+        .logNumAmpsPerNode = logNumAmpsPerNode,
+        .numAmpsPerNode = powerOf2(logNumAmpsPerNode),
 
-    // pre-set all pointers to NULL so post-alloc validation can safely free or ignore
-    qureg.cpuAmps = NULL;
-    qureg.gpuAmps = NULL;
-    qureg.cpuCommBuffer = NULL;
-    qureg.gpuCommBuffer = NULL;
+        // always allocate CPU memory
+        .cpuAmps = cpu_allocAmps(qureg.numAmpsPerNode), // NULL if faied
 
-    // always allocate CPU memory
-    qureg.cpuAmps = cpu_allocAmps(qureg.numAmpsPerNode);
-
-    // conditionally allocate CPU communication buffer (even if numNodes == 1)
-    if (useDistrib)
-        qureg.cpuCommBuffer = cpu_allocAmps(qureg.numAmpsPerNode);
-
-    // conditionally allocate GPU memory
-    if (useGpuAccel)
-        qureg.gpuAmps = gpu_allocAmps(qureg.numAmpsPerNode);
-
-    // conditionally allocate GPU communication buffer
-    if (useGpuAccel && useDistrib)
-        qureg.gpuCommBuffer = gpu_allocAmps(qureg.numAmpsPerNode);
+        // conditionally allocate GPU memory and communication buffers (even if numNodes == 1)
+        .cpuCommBuffer = (useDistrib)?                cpu_allocAmps(qureg.numAmpsPerNode) : NULL,
+        .gpuAmps       = (useGpuAccel)?               gpu_allocAmps(qureg.numAmpsPerNode) : NULL,
+        .gpuCommBuffer = (useGpuAccel && useDistrib)? gpu_allocAmps(qureg.numAmpsPerNode) : NULL,
+    };
 
     // check all allocations succeeded (if any failed, validation frees all non-failures before throwing error)
     bool isNewQureg = true;
@@ -232,7 +216,7 @@ void destroyQureg(Qureg qureg) {
     if (qureg.isGpuAccelerated && qureg.isDistributed)
         gpu_deallocAmps(qureg.gpuCommBuffer);
 
-    // cannot set freed fields to NULL because qureg
+    // cannot set free'd fields to NULL because qureg
     // wasn't passed-by-reference, and isn't returned.
 }
 

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -57,6 +57,17 @@ void error_validationMessageContainedUnsubstitutedVars(std::string msg) {
 
 
 /*
+ * ENVIRONMENT ERRORS
+ */
+
+void error_allocOfQuESTEnvFailed() {
+
+    raiseInternalError("Attempted memory allocation for the newly created QuESTEnv unexpectedly failed.");
+}
+
+
+
+/*
  * MEMORY ERRORS
  */
 

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -28,6 +28,14 @@ void error_validationMessageContainedUnsubstitutedVars(std::string msg);
 
 
 /*
+ * ENVIRONMENT ERRORS
+ */
+
+void error_allocOfQuESTEnvFailed();
+
+
+
+/*
  * MEMORY ERRORS
  */
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -43,7 +43,11 @@ CompMatr2 util_getConj(CompMatr2 matrix) {
  * MATRIX UNITARITY
  */
 
-bool isUnitary(qcomp** matrix, qindex dim) {
+bool isUnitary(qcomp* const* const matrix, qindex dim) {
+
+    // matrix is simply qcomp** but inherits the consts
+    // from CompMatrN.elems, which protects changing
+    // the memory addresses but permits element change
 
     qreal epsSq = VALIDATION_EPSILON * VALIDATION_EPSILON;
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -43,7 +43,7 @@ CompMatr2 util_getConj(CompMatr2 matrix) {
  * MATRIX UNITARITY
  */
 
-bool isUnitary(qcomp* const* const matrix, qindex dim) {
+bool isUnitary(qcomp** matrix, qindex dim) {
 
     // matrix is simply qcomp** but inherits the consts
     // from CompMatrN.elems, which protects changing

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -387,15 +387,17 @@ void validate_newEnvDeploymentMode(int isDistrib, int isGpuAccel, int isMultithr
     // because that requires we first initialise MPI, which we wish the caller to explicitly perform
 }
 
-void validate_newEnvDistributedBetweenPower2Nodes(int numNodes, const char* caller) {
+void validate_newEnvDistributedBetweenPower2Nodes(const char* caller) {
 
     // note that we do NOT finalize MPI before erroring below, because that would necessitate
     // every node (launched by mpirun) serially print the error message, causing spam.
     // Instead, we permit the evil of every MPI process calling exit() and MPI aborting when
     // encountering the first non-zero exit code.
 
-    if (!isPowerOf2(numNodes))
-        assertThat(false, report::CANNOT_DISTRIB_ENV_BETWEEN_NON_POW_2_NODES, {{"${NUM_NODES}",numNodes}}, caller);
+    int numNodes = comm_getNumNodes(); // callable even when not distributed
+    tokenSubs vars = {{"${NUM_NODES}", numNodes}};
+
+    assertThat(isPowerOf2(numNodes), report::CANNOT_DISTRIB_ENV_BETWEEN_NON_POW_2_NODES, vars, caller);
 }
 
 void validate_gpuIsCuQuantumCompatible(const char* caller) {

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -22,7 +22,7 @@ void validate_envNeverInit(bool isQuESTInit, bool isQuESTFinal, const char* call
 
 void validate_newEnvDeploymentMode(int isDistrib, int isGpuAccel, int isMultithread, const char* caller);
 
-void validate_newEnvDistributedBetweenPower2Nodes(int numNodes, const char* caller);
+void validate_newEnvDistributedBetweenPower2Nodes(const char* caller);
 
 void validate_gpuIsCuQuantumCompatible(const char* caller);
 


### PR DESCRIPTION
to improve defensive design, preventing users from mangling `Qureg`, `QuESTEnv` or `CompMatr` fields (except, I guess, if they really insisted upon it using `memcpy`)