### PR TITLE
added complex arithmetic

### DIFF
--- a/examples/numbers/arithmetic.c
+++ b/examples/numbers/arithmetic.c
@@ -2,7 +2,8 @@
 
 int main() {
 
-    qcomp x = 1.2 + 3.4i;
+    // literal 1.2 + 3.4i is restrictedly double precision
+    qcomp x = qcomp(1.2, 3.4);
 
     // C + R
     x = x + (int) 3;

--- a/examples/numbers/arithmetic.c
+++ b/examples/numbers/arithmetic.c
@@ -1,0 +1,92 @@
+#include "quest.h"
+
+int main() {
+
+    qcomp x = 1.2 + 3.4i;
+
+    // C + R
+    x = x + (int) 3;
+    x = x + (qindex) 3;
+    x = x + (float) 2;
+    x = x + (double) 2;
+    x = x + (long double) 2;
+
+    // R + C
+    x = (int) 3         + x;
+    x = (qindex) 3      + x;
+    x = (float) 2       + x;
+    x = (double) 2      + x;
+    x = (long double) 2 + x;
+
+    // C - R
+    x = x - (int) 3;
+    x = x - (qindex) 3;
+    x = x - (float) 2;
+    x = x - (double) 2;
+    x = x - (long double) 2;
+
+    // R - C
+    x = (int) 3         - x;
+    x = (qindex) 3      - x;
+    x = (float) 2       - x;
+    x = (double) 2      - x;
+    x = (long double) 2 - x;
+
+    // C * R
+    x = x * (int) 3;
+    x = x * (qindex) 3;
+    x = x * (float) 2;
+    x = x * (double) 2;
+    x = x * (long double) 2;
+
+    // R * C
+    x = (int) 3         * x;    
+    x = (qindex) 3      * x;
+    x = (float) 2       * x;
+    x = (double) 2      * x;
+    x = (long double) 2 * x;
+
+    // C / R
+    x = x / (int) 3;
+    x = x / (qindex) 3;
+    x = x / (float) 2;
+    x = x / (double) 2;
+    x = x / (long double) 2;
+
+    // R / C
+    x = (int) 3         / x;
+    x = (qindex) 3      / x;
+    x = (float) 2       / x;
+    x = (double) 2      / x;
+    x = (long double) 2 / x;
+
+    // C += R
+    x += (int) 3;
+    x += (qindex) 3;
+    x += (float) 2;
+    x += (double) 2;
+    x += (long double) 2;
+
+    // C -= R
+    x -= (int) 3;
+    x -= (qindex) 3;
+    x -= (float) 2;
+    x -= (double) 2;
+    x -= (long double) 2;
+
+    // C *= R
+    x *= (int) 3;
+    x *= (qindex) 3;
+    x *= (float) 2;
+    x *= (double) 2;
+    x *= (long double) 2;
+
+    // C /= R
+    x /= (int) 3;
+    x /= (qindex) 3;
+    x /= (float) 2;
+    x /= (double) 2;
+    x /= (long double) 2;
+
+    reportQcomp(x);
+}

--- a/examples/numbers/arithmetic.c
+++ b/examples/numbers/arithmetic.c
@@ -2,6 +2,8 @@
 
 int main() {
 
+    initQuESTEnv();
+
     // literal 1.2 + 3.4i is restrictedly double precision
     qcomp x = qcomp(1.2, 3.4);
 
@@ -90,4 +92,6 @@ int main() {
     x /= (long double) 2;
 
     reportQcomp(x);
+
+    finalizeQuESTEnv();
 }

--- a/examples/numbers/arithmetic.cpp
+++ b/examples/numbers/arithmetic.cpp
@@ -2,6 +2,8 @@
 
 int main() {
 
+    initQuESTEnv();
+
     // literal 1.2 + 3.4i is restrictedly double precision
     qcomp x = qcomp(1.2, 3.4);
 
@@ -90,4 +92,6 @@ int main() {
     x /= (long double) 2;
 
     reportQcomp(x);
+    
+    finalizeQuESTEnv();
 }

--- a/examples/numbers/arithmetic.cpp
+++ b/examples/numbers/arithmetic.cpp
@@ -2,7 +2,8 @@
 
 int main() {
 
-    qcomp x = 1.2 + 3.4i;
+    // literal 1.2 + 3.4i is restrictedly double precision
+    qcomp x = qcomp(1.2, 3.4);
 
     // C + R
     x = x + (int) 3;

--- a/examples/numbers/arithmetic.cpp
+++ b/examples/numbers/arithmetic.cpp
@@ -1,0 +1,92 @@
+#include "quest.h"
+
+int main() {
+
+    qcomp x = 1.2 + 3.4i;
+
+    // C + R
+    x = x + (int) 3;
+    x = x + (qindex) 3;
+    x = x + (float) 2;
+    x = x + (double) 2;
+    x = x + (long double) 2;
+
+    // R + C
+    x = (int) 3         + x;
+    x = (qindex) 3      + x;
+    x = (float) 2       + x;
+    x = (double) 2      + x;
+    x = (long double) 2 + x;
+
+    // C - R
+    x = x - (int) 3;
+    x = x - (qindex) 3;
+    x = x - (float) 2;
+    x = x - (double) 2;
+    x = x - (long double) 2;
+
+    // R - C
+    x = (int) 3         - x;
+    x = (qindex) 3      - x;
+    x = (float) 2       - x;
+    x = (double) 2      - x;
+    x = (long double) 2 - x;
+
+    // C * R
+    x = x * (int) 3;
+    x = x * (qindex) 3;
+    x = x * (float) 2;
+    x = x * (double) 2;
+    x = x * (long double) 2;
+
+    // R * C
+    x = (int) 3         * x;    
+    x = (qindex) 3      * x;
+    x = (float) 2       * x;
+    x = (double) 2      * x;
+    x = (long double) 2 * x;
+
+    // C / R
+    x = x / (int) 3;
+    x = x / (qindex) 3;
+    x = x / (float) 2;
+    x = x / (double) 2;
+    x = x / (long double) 2;
+
+    // R / C
+    x = (int) 3         / x;
+    x = (qindex) 3      / x;
+    x = (float) 2       / x;
+    x = (double) 2      / x;
+    x = (long double) 2 / x;
+
+    // C += R
+    x += (int) 3;
+    x += (qindex) 3;
+    x += (float) 2;
+    x += (double) 2;
+    x += (long double) 2;
+
+    // C -= R
+    x -= (int) 3;
+    x -= (qindex) 3;
+    x -= (float) 2;
+    x -= (double) 2;
+    x -= (long double) 2;
+
+    // C *= R
+    x *= (int) 3;
+    x *= (qindex) 3;
+    x *= (float) 2;
+    x *= (double) 2;
+    x *= (long double) 2;
+
+    // C /= R
+    x /= (int) 3;
+    x /= (qindex) 3;
+    x /= (float) 2;
+    x /= (double) 2;
+    x /= (long double) 2;
+
+    reportQcomp(x);
+}

--- a/quest/include/types.h
+++ b/quest/include/types.h
@@ -61,34 +61,130 @@ typedef INDEX_TYPE qindex;
 
 
 /*
- * COMPLEX TYPE OVERLOADS
+ * COMPLEX TYPE INSTANTIATION
  */
 
 #ifdef __cplusplus
-
-    // enable C++ literals (requires C++14)
-    using namespace std::complex_literals;
 
     // qcomp() C++ instantiation is already enabled
 
 #else
 
-    #ifdef _MSC_VER
+    // TODO: below we define macros qcomp(re,im) to spoof
+    // C++'s initializer, but this is an antipattern! It
+    // causes code like qcomp(*)[] (a valid type) to be
+    // attemptedly substituted with the macro at 
+    // pre-processing which fails and throws an error.
+    // This might plague user code, and also forces us to
+    // use smelly type aliasing in matrices.h. Fix this!
 
-        // MSVC C literals are literally impossible
+    #ifdef _MSC_VER
 
         // enable qcomp() C instantiation
         #define qcomp(re,im) = (qcomp) {(re), (im)}
 
     #else
 
-        // C literals are already enabled (requires C99)
-
         // enable qcomp() C instantiation
         #define qcomp(re,im) ( (qreal) (re) + I*((qreal) (im)) )
 
     #endif
 
+#endif
+
+
+
+/*
+ * COMPLEX TYPE LITERALS
+ */
+
+// MSVC C literals are literally impossible, and
+// C11 literals are already defined in complex header
+
+#ifdef __cplusplus
+
+    // requires C++14
+    using namespace std::complex_literals;
+
+#endif
+
+
+
+/*
+ * COMPLEX TYPE ARITHMETIC OVERLOADS
+ */
+
+// C11 arithmetic is already defined in complex header, and beautifully
+// permits mixing of parameterised types and precisions
+
+#ifdef __cplusplus
+
+    // C++14 defines overloads between complex and same-precision floats,
+    // so e.g. complex<double> + double work fine. However, for differing
+    // types and precisions, we must ourselves define operators which cast
+    // the non-complex type to a qreal (to match qcomp). We must do this for
+    // all operators the user might wish to use (e.g. + - * /), and their
+    // assignment forms (x += 2), and when their argument order is reversed.
+    // To avoid 108 unique definitions, we employ these unholy macros.
+
+    #define DEFINE_OPERATOR_FOR_TYPE(op, type) \
+        inline qcomp operator op (const qcomp& a, const type& b) { \
+            return a op qcomp((qreal) b,0); \
+        } \
+        inline qcomp operator op (const type& b, const qcomp& a) { \
+            return a op b; \
+        } \
+        inline qcomp& operator op##= (qcomp& a, const type& b) { \
+            a = a op b; \
+            return a; \
+        }
+
+    #define DEFINE_COMPLEX_ARITHMETIC_FOR(type) \
+        DEFINE_OPERATOR_FOR_TYPE(+, type) \
+        DEFINE_OPERATOR_FOR_TYPE(-, type) \
+        DEFINE_OPERATOR_FOR_TYPE(*, type) \
+        DEFINE_OPERATOR_FOR_TYPE(/, type)
+
+    DEFINE_COMPLEX_ARITHMETIC_FOR(int)
+    DEFINE_COMPLEX_ARITHMETIC_FOR(long int)
+    DEFINE_COMPLEX_ARITHMETIC_FOR(long long int)
+    DEFINE_COMPLEX_ARITHMETIC_FOR(unsigned)
+    DEFINE_COMPLEX_ARITHMETIC_FOR(long unsigned)
+    DEFINE_COMPLEX_ARITHMETIC_FOR(long long unsigned)
+
+    // we must not redefine the exising overloads between complex<T> and T
+    #if (FLOAT_PRECISION != 1)
+        DEFINE_COMPLEX_ARITHMETIC_FOR(float)
+    #endif
+    #if (FLOAT_PRECISION != 2)
+        DEFINE_COMPLEX_ARITHMETIC_FOR(double)
+    #endif
+    #if (FLOAT_PRECISION != 4)
+        DEFINE_COMPLEX_ARITHMETIC_FOR(long double)
+    #endif
+
+    // keep these unholy macros away from the users
+    #undef DEFINE_OPERATOR_FOR_TYPE
+    #undef DEFINE_COMPLEX_ARITHMETIC_FOR
+
+#endif
+
+
+
+/*
+ * CONVENIENCE FUNCTIONS
+ */
+
+// enable invocation by both C and C++ binaries
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void reportQcomp(qcomp num);
+
+// end de-mangler
+#ifdef __cplusplus
+}
 #endif
 
 

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -9,19 +9,16 @@
  * documentation is aware, but secretly ensures the backend C++ 
  * binaries are send qcomps from the user's C code only by pointer.
  * 
- * Note that CompMatr getters and setters (like getCompMatr1()) are
+ * Note that matrix getters and setters (like getCompMatr1()) are
  * missing from this file, even though they contain qcomp[2][2] (which
  * are NOT pointers) and cannot be directly passed between binaries.
- * Those functions are instead defined in structures.h/.cpp because
+ * Those functions are instead defined in matrices.h/.cpp because
  * those structs are declared 'const'; they must be intiailised inline, 
  * and can never be modified by pointer. We shouldn't even address them!
  */
 
 #ifndef WRAPPERS_H
 #define WRAPPERS_H
-
-#include "quest/include/types.h"
-#include "quest/include/structures.h"
 
 // these definitions are only exposed to C, 
 // since they duplicate existing C++ functions

--- a/quest/src/api/types.cpp
+++ b/quest/src/api/types.cpp
@@ -5,12 +5,14 @@
 #include "quest/include/types.h"
 
 #include "quest/src/core/formatter.hpp"
+#include "quest/src/core/validation.hpp"
 #include "quest/src/comm/comm_config.hpp"
 
 #include <iostream>
 
 
 extern "C" void reportQcomp(qcomp num) {
+    validate_envIsInit(__func__);
 
     // only root node reports (but no synch necesary)
     if (comm_getRank() != 0)

--- a/quest/src/api/types.cpp
+++ b/quest/src/api/types.cpp
@@ -5,11 +5,16 @@
 #include "quest/include/types.h"
 
 #include "quest/src/core/formatter.hpp"
+#include "quest/src/comm/comm_config.hpp"
 
 #include <iostream>
 
 
 extern "C" void reportQcomp(qcomp num) {
+
+    // only root node reports (but no synch necesary)
+    if (comm_getRank() != 0)
+        return;
 
     std::cout << form_str(num) << std::endl;
 }

--- a/quest/src/api/types.cpp
+++ b/quest/src/api/types.cpp
@@ -1,0 +1,15 @@
+/** @file
+ * API definitions of convenience functions for using QuEST's numerical types
+ */
+
+#include "quest/include/types.h"
+
+#include "quest/src/core/formatter.hpp"
+
+#include <iostream>
+
+
+extern "C" void reportQcomp(qcomp num) {
+
+    std::cout << form_str(num) << std::endl;
+}

--- a/quest/src/core/formatter.hpp
+++ b/quest/src/core/formatter.hpp
@@ -5,6 +5,7 @@
 #ifndef FORMATTER_HPP
 #define FORMATTER_HPP
 
+#include "quest/include/types.h"
 #include "quest/include/matrices.h"
 
 #include <vector>
@@ -32,18 +33,17 @@ std::string form_getFloatPrecisionFlag();
 
 /*
  * STRING CASTS
- *
- * which are aggravatingly necessarily defined here in the header
- * because of their use of templating.
  */
 
-template<typename T> std::string form_str(T expr) {
 
-    // note that passing qcomp (and complex<T> generally) will see them
-    // formatted as tuples (re, im). they should instead be passed to
-    // compToStr() which is currently a private member of formatter.cpp.
-    // I tried and failed to conjure the templating magic necessary to
-    // automatically invoke it when T is a complex<K>.
+// type T can be int, qindex, float, double, long double.
+// this more specific form_str() definition is called when passing complex
+template <typename T>
+std::string form_str(std::complex<T> num);
+
+// type T can be any non-complex type recognised by ostringstream!
+template<typename T> 
+std::string form_str(T expr) {
 
     // write to buffer (rather than use to_string()) so that floating-point numbers
     // are automatically converted to scientific notation when necessary

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -108,6 +108,7 @@ API_FILES=(
     "operations"
     "qasm"
     "qureg"
+    "types"
 )
 
 # files in GPU_DIR


### PR DESCRIPTION
in a precision agnostic fashion. This enables C and C++ users to perform arithmetic between qcomp and non-equal-precision numbers (like integers, non-qreal decimals, etc)

Other changes:
- added reportQcomp
- added arithmetic examples
- cleaned up formatter.cpp, overloading form_str to format complex numbers so that other core files can stringify complex numbers