### PR TITLE
added DiagMatr

### DIFF
--- a/examples/matrices/initialisation.c
+++ b/examples/matrices/initialisation.c
@@ -2,6 +2,12 @@
 #include <stdlib.h>
 
 
+
+/*
+ * CompMatr
+ */
+
+
 void demo_getInlineCompMatr() {
 
     // inline literal without gross C compound-literal syntax
@@ -37,9 +43,9 @@ void demo_getCompMatr() {
 
     // nested pointers
     int dim = 4;
-    qcomp** ptrs = malloc(dim * sizeof(qcomp));
+    qcomp** ptrs = malloc(dim * sizeof *ptrs);
     for (int i=0; i<dim; i++) {
-        ptrs[i] = malloc(dim * sizeof(qcomp));
+        ptrs[i] = malloc(dim * sizeof **ptrs);
         for (int j=0; j<dim; j++)
             ptrs[i][j] = i + j*1i;
     }
@@ -108,9 +114,9 @@ void demo_setCompMatr() {
 
     // nested pointers
     int dim = 8;
-    qcomp** ptrs = malloc(dim * sizeof(qcomp));
+    qcomp** ptrs = malloc(dim * sizeof *ptrs);
     for (int i=0; i<dim; i++) {
-        ptrs[i] = malloc(dim * sizeof(qcomp));
+        ptrs[i] = malloc(dim * sizeof **ptrs);
         for (int j=0; j<dim; j++)
             ptrs[i][j] = i + j*1i;
     }
@@ -141,6 +147,120 @@ void demo_setCompMatr() {
 }
 
 
+
+/*
+ * DiagMatr
+ */
+
+
+void demo_getInlineDiagMatr() {
+
+    // inline literal without gross C compound-literal syntax
+    DiagMatr1 a = getInlineDiagMatr1({.1, .2});
+    reportDiagMatr1(a);
+
+    // unspecified elements default to 0 (C only)
+    DiagMatr2 b = getInlineDiagMatr2({1i});
+    reportDiagMatr2(b);
+}
+
+
+void demo_getDiagMatr() {
+
+    // compile-time array
+    qcomp arr[2] = {5,6};
+    DiagMatr1 a = getDiagMatr1(arr);
+    reportDiagMatr1(a);
+
+    // VLA (C only)
+    int len = 4;
+    qcomp elems[len];
+    elems[0] = .1;
+    elems[1] = 2i;
+    elems[2] = -.7i;
+    elems[3] = 1E-5;
+    DiagMatr1 b = getDiagMatr1(elems);
+    reportDiagMatr1(b);
+
+    // pointer
+    int dim = 4;
+    qcomp* ptr = malloc(dim * sizeof *ptr);
+    for (int i=0; i<dim; i++)
+        ptr[i] = i + 1i*i;
+    DiagMatr2 c = getDiagMatr2(ptr);
+    reportDiagMatr2(c);
+
+    // temporary array as compound literal (C only)
+    DiagMatr2 d = getDiagMatr2( (qcomp[4]) {5, 6, 8}); // defaults 0
+    reportDiagMatr2(d);
+
+    // cleanup
+    free(ptr);
+}
+
+
+void demo_setInlineDiagMatr() {
+
+    // inline literal without gross C compound-literal syntax
+    DiagMatr a = createDiagMatr(2);
+    setInlineDiagMatr(a, 2, {.7, .8, .9, .9});
+    reportDiagMatr(a);
+    destroyDiagMatr(a);
+
+    // unspecified elements default to 0 (C only)
+    DiagMatr b = createDiagMatr(3);
+    setInlineDiagMatr(b, 3, {1, 2, 3, 4, -1});
+    reportDiagMatr(b);
+    destroyDiagMatr(b);
+}
+
+
+void demo_setDiagMatr() {
+
+    // compile-time array passed to VLA arg (C only) 
+    qcomp arr[2] = {5, 4};
+    DiagMatr a = createDiagMatr(1);
+    setDiagMatr(a, arr);
+    reportDiagMatr(a);
+    destroyDiagMatr(a);
+
+    // VLA (C only)
+    int len = 2;
+    qcomp elems[len];
+    elems[0] = .1;
+    elems[1] = 2i;
+    DiagMatr b = createDiagMatr(1);
+    setDiagMatr(b, elems);
+    reportDiagMatr(b);
+    destroyDiagMatr(b);
+
+    // heap pointer
+    int dim = 1 << 3;
+    qcomp* ptr = malloc(dim * sizeof *ptr);
+    for (int i=0; i<dim; i++)
+        ptr[i] = i + 1i*i;
+    DiagMatr c = createDiagMatr(3);
+    setDiagMatr(c, ptr);
+    reportDiagMatr(c);
+    destroyDiagMatr(c);
+
+    // temporary array as compound literal (C only)
+    DiagMatr d = createDiagMatr(1);
+    setDiagMatr(d, (qcomp[2]) {9,8});
+    reportDiagMatr(d);
+    destroyDiagMatr(d);
+
+    // cleanup
+    free(ptr);
+}
+
+
+
+/*
+ * main
+ */
+
+
 int main() {
     
     initQuESTEnv();
@@ -149,6 +269,11 @@ int main() {
     demo_getCompMatr();
     demo_setInlineCompMatr();
     demo_setCompMatr();
+
+    demo_getInlineDiagMatr();
+    demo_getDiagMatr();
+    demo_setInlineDiagMatr();
+    demo_setDiagMatr();
 
     finalizeQuESTEnv();
     return 0;

--- a/examples/matrices/initialisation.cpp
+++ b/examples/matrices/initialisation.cpp
@@ -3,6 +3,12 @@
 #include <vector>
 
 
+
+/*
+ * CompMatr
+ */
+
+
 void demo_getInlineCompMatr() {
 
     // inline literal; identical to getCompMatr1() for consistencty with C API
@@ -38,9 +44,9 @@ void demo_getCompMatr() {
 
     // nested pointers
     int dim = 4;
-    qcomp** ptrs = (qcomp**) malloc(dim * sizeof(qcomp));
+    qcomp** ptrs = (qcomp**) malloc(dim * sizeof *ptrs);
     for (int i=0; i<dim; i++) {
-        ptrs[i] =(qcomp*) malloc(dim * sizeof(qcomp));
+        ptrs[i] =(qcomp*) malloc(dim * sizeof **ptrs);
         for (int j=0; j<dim; j++)
             ptrs[i][j] = i + j*1i;
     }
@@ -106,9 +112,9 @@ void demo_setCompMatr() {
 
     // nested pointers
     int dim = 8;
-    qcomp** ptrs = (qcomp**) malloc(dim * sizeof(qcomp));
+    qcomp** ptrs = (qcomp**) malloc(dim * sizeof *ptrs);
     for (int i=0; i<dim; i++) {
-        ptrs[i] = (qcomp*) malloc(dim * sizeof(qcomp));
+        ptrs[i] = (qcomp*) malloc(dim * sizeof **ptrs);
         for (int j=0; j<dim; j++)
             ptrs[i][j] = i + j*1i;
     }
@@ -133,6 +139,102 @@ void demo_setCompMatr() {
 }
 
 
+
+/*
+ * DiagMatr
+ */
+
+void demo_getInlineDiagMatr() {
+
+    // inline literal; identical to getDiagMatr1() for consistencty with C API
+    DiagMatr1 a = getInlineDiagMatr1( {9,8} );
+    reportDiagMatr1(a);
+
+    // we must specify all elements (only necessary in C++)
+    DiagMatr2 b = getInlineDiagMatr2({1i, 2i, 9i, 8i});
+    reportDiagMatr2(b);
+}
+
+
+void demo_getDiagMatr() {
+
+    // inline literal (C++ only)
+    DiagMatr1 a = getDiagMatr1({-5i, -10i});
+    reportDiagMatr1(a);
+
+    // vector (C++ only)
+    std::vector<qcomp> vec {20i, 30i};
+    DiagMatr1 b = getDiagMatr1(vec);
+    reportDiagMatr1(b);
+
+    // compile-time array
+    qcomp arr[4] = {7i, 8i, 8, 7};
+    DiagMatr1 c = getDiagMatr1(arr);
+    reportDiagMatr1(c);
+
+    // heap pointer
+    int dim = 4;
+    qcomp* ptr = (qcomp*) malloc(dim * sizeof *ptr);
+    for (int i=0; i<dim; i++)
+        ptr[i] = 10i*i;
+    DiagMatr2 d = getDiagMatr2(ptr);
+    reportDiagMatr2(d);
+
+    // cleanup
+    free(ptr);
+}
+
+
+void demo_setInlineDiagMatr() {
+
+    // inline literal; identical to setDiagMatr() for consistencty with C API
+    DiagMatr a = createDiagMatr(1);
+    setInlineDiagMatr(a, 1, {333, 444});
+    reportDiagMatr(a);
+    destroyDiagMatr(a);
+
+    // we must specify all elements (only necessary in C++)
+    DiagMatr b = createDiagMatr(3);
+    setInlineDiagMatr(b, 3, {4,5,4,5,6,7,6,7i});
+    reportDiagMatr(b);
+    destroyDiagMatr(b);
+}
+
+
+void demo_setDiagMatr() {
+
+    // inline literal (C++ only)
+    DiagMatr a = createDiagMatr(1);
+    setDiagMatr(a, {6i,5i});
+    reportDiagMatr(a);
+
+    // vector (C++ only)
+    std::vector<qcomp> vec {11, 22, 33, 44};
+    DiagMatr b = createDiagMatr(2);
+    setDiagMatr(b, vec);
+    reportDiagMatr(b);
+
+    // heap pointer
+    int dim = 8;
+    qcomp* ptr = (qcomp*) malloc(dim * sizeof *ptr);
+    for (int i=0; i<dim; i++)
+        ptr[i] = -i*.5i;
+    DiagMatr c = createDiagMatr(3);
+    setDiagMatr(c, ptr);
+    reportDiagMatr(c);
+    destroyDiagMatr(c);
+
+    // cleanup
+    free(ptr);
+}
+
+
+
+/*
+ * main
+ */
+
+
 int main() {
     
     initQuESTEnv();
@@ -141,6 +243,11 @@ int main() {
     demo_getCompMatr();
     demo_setInlineCompMatr();
     demo_setCompMatr();
+
+    demo_getInlineDiagMatr();
+    demo_getDiagMatr();
+    demo_setInlineDiagMatr();
+    demo_setDiagMatr();
 
     finalizeQuESTEnv();
     return 0;

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -190,9 +190,9 @@ void error_gpuCopyButQuregNotGpuAccelerated() {
     raiseInternalError("A function attempted to access GPU memory of a Qureg which is not GPU accelerated.");
 }
 
-void error_gpuCopyButCompMatrNotGpuAccelerated() {
+void error_gpuCopyButMatrixNotGpuAccelerated() {
 
-    raiseInternalError("A function attempted to access GPU memory of a CompMatr which is not GPU accelerated.");
+    raiseInternalError("A function attempted to access GPU memory of a matrix (e.g. a CompMatr or DiagMatr) which is not GPU accelerated.");
 }
 
 void error_gpuUnexpectedlyInaccessible() {

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -94,7 +94,7 @@ void error_gpuSimButGpuNotCompiled();
 
 void error_gpuCopyButQuregNotGpuAccelerated();
 
-void error_gpuCopyButCompMatrNotGpuAccelerated();
+void error_gpuCopyButMatrixNotGpuAccelerated();
 
 void error_gpuMemSyncQueriedButEnvNotGpuAccelerated();
 

--- a/quest/src/core/formatter.hpp
+++ b/quest/src/core/formatter.hpp
@@ -73,14 +73,31 @@ namespace form_substrings {
 
 
 /*
+ * DEFAULT INDENTS OF PRINTERS
+ *
+ * which doesn't need to be publicly accessible but we want them as
+ * default arguments to the public signatures, so whatever. Declared
+ * static to avoid symbol duplication by repeated header inclusion.
+ */
+
+static std::string defaultMatrIndent  = "    ";
+static std::string defaultTableIndent = "  ";
+
+
+
+/*
  * MATRIX PRINTING
  */
 
-void form_printMatrix(CompMatr1 matr, std::string indent="    ");
+void form_printMatrixInfo(std::string nameStr, int numQubits, qindex dim, size_t elemMem, size_t otherMem);
 
-void form_printMatrix(CompMatr2 matr, std::string indent="    ");
+void form_printMatrix(CompMatr1 matr, std::string indent=defaultMatrIndent);
+void form_printMatrix(CompMatr2 matr, std::string indent=defaultMatrIndent);
+void form_printMatrix(CompMatr  matr, std::string indent=defaultMatrIndent);
 
-void form_printMatrix(CompMatr matr, std::string indent="    ");
+void form_printMatrix(DiagMatr1 matr, std::string indent=defaultMatrIndent);
+void form_printMatrix(DiagMatr2 matr, std::string indent=defaultMatrIndent);
+void form_printMatrix(DiagMatr  matr, std::string indent=defaultMatrIndent);
 
 
 
@@ -88,9 +105,8 @@ void form_printMatrix(CompMatr matr, std::string indent="    ");
  * TABLE PRINTING
  */
 
-void form_printTable(std::string title, std::vector<std::tuple<std::string, std::string>> rows, std::string indent="  ");
-
-void form_printTable(std::string title, std::vector<std::tuple<std::string, long long int>> rows, std::string indent="  ");
+void form_printTable(std::string title, std::vector<std::tuple<std::string, std::string>>   rows, std::string indent=defaultTableIndent);
+void form_printTable(std::string title, std::vector<std::tuple<std::string, long long int>> rows, std::string indent=defaultTableIndent);
 
 
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -7,6 +7,9 @@
 #include "quest/include/structures.h"
 
 #include "quest/src/core/errors.hpp"
+#include "quest/src/core/utilities.hpp"
+
+#include <complex>
 
 
 
@@ -14,27 +17,47 @@
  * MATRIX CONJUGATION
  */
 
+// type T can be qcomp** or qcomp*[]
 template <typename T>
-void setElemsConj(T& matrix) {
-    for (qindex i=0; i<matrix.numRows; i++)
-        for (qindex j=0; j<matrix.numRows; j++)
-            matrix.elems[i][j] = conj(matrix.elems[i][j]);
+void setDenseElemsConj(T elems, qindex dim) {
+    for (qindex i=0; i<dim; i++)
+        for (qindex j=0; j<dim; j++)
+           elems[i][j] = conj(elems[i][j]);
 }
 
-void util_setConj(CompMatr matrix) {
-    setElemsConj(matrix);
+// diagonals don't need templating because arrays decay to pointers, yay!
+void setDiagElemsConj(qcomp* elems, qindex dim) {
+    for (qindex i=0; i<dim; i++)
+        elems[i] = conj(elems[i]);
 }
 
 CompMatr1 util_getConj(CompMatr1 matrix) {
     CompMatr1 conj = matrix;
-    setElemsConj(conj);
+    setDenseElemsConj(conj.elems, matrix.numRows);
+    return conj;
+}
+CompMatr2 util_getConj(CompMatr2 matrix) {
+    CompMatr2 conj = matrix;
+    setDenseElemsConj(conj.elems, matrix.numRows);
     return conj;
 }
 
-CompMatr2 util_getConj(CompMatr2 matrix) {
-    CompMatr2 conj = matrix;
-    setElemsConj(conj);
+DiagMatr1 util_getConj(DiagMatr1 matrix) {
+    DiagMatr1 conj = matrix;
+    setDiagElemsConj(conj.elems, matrix.numElems);
     return conj;
+}
+DiagMatr2 util_getConj(DiagMatr2 matrix) {
+    DiagMatr2 conj = matrix;
+    setDiagElemsConj(conj.elems, matrix.numElems);
+    return conj;
+}
+
+void util_setConj(CompMatr matrix) {
+    setDenseElemsConj(matrix.cpuElems, matrix.numRows);
+}
+void util_setConj(DiagMatr matrix) {
+    setDiagElemsConj(matrix.cpuElems, matrix.numElems);
 }
 
 
@@ -43,11 +66,9 @@ CompMatr2 util_getConj(CompMatr2 matrix) {
  * MATRIX UNITARITY
  */
 
-bool isUnitary(qcomp** matrix, qindex dim) {
-
-    // matrix is simply qcomp** but inherits the consts
-    // from CompMatr.elems, which protects changing
-    // the memory addresses but permits element change
+// type T can be qcomp** or qcomp*[]
+template <typename T>
+bool isUnitary(T elems, qindex dim) {
 
     qreal epsSq = VALIDATION_EPSILON * VALIDATION_EPSILON;
 
@@ -58,7 +79,7 @@ bool isUnitary(qcomp** matrix, qindex dim) {
             // compute m[r,...] * dagger(m)[...,c]
             qcomp elem = 0;
             for (qindex i=0; i<dim; i++)
-                elem += matrix[r][i] * conj(matrix[c][i]);
+                elem += elems[r][i] * conj(elems[c][i]);
 
             // check if further than epsilon from identity[r,c]
             qcomp dif = elem - qcomp(r == c, 0);
@@ -71,31 +92,39 @@ bool isUnitary(qcomp** matrix, qindex dim) {
     return true;
 }
 
+// diagonal version doesn't need templating because array decays to pointer, yay!
+bool isUnitary(qcomp* diags, qindex dim) {
+
+    // check every element has unit magnitude
+    for (qindex i=0; i<dim; i++) {
+        qreal mag = std::abs(diags[i]);
+        qreal dif = std::abs(1 - mag);
+
+        if (dif > VALIDATION_EPSILON)
+            return false;
+    }
+
+    return true;
+}
+
 bool util_isUnitary(CompMatr1 matrix) {
-
-    qcomp* ptrs[] = {
-        matrix.elems[0], 
-        matrix.elems[1]
-    };
-
-    return isUnitary(ptrs, matrix.numRows);
-}
-
-bool util_isUnitary(CompMatr2 matrix) {
-
-    qcomp* ptrs[] = {
-        matrix.elems[0], 
-        matrix.elems[1], 
-        matrix.elems[2], 
-        matrix.elems[3]
-    };
-
-    return isUnitary(ptrs, matrix.numRows);
-}
-
-bool util_isUnitary(CompMatr matrix) {
-
     return isUnitary(matrix.elems, matrix.numRows);
+}
+bool util_isUnitary(CompMatr2 matrix) {
+    return isUnitary(matrix.elems, matrix.numRows);
+}
+bool util_isUnitary(CompMatr matrix) {
+    return isUnitary(matrix.cpuElems, matrix.numRows);
+}
+
+bool util_isUnitary(DiagMatr1 matrix) {
+    return isUnitary(matrix.elems, matrix.numElems);
+}
+bool util_isUnitary(DiagMatr2 matrix) {
+    return isUnitary(matrix.elems, matrix.numElems);
+}
+bool util_isUnitary(DiagMatr matrix) {
+    return isUnitary(matrix.cpuElems, matrix.numElems);
 }
 
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -11,17 +11,76 @@
 
 #include "quest/src/core/errors.hpp"
 
+#include <type_traits>
+
+
+
+/*
+ * MATRIX TYPING
+ *
+ * defined here in the header since templated, and which use compile-time inspection
+ */
+
+// T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr
+template<class T>
+constexpr bool isDenseMatrixType() {
+
+    // CompMatr are "dense", storing all 2D elements
+    if constexpr (
+        std::is_same_v<T, CompMatr1> ||
+        std::is_same_v<T, CompMatr2> ||
+        std::is_same_v<T, CompMatr>
+    )
+        return true;
+
+    // DiagMatr are "sparse", storing only the diagonals
+    if constexpr (
+        std::is_same_v<T, DiagMatr1> ||
+        std::is_same_v<T, DiagMatr2> ||
+        std::is_same_v<T, DiagMatr>
+    )
+        return false;
+
+    // this line is unreachable but throwing errors in a template expansion is ludicrous;
+    // above type checks are explicit in case we add more matrix types later
+    return false;
+}
+
+// T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr
+template<class T>
+constexpr bool isFixedSizeMatrixType() {
+
+    return (
+        std::is_same_v<T, CompMatr1> ||
+        std::is_same_v<T, CompMatr2> ||
+        std::is_same_v<T, DiagMatr1> ||
+        std::is_same_v<T, DiagMatr2>
+    );
+}
+
+// T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr
+template<class T>
+constexpr qindex getMatrixDim(T matr) {
+    
+    if constexpr (isDenseMatrixType<T>())
+        return matr.numRows;
+    else
+        return matr.numElems;
+}
+
 
 
 /*
  * MATRIX CONJUGATION
  */
 
-void util_setConj(CompMatr matrix);
-
 CompMatr1 util_getConj(CompMatr1 matrix);
-
 CompMatr2 util_getConj(CompMatr2 matrix);
+DiagMatr1 util_getConj(DiagMatr1 matrix);
+DiagMatr2 util_getConj(DiagMatr2 matrix);
+
+void util_setConj(CompMatr matrix);
+void util_setConj(DiagMatr matrix);
 
 
 
@@ -30,10 +89,11 @@ CompMatr2 util_getConj(CompMatr2 matrix);
  */
 
 bool util_isUnitary(CompMatr1 matrix);
-
 bool util_isUnitary(CompMatr2 matrix);
-
 bool util_isUnitary(CompMatr matrix);
+bool util_isUnitary(DiagMatr1 matrix);
+bool util_isUnitary(DiagMatr2 matrix);
+bool util_isUnitary(DiagMatr matrix);
 
 
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -183,36 +183,23 @@ namespace report {
      * MATRIX CREATION
      */
 
-    std::string NON_POSITIVE_NUM_QUBITS_IN_NEW_MATRIX = 
+    std::string NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE = 
         "Cannot create a matrix which acts upon ${NUM_QUBITS} qubits; must target one or more qubits.";
 
     std::string NEW_MATRIX_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
         "Cannot create a matrix which acts upon ${NUM_QUBITS} qubits since the necessary memory size (${QCOMP_BYTES} * 2^${DUB_QUBITS} bytes) would overflow size_t, and be intractably slow to serially process. The maximum size matrix targets ${MAX_QUBITS} qubits.";
 
-    std::string FAILED_NEW_CPU_ALLOC_OF_COMPLEX_MATRIX =
-        "Allocation of memory for a new ComplexMatrixN failed.";
 
-    std::string FAILED_NEW_GPU_ALLOC_OF_COMPLEX_MATRIX =
-        "Allocation of GPU memory for a new ComplexMatrixN failed.";
+    std::string NEW_MATRIX_CPU_ALLOC_FAILED = 
+        "Attempted allocation of memory (${NUM_BYTES} bytes in RAM) failed.";
+
+    std::string NEW_MATRIX_GPU_ALLOC_FAILED = 
+        "Attempted allocation of GPU memory (${NUM_BYTES} bytes in VRAM) failed.";
 
 
     /*
      * EXISTING MATRIX
      */
-
-    std::string INVALID_EXISTING_CPU_ALLOC_OF_COMPLEX_MATRIX =
-        "Invalid CompMatr. One or more rows of the 2D elements array was seemingly unallocated.";
-
-    std::string INVALID_EXISTING_GPU_ALLOC_OF_COMPLEX_MATRIX =
-        "Invalid CompMatr. The GPU memory was seemingly unallocated.";
-
-
-    std::string COMPLEX_MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
-        "The CompMatr contained a reserved, forbidden value as the first element, used internally to detect that whether GPU memory has not synchronised. The value was intended to be extremely unlikely to be used by users - go buy a lottery ticket! If you insist on using this value in the first element, add a numerically insignificant perturbation.";
-
-    std::string COMPLEX_MATRIX_NOT_SYNCED_TO_GPU = 
-        "The CompMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncCompMatr() after manually modifying elements, or overwrite all elements with setCompMatr().";
-
 
     std::string INVALID_COMP_MATR_1_FIELDS =
         "Invalid CompMatr1. Targeted ${NUM_QUBITS} qubits (instead of 1) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 2x2). It is likely this matrix was not initialised with getCompMatr1().";
@@ -220,19 +207,54 @@ namespace report {
     std::string INVALID_COMP_MATR_2_FIELDS =
         "Invalid CompMatr2. Targeted ${NUM_QUBITS} qubits (instead of 2) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 4x4). It is likely this matrix was not initialised with getCompMatr2().";
 
-    std::string INVALID_COMP_MATR_N_FIELDS =
-        "Invalid CompMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not initialised with createCompMatr().";
+    std::string INVALID_COMP_MATR_FIELDS =
+        "Invalid CompMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createCompMatr().";
+
+    std::string INVALID_COMP_MATR_CPU_MEM_ALLOC =
+        "Invalid CompMatr. One or more rows of the 2D CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createCompMatr().";
+
+    std::string INVALID_COMP_MATR_GPU_MEM_ALLOC =
+        "Invalid CompMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createCompMatr().";
 
 
-    std::string COMPLEX_MATRIX_NEW_ELEMS_WRONG_NUM_ROWS =
+    std::string INVALID_DIAG_MATR_1_FIELDS =
+        "Invalid DiagMatr1. Targeted ${NUM_QUBITS} qubits (instead of 1) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 2x2). It is likely this matrix was not initialised with getDiagMatr1().";
+
+    std::string INVALID_DIAG_MATR_2_FIELDS =
+        "Invalid DiagMatr2. Targeted ${NUM_QUBITS} qubits (instead of 2) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 4x4). It is likely this matrix was not initialised with getDiagMatr2().";
+
+    std::string INVALID_DIAG_MATR_FIELDS =
+        "Invalid DiagMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createDiagMatr().";
+
+    std::string INVALID_DIAG_MATR_CPU_MEM_ALLOC =
+        "Invalid DiagMatr. The CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
+
+    std::string INVALID_DIAG_MATR_GPU_MEM_ALLOC =
+        "Invalid DiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
+
+
+    std::string MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
+        "The new elements contained a reserved, forbidden value as the first element, used internally to detect that whether GPU memory has not synchronised. The value was intended to be extremely unlikely to be used by users - go buy a lottery ticket! If you insist on using this value in the first element, add a numerically insignificant perturbation.";
+
+    std::string COMP_MATR_NOT_SYNCED_TO_GPU = 
+        "The CompMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncCompMatr() after manually modifying elements, or overwrite all elements with setCompMatr().";
+
+    std::string DIAG_MATR_NOT_SYNCED_TO_GPU = 
+        "The DiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncDiagMatr() after manually modifying elements, or overwrite all elements with setDiagMatr().";
+
+
+    std::string COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS =
         "Incompatible number of rows (${NUM_GIVEN_ROWS}) of elements given to overwrite a ${NUM_QUBITS}-qubit CompMatr, which expects ${NUM_EXPECTED_ROWS} rows.";
 
-    std::string COMPLEX_MATRIX_NEW_ELEMS_WRONG_ROW_DIM =
-        "One or more rows contained an incompatible number of elements (${NUM_GIVEN_ELEMS}). The ${NUM_QUBITS}-qubit CompMatr expects a ${EXPECTED_DIM}x${EXPECTED_DIM} matrix.";
+    std::string COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM =
+        "One or more rows contained an incompatible number of elements (${NUM_GIVEN_ELEMS}). The ${NUM_QUBITS}-qubit CompMatr expects a square ${EXPECTED_DIM}x${EXPECTED_DIM} matrix.";
 
+    std::string DIAG_MATR_WRONG_NUM_NEW_ELEMS = 
+        "Incompatible number of elements (${NUM_GIVEN_ELEMS}) assigned to a ${NUM_QUBITS}-qubit DiagMatr, which expects ${NUM_EXPECTED_ELEMS} elements.";
+    
 
     std::string MATRIX_NOT_UNITARY = 
-        "The given complex matrix was not (approximately) unitary.";
+        "The given matrix was not (approximately) unitary.";
 
 
     /*
@@ -720,64 +742,103 @@ void assertNewMatrixNotTooBig(int numQubits, const char* caller) {
 
 void validate_newMatrixNumQubits(int numQubits, const char* caller) {
 
-    assertThat(numQubits >= 1, report::NON_POSITIVE_NUM_QUBITS_IN_NEW_MATRIX, caller);
+    assertThat(numQubits >= 1, report::NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE, caller);
     assertNewMatrixNotTooBig(numQubits, caller);
 }
 
-void validate_newOrExistingMatrixAllocs(CompMatr matr, bool isNewMatr, const char* caller) {
-
-    std::string cpuErrMsg = (isNewMatr)? 
-        report::FAILED_NEW_CPU_ALLOC_OF_COMPLEX_MATRIX :
-        report::INVALID_EXISTING_CPU_ALLOC_OF_COMPLEX_MATRIX;
+void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller) {
+    tokenSubs vars = {{"${NUM_BYTES}", numBytes}};
 
     // assert CPU array of rows was malloc'd successfully
-    assertThat(matr.elems != NULL, cpuErrMsg, caller);
+    assertThat(matr.cpuElems != NULL, report::NEW_MATRIX_CPU_ALLOC_FAILED, vars, caller);
 
-    // assert each CPU row was calloc'd successfully. this is flawed;
-    // .elems will be non-NULL when matr was default initialised (not constructed),
-    // passing validation and causing a segmentation fault in below loop. oh well!
+    // assert each CPU row was calloc'd successfully
     for (qindex r=0; r<matr.numRows; r++)
-        assertThat(matr.elems[r] != NULL, cpuErrMsg, caller);
-
-    std::string gpuErrMsg = (isNewMatr)? 
-        report::FAILED_NEW_GPU_ALLOC_OF_COMPLEX_MATRIX :
-        report::INVALID_EXISTING_GPU_ALLOC_OF_COMPLEX_MATRIX;
-
-    // assert GPU memory was malloc'd successfully
+        assertThat(matr.cpuElems[r] != NULL, report::NEW_MATRIX_CPU_ALLOC_FAILED, vars, caller);
+    
+    // optionally assert GPU memory was malloc'd successfully
     if (getQuESTEnv().isGpuAccelerated)
-        assertThat(matr.gpuElems != NULL, gpuErrMsg, caller);
+        assertThat(matr.gpuElems != NULL, report::NEW_MATRIX_GPU_ALLOC_FAILED, vars, caller);
 }
+
+void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller) {
+    tokenSubs vars = {{"${NUM_BYTES}", numBytes}};
+
+    // assert CPU array of rows was malloc'd successfully
+    assertThat(matr.cpuElems != NULL, report::NEW_MATRIX_CPU_ALLOC_FAILED, vars, caller);
+
+    // optionally assert GPU memory was malloc'd successfully
+    if (getQuESTEnv().isGpuAccelerated)
+        assertThat(matr.gpuElems != NULL, report::NEW_MATRIX_GPU_ALLOC_FAILED, vars, caller);
+}
+
 
 
 /*
  * EXISTING MATRICES
  */
 
+// T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr
 template <class T>
-void assertMatrixFieldsAreValid(T matr, std::string errMsg, const char* caller) {
+void assertMatrixFieldsAreValid(T matr, int expectedNumQb, std::string errMsg, const char* caller) {
 
+    qindex dim = getMatrixDim(matr);
     tokenSubs vars = {
         {"${NUM_QUBITS}", matr.numQubits},
-        {"${NUM_ROWS}",   matr.numRows}};
+        {"${NUM_ROWS}",   dim}};
 
-    bool validDims = (matr.numQubits >= 1) && (matr.numRows == powerOf2(matr.numQubits));
-    assertThat(validDims, errMsg, vars, caller);
+    // assert correct fixed-size numQubits (caller gaurantees this passes for dynamic-size),
+    // where the error message string already contains the expected numQb
+    assertThat(matr.numQubits == expectedNumQb, errMsg, vars, caller);
+
+    qindex expectedDim = powerOf2(matr.numQubits);
+    assertThat(matr.numQubits >= 1, errMsg, vars, caller);
+    assertThat(dim == expectedDim,  errMsg, vars, caller);
 }
 
-void validate_matrixInit(CompMatr1 matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, report::INVALID_COMP_MATR_1_FIELDS, caller);
-}
-void validate_matrixInit(CompMatr2 matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, report::INVALID_COMP_MATR_2_FIELDS, caller);
-}
-void validate_matrixInit(CompMatr matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, report::INVALID_COMP_MATR_N_FIELDS, caller);
+// T can be CompMatr or DiagMatr (the only matrix structs with pointers)
+template <class T>
+void assertMatrixAllocsAreValid(T matr, std::string cpuErrMsg, std::string gpuErrMsg, const char* caller) {
 
-    // CompMatr must also have its allocations checked
-    validate_newOrExistingMatrixAllocs(matr, false, caller);
+    // assert CPU memory is allocated
+    assertThat(matr.cpuElems != NULL, cpuErrMsg, caller);
+
+    // we do not check that each CPU memory row (of CompMatr; irrelevant to DiagMatr)
+    // is not-NULL because it's really unlikely that inner memory wasn't allocaed but
+    // outer was and this wasn't somehow caught by post-creation validation (i.e. the 
+    // user manually malloc'd memory after somehow getting around const fields). Further,
+    // since this function is called many times (i.e. each time the user passes a matrix
+    // to a simulation function like multiQubitUnitary()), it may be inefficient to 
+    // serially process each row pointer.
+
+    // optionally assert GPU memory is allocated
+    if (getQuESTEnv().isGpuAccelerated)
+        assertThat(matr.gpuElems != NULL, gpuErrMsg, caller);
 }
 
-void validate_numMatrixElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller) {
+void validate_matrixFields(CompMatr1 matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, 1, report::INVALID_COMP_MATR_1_FIELDS, caller);
+}
+void validate_matrixFields(CompMatr2 matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, 2, report::INVALID_COMP_MATR_2_FIELDS, caller);
+}
+void validate_matrixFields(CompMatr matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_COMP_MATR_FIELDS, caller);
+    assertMatrixAllocsAreValid(matr, report::INVALID_COMP_MATR_CPU_MEM_ALLOC, report::INVALID_COMP_MATR_GPU_MEM_ALLOC, caller);
+}
+
+void validate_matrixFields(DiagMatr1 matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, 1, report::INVALID_DIAG_MATR_1_FIELDS, caller);
+}
+void validate_matrixFields(DiagMatr2 matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, 2, report::INVALID_DIAG_MATR_2_FIELDS, caller);
+}
+void validate_matrixFields(DiagMatr matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_DIAG_MATR_FIELDS, caller);
+    assertMatrixAllocsAreValid(matr, report::INVALID_DIAG_MATR_CPU_MEM_ALLOC, report::INVALID_DIAG_MATR_GPU_MEM_ALLOC, caller);
+}
+
+void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller) {
 
     qindex dim = powerOf2(numQubits);
     tokenSubs vars = {
@@ -785,7 +846,7 @@ void validate_numMatrixElems(int numQubits, std::vector<std::vector<qcomp>> elem
         {"${NUM_EXPECTED_ROWS}", dim},
         {"${NUM_GIVEN_ROWS}",    elems.size()}};
 
-    assertThat(elems.size() == dim, report::COMPLEX_MATRIX_NEW_ELEMS_WRONG_NUM_ROWS, vars, caller);
+    assertThat(elems.size() == dim, report::COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS, vars, caller);
 
     for(auto & row : elems) {
 
@@ -794,33 +855,46 @@ void validate_numMatrixElems(int numQubits, std::vector<std::vector<qcomp>> elem
             {"${EXPECTED_DIM}",    dim},
             {"${NUM_GIVEN_ELEMS}", row.size()}};
 
-        assertThat(row.size() == dim, report::COMPLEX_MATRIX_NEW_ELEMS_WRONG_ROW_DIM, vars, caller);
+        assertThat(row.size() == dim, report::COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM, vars, caller);
     }
 }
+void validate_matrixNumNewElems(int numQubits, std::vector<qcomp> elems, const char* caller) {
 
-void validate_matrixElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller) {
+    qindex dim = powerOf2(numQubits);
+    tokenSubs vars = {
+        {"${NUM_QUBITS}",        numQubits},
+        {"${NUM_EXPECTED_ELEMS}", dim},
+        {"${NUM_GIVEN_ELEMS}",    elems.size()}};
+
+    assertThat(elems.size() == dim, report::DIAG_MATR_WRONG_NUM_NEW_ELEMS, vars, caller);
+}
+
+void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller) {
 
     // we permit the matrix to contain the GPU-mem-unsync flag in CPU-only mode,
     // to avoid astonishing a CPU-only user with a GPU-related error message
     if (!getQuESTEnv().isGpuAccelerated)
         return;
 
-    assertThat(!gpu_doCpuAmpsHaveUnsyncMemFlag(firstElem), report::COMPLEX_MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG, caller);
+    assertThat(!gpu_doCpuAmpsHaveUnsyncMemFlag(firstElem), report::MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG, caller);
 }
 
-void validate_matrixIsSynced(CompMatr matr, const char* caller) {
+// type T can be CompMatr or DiagMatr
+template <class T>
+void assertMatrixIsSynced(T matr, std::string errMsg, const char* caller) {
 
-    // checks fields AND allocations
-    validate_matrixInit(matr, caller);
+    // checks fields (including memory allocations)
+    validate_matrixFields(matr, caller);
 
     // we don't need to perform any sync check in CPU-only mode
     if (matr.gpuElems != NULL)
         return;
 
     // check if GPU amps have EVER been overwritten; we sadly cannot check the LATEST changes were pushed though
-    assertThat(gpu_haveGpuAmpsBeenSynced(matr.gpuElems), report::COMPLEX_MATRIX_NOT_SYNCED_TO_GPU, caller);
+    assertThat(gpu_haveGpuAmpsBeenSynced(matr.gpuElems), errMsg, caller);
 }
 
+// type T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr
 template <class T> 
 void assertMatrixIsUnitary(T matr, const char* caller) {
 
@@ -838,16 +912,35 @@ void assertMatrixIsUnitary(T matr, const char* caller) {
     assertThat(util_isUnitary(matr), report::MATRIX_NOT_UNITARY, caller);
 }
 
+void validate_matrixIsSynced(CompMatr matr, const char* caller) {
+    assertMatrixIsSynced(matr, report::COMP_MATR_NOT_SYNCED_TO_GPU, caller);
+}
+void validate_matrixIsSynced(DiagMatr matr, const char* caller) {
+    assertMatrixIsSynced(matr, report::DIAG_MATR_NOT_SYNCED_TO_GPU, caller);
+}
+
 void validate_matrixIsUnitary(CompMatr1 matr, const char* caller) {
-    validate_matrixInit(matr, caller);
+    validate_matrixFields(matr, caller);
     assertMatrixIsUnitary(matr, caller);
 }
 void validate_matrixIsUnitary(CompMatr2 matr, const char* caller) {
-    validate_matrixInit(matr, caller);
+    validate_matrixFields(matr, caller);
     assertMatrixIsUnitary(matr, caller);
 }
 void validate_matrixIsUnitary(CompMatr matr, const char* caller) {
-    validate_matrixIsSynced(matr, caller);
+    validate_matrixIsSynced(matr, caller); // also checks fields
+    assertMatrixIsUnitary(matr, caller);
+}
+void validate_matrixIsUnitary(DiagMatr1 matr, const char* caller) {
+    validate_matrixFields(matr, caller);
+    assertMatrixIsUnitary(matr, caller);
+}
+void validate_matrixIsUnitary(DiagMatr2 matr, const char* caller) {
+    validate_matrixFields(matr, caller);
+    assertMatrixIsUnitary(matr, caller);
+}
+void validate_matrixIsUnitary(DiagMatr matr, const char* caller) {
+    validate_matrixIsSynced(matr, caller); // also checks fields
     assertMatrixIsUnitary(matr, caller);
 }
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -62,7 +62,8 @@ void validate_quregInit(Qureg qureg, const char* caller);
 
 void validate_newMatrixNumQubits(int numQubits, const char* caller);
 
-void validate_newOrExistingMatrixAllocs(CompMatr matr, bool isNewMatr, const char* caller);
+void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller);
+void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller);
 
 
 
@@ -70,19 +71,27 @@ void validate_newOrExistingMatrixAllocs(CompMatr matr, bool isNewMatr, const cha
  * EXISTING MATRIX
  */
 
-void validate_matrixInit(CompMatr1 matr, const char* caller);
-void validate_matrixInit(CompMatr2 matr, const char* caller);
-void validate_matrixInit(CompMatr  matr, const char* caller);
+void validate_matrixFields(CompMatr1 matr, const char* caller);
+void validate_matrixFields(CompMatr2 matr, const char* caller);
+void validate_matrixFields(CompMatr  matr, const char* caller);
+void validate_matrixFields(DiagMatr1 matr, const char* caller);
+void validate_matrixFields(DiagMatr2 matr, const char* caller);
+void validate_matrixFields(DiagMatr  matr, const char* caller);
 
-void validate_numMatrixElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller);
+void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller);
+void validate_matrixNumNewElems(int numQubits, std::vector<qcomp> elems, const char* caller);
 
-void validate_matrixElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller);
+void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller);
 
 void validate_matrixIsSynced(CompMatr matr, const char* caller);
+void validate_matrixIsSynced(DiagMatr matr, const char* caller);
 
 void validate_matrixIsUnitary(CompMatr1 matr, const char* caller);
 void validate_matrixIsUnitary(CompMatr2 matr, const char* caller);
 void validate_matrixIsUnitary(CompMatr  matr, const char* caller);
+void validate_matrixIsUnitary(DiagMatr1 matr, const char* caller);
+void validate_matrixIsUnitary(DiagMatr2 matr, const char* caller);
+void validate_matrixIsUnitary(DiagMatr  matr, const char* caller);
 
 
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -349,11 +349,11 @@ void gpu_copyCpuToGpu(CompMatr matr) {
 
     // copy each CPU row into flattened GPU memory. we make each memcpy asynch,
     // but it's unclear it helps, nor whether single-stream sync is necessary
-    size_t numBytesPerRow = matr.numRows * sizeof(**matr.elems);
+    size_t numBytesPerRow = matr.numRows * sizeof(**matr.cpuElems);
     gpu_sync();
 
     for (qindex r=0; r<matr.numRows; r++) {
-        qcomp* cpuRow = matr.elems[r];
+        qcomp* cpuRow = matr.cpuElems[r];
         qcomp* gpuSlice = &matr.gpuElems[r*matr.numRows];
         CUDA_CHECK( cudaMemcpyAsync(gpuSlice, cpuRow, numBytesPerRow, cudaMemcpyHostToDevice) );
     }

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -82,6 +82,7 @@ void gpu_copyGpuToCpu(Qureg qureg, qcomp* gpuArr, qcomp* cpuArr, qindex numElems
 void gpu_copyGpuToCpu(Qureg qureg);
 
 void gpu_copyCpuToGpu(CompMatr matr);
+void gpu_copyCpuToGpu(DiagMatr matr);
 
 bool gpu_haveGpuAmpsBeenSynced(qcomp* gpuArr);
 


### PR DESCRIPTION
and...
- changed 'elems' field of dynamic-size CompMatr to 'cpuElems' to better imply the need for synchronisation
- moved some matrix formatting logic into formatter.cpp, out of structures.cpp
- made matrix-creator free after failed validation to avoid memory leak
- disambiguated some validation naming