### PR TITLE
renamed structures.h to matrices.h

### DIFF
--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -1,6 +1,6 @@
 /** @file
- * Signatures of API data structures like gate matrices. Note QuESTEnv and Qureg 
- * structs have their own signatures in environment.h and qureg.h respectively.
+ * Signatures of API matrix data structures, and their getters and setters, 
+ * as well as reporting utilities.
  * 
  * This file uses extensive preprocessor trickery to achieve platform agnostic,
  * C and C++ compatible, type agnostic, getters and setters of complex matrices.
@@ -27,8 +27,8 @@
  * You've just crossed over into the Twilight Zone.
  */
 
-#ifndef STRUCTURES_H
-#define STRUCTURES_H
+#ifndef MATRICES_H
+#define MATRICES_H
 
 #include "quest/include/types.h"
 
@@ -234,7 +234,7 @@ static inline CompMatr2 getCompMatr2FromPtr(qcomp** in) {
 #ifdef __cplusplus
 
     // C++ uses overloads, accepting even vector initialiser lists,
-    // which are defined in structures.cpp.
+    // which are defined in matrices.cpp.
 
     CompMatr1 getCompMatr1(qcomp in[2][2]);
     CompMatr1 getCompMatr1(qcomp** in);
@@ -575,4 +575,4 @@ extern "C" {
 
 
 
-#endif // STRUCTURES_H
+#endif // MATRICES_H

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -8,7 +8,7 @@
 #define OPERATIONS_H
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 // enable invocation by both C and C++ binaries
 #ifdef __cplusplus

--- a/quest/include/quest.h
+++ b/quest/include/quest.h
@@ -17,7 +17,7 @@
 #include "quest/include/precision.h"
 #include "quest/include/qasm.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 #include "quest/include/types.h"
 #include "quest/include/version.h"
 #include "quest/include/wrappers.h"

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -1,13 +1,12 @@
 /** @file
- * Definitions of API data structures like gate matrices. 
- * Note QuESTEnv and Qureg structs have their own definitions 
- * in environment.cpp and qureg.cpp respectively.
+ * Definitions of API matrix data structures, and their getters
+ * and setters, as well as reporting utilities.
  * 
  * This file defines many "layers" of initialisation of complex
  * matrices, as explained in the header file.
  */
 
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 #include "quest/include/environment.h"
 #include "quest/include/types.h"
 

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/utilities.hpp"

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -9,7 +9,7 @@
  */
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/cpu/cpu_subroutines.hpp"
 #include "quest/src/gpu/gpu_subroutines.hpp"

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -12,7 +12,7 @@
 #define ACCELERATOR_HPP
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 
 

--- a/quest/src/core/formatter.cpp
+++ b/quest/src/core/formatter.cpp
@@ -3,7 +3,7 @@
  */
 
 #include "quest/include/types.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/formatter.hpp"
 #include "quest/src/core/utilities.hpp"

--- a/quest/src/core/formatter.hpp
+++ b/quest/src/core/formatter.hpp
@@ -5,7 +5,7 @@
 #ifndef FORMATTER_HPP
 #define FORMATTER_HPP
 
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include <vector>
 #include <tuple>

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -9,7 +9,7 @@
  */
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/comm/comm_routines.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -12,7 +12,7 @@
 #define LOCALISER_HPP
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -4,7 +4,7 @@
 
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/utilities.hpp"

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -7,7 +7,7 @@
 
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -6,7 +6,7 @@
 #include "quest/include/modes.h"
 #include "quest/include/environment.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"
@@ -283,8 +283,7 @@ void default_invalidQuESTInputError(const char* msg, const char* func) {
     // will then attempt to instantly abort all nodes, losing the error message.
     comm_sync();
 
-    // TODO:
-    //      why don't we finalize MPI here?!?!
+    // finalise MPI before error-exit to avoid scaring user with giant MPI error message
     if (comm_isInit())
         comm_end();
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -8,7 +8,7 @@
 
 #include "quest/include/environment.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include <vector>
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -5,7 +5,7 @@
 
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/bitwise.hpp"
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -6,7 +6,7 @@
 #define CPU_SUBROUTINES_HPP
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -5,7 +5,7 @@
 #include "quest/include/modes.h"
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 #include "quest/include/environment.h"
 
 #include "quest/src/core/errors.hpp"

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -9,7 +9,7 @@
 
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include <cstdlib>
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -12,7 +12,7 @@
 #include "quest/include/modes.h"
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -6,7 +6,7 @@
 #define GPU_SUBROUTINES_HPP
 
 #include "quest/include/qureg.h"
-#include "quest/include/structures.h"
+#include "quest/include/matrices.h"
 
 
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -103,11 +103,11 @@ API_FILES=(
     "decoherence"
     "environment"
     "initialisations"
+    "matrices"
     "modes"
     "operations"
     "qasm"
     "qureg"
-    "structures"
 )
 
 # files in GPU_DIR


### PR DESCRIPTION
since the CompMatr and DiagMatr code was together sufficiently substantial to warrant its own file.

Further data structures will be given their own files, or a file for their family, like paulis.h for PauliStr and PauliStrSum