### PR TITLE
added FullStateDiagMatr

### DIFF
--- a/examples/matrices/initialisation.c
+++ b/examples/matrices/initialisation.c
@@ -255,6 +255,46 @@ void demo_setDiagMatr() {
 }
 
 
+void demo_setInlineFullStateDiagMatr() {
+
+    FullStateDiagMatr matr = createCustomFullStateDiagMatr(5, 1);
+
+    // inline literal; identical to setFullStateDiagMatr() for consistencty with C API
+    setInlineFullStateDiagMatr(matr, 3, 10, {3,4,5,6,7,8,9,1,12,13});
+    setInlineFullStateDiagMatr(matr, 15, 6, {6,5,4,3,2,1});
+    
+    reportFullStateDiagMatr(matr);
+    destroyFullStateDiagMatr(matr);
+}
+
+
+void demo_setFullStateDiagMatr() {
+
+    FullStateDiagMatr matr = createCustomFullStateDiagMatr(5, 1);
+
+    // VLA (C only)
+    int n = 10;
+    qcomp vla[n];
+    for (int i=0; i<n; i++)
+        vla[i] =.123*i*1i;
+    setFullStateDiagMatr(matr, 2, vla, n);
+
+    // compile-time array
+    qcomp arr[4] = {7i, 8i, 8, 7};
+    setFullStateDiagMatr(matr, 15, arr, 4);
+
+    // heap pointer
+    int dim = 6;
+    qcomp* ptr = (qcomp*) malloc(dim * sizeof *ptr);
+    for (int i=0; i<dim; i++)
+        ptr[i] = -i*.5i;
+    setFullStateDiagMatr(matr, 25, ptr, 6);
+
+    reportFullStateDiagMatr(matr);
+    destroyFullStateDiagMatr(matr);
+}
+
+
 
 /*
  * main
@@ -274,6 +314,9 @@ int main() {
     demo_getDiagMatr();
     demo_setInlineDiagMatr();
     demo_setDiagMatr();
+
+    demo_setInlineFullStateDiagMatr();
+    demo_setFullStateDiagMatr();
 
     finalizeQuESTEnv();
     return 0;

--- a/examples/matrices/initialisation.cpp
+++ b/examples/matrices/initialisation.cpp
@@ -214,18 +214,65 @@ void demo_setDiagMatr() {
     setDiagMatr(b, vec);
     reportDiagMatr(b);
 
+    // compile-time array
+    qcomp arr[4] = {7i, 8i, 8, 7};
+    DiagMatr c = createDiagMatr(2);
+    setDiagMatr(c, arr);
+    reportDiagMatr(c);
+
     // heap pointer
     int dim = 8;
     qcomp* ptr = (qcomp*) malloc(dim * sizeof *ptr);
     for (int i=0; i<dim; i++)
         ptr[i] = -i*.5i;
-    DiagMatr c = createDiagMatr(3);
-    setDiagMatr(c, ptr);
-    reportDiagMatr(c);
-    destroyDiagMatr(c);
+    DiagMatr d = createDiagMatr(3);
+    setDiagMatr(d, ptr);
+    reportDiagMatr(d);
+    destroyDiagMatr(d);
 
     // cleanup
     free(ptr);
+}
+
+
+void demo_setInlineFullStateDiagMatr() {
+
+    FullStateDiagMatr matr = createCustomFullStateDiagMatr(5, 1);
+
+    // inline literal; identical to setFullStateDiagMatr() for consistencty with C API
+    setInlineFullStateDiagMatr(matr, 3, 10, {3,4,5,6,7,8,9,1,12,13});
+    setInlineFullStateDiagMatr(matr, 15, 6, {6,5,4,3,2,1});
+    
+    reportFullStateDiagMatr(matr);
+    destroyFullStateDiagMatr(matr);
+}
+
+
+void demo_setFullStateDiagMatr() {
+
+    FullStateDiagMatr matr = createCustomFullStateDiagMatr(5, 1);
+
+    // inline literal (C++ only)
+    setFullStateDiagMatr(matr, 0, {1,2,3,4});
+    setFullStateDiagMatr(matr, 4, {5,6,7,8});
+
+    // vector (C++ only)
+    std::vector<qcomp> vec {11, 22, 33, 44};
+    setFullStateDiagMatr(matr, 7, vec);
+
+    // compile-time array must pass size
+    qcomp arr[4] = {7i, 8i, 8, 7};
+    setFullStateDiagMatr(matr, 15, arr, 4);
+
+    // heap pointer
+    int dim = 6;
+    qcomp* ptr = (qcomp*) malloc(dim * sizeof *ptr);
+    for (int i=0; i<dim; i++)
+        ptr[i] = -i*.5i;
+    setFullStateDiagMatr(matr, 25, ptr, 6);
+
+    reportFullStateDiagMatr(matr);
+    destroyFullStateDiagMatr(matr);
 }
 
 
@@ -248,6 +295,9 @@ int main() {
     demo_getDiagMatr();
     demo_setInlineDiagMatr();
     demo_setDiagMatr();
+
+    demo_setInlineFullStateDiagMatr();
+    demo_setFullStateDiagMatr();
 
     finalizeQuESTEnv();
     return 0;

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -239,11 +239,11 @@ void printQuregSizeLimits(bool isDensMatr) {
     // max CPU registers are only determinable if RAM query succeeds
     try {
         qindex cpuMem = mem_tryGetLocalRamCapacityInBytes();
-        maxQbForCpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, 1, cpuMem));
+        maxQbForCpu = form_str(mem_getMaxNumQuregQubitsWhichCanFitInMemory(isDensMatr, 1, cpuMem));
 
         // and the max MPI sizes are only relevant when env is distributed
         if (globalEnvPtr->isDistributed)
-            maxQbForMpiCpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, numNodes, cpuMem));
+            maxQbForMpiCpu = form_str(mem_getMaxNumQuregQubitsWhichCanFitInMemory(isDensMatr, numNodes, cpuMem));
 
         // when MPI irrelevant, change their status from "unknown" to "N/A"
         else
@@ -259,11 +259,11 @@ void printQuregSizeLimits(bool isDensMatr) {
     // max GPU registers only relevant if env is GPU-accelerated
     if (globalEnvPtr->isGpuAccelerated) {
         qindex gpuMem = gpu_getCurrentAvailableMemoryInBytes();
-        maxQbForGpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, 1, gpuMem));
+        maxQbForGpu = form_str(mem_getMaxNumQuregQubitsWhichCanFitInMemory(isDensMatr, 1, gpuMem));
 
         // and the max MPI sizes are further only relevant when env is distributed 
         if (globalEnvPtr->isDistributed)
-            maxQbForMpiGpu = form_str(mem_getMaxNumQubitsWhichCanFitInMemory(isDensMatr, numNodes, gpuMem));
+            maxQbForMpiGpu = form_str(mem_getMaxNumQuregQubitsWhichCanFitInMemory(isDensMatr, numNodes, gpuMem));
     }
 
     // tailor table title to type of Qureg

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -499,17 +499,13 @@ extern "C" void setFullStateDiagMatr(FullStateDiagMatr out, qindex startInd, qco
     if (!out.isDistributed)
         memcpy(&out.cpuElems[startInd], in, numElems * sizeof(qcomp));
 
-    // distributed nodes containing no targeted elements do nothing
-    else if (!util_areAnyElemsWithinThisNode(out.numElemsPerNode, startInd, numElems))
-        return;
-
-    // but distributed nodes containing one or more targeted elems overwrite this subset
-    else {
+    // only distributed nodes containing targeted elemsn need to do anything
+    else if (util_areAnyElemsWithinThisNode(out.numElemsPerNode, startInd, numElems)) {
         util_IndexRange range = util_getLocalIndRangeOfElemsWithinThisNode(out.numElemsPerNode, startInd, numElems);
         memcpy(&out.cpuElems[range.localDistribStartInd], &in[range.localDuplicStartInd], range.numElems * sizeof(qcomp));
     }
 
-    // overwrite GPU; validation gauranteed to succeed
+    // all nodes overwrite GPU; validation gauranteed to succeed
     syncFullStateDiagMatr(out);
 }
 

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -10,12 +10,15 @@
 #include "quest/include/environment.h"
 #include "quest/include/types.h"
 
-#include "quest/src/comm/comm_config.hpp"
 #include "quest/src/core/validation.hpp"
+#include "quest/src/core/autodeployer.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/formatter.hpp"
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/memory.hpp"
+#include "quest/src/comm/comm_config.hpp"
+#include "quest/src/comm/comm_routines.hpp"
+#include "quest/src/cpu/cpu_config.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
 
 #include <iostream>
@@ -29,7 +32,7 @@
 /*
  * PRIVATE UTILITES 
  *
- * noting that some public matrix utilities (like isDenseMatrix) 
+ * noting that some public matrix utilities (like util_isDenseMatrix) 
  * are defined in utilities.hpp
  */
 
@@ -60,16 +63,16 @@ T getCompMatrFromElems(B in, int num) {
 }
 
 
-// type T can be CompMatr or DiagMatr
+// type T can be CompMatr, DiagMatr or FullStateDiagMatr
 template <class T>
-bool didAnyAllocsFail(T matr) {
+bool didAnyLocalAllocsFail(T matr) {
 
     // outer CPU memory should always be allocated
     if (matr.cpuElems == NULL)
         return true;
 
     // if memory is 2D, we must also check each inner array was allocated
-    if constexpr (isDenseMatrixType<T>())
+    if constexpr (util_isDenseMatrixType<T>())
         for (qindex r=0; r<matr.numRows; r++)
             if (matr.cpuElems[r] == NULL)
                 return true;
@@ -83,16 +86,28 @@ bool didAnyAllocsFail(T matr) {
 }
 
 
-// type T can be CompMatr or DiagMatr
+// type T can be CompMatr, DiagMatr or FullStateDiagMatr
+template <class T>
+bool didAnyAllocsFailOnAnyNode(T matr) {
+
+    bool anyFail = didAnyLocalAllocsFail(matr);
+    if (comm_isInit())
+        anyFail = comm_isTrueOnAllNodes(anyFail);
+
+    return anyFail;
+}
+
+
+// type T can be CompMatr, DiagMatr or FullStateDiagMatr
 template <class T>
 void freeAllMemoryIfAnyAllocsFailed(T matr) {
 
-    // do nothing if everything allocated successfully
-    if (!didAnyAllocsFail(matr))
+    // do nothing if everything allocated successfully between all nodes
+    if (!didAnyAllocsFailOnAnyNode(matr))
         return;
 
     // otherwise, free all successfully allocated rows of 2D structures (if outer list allocated)
-    if constexpr (isDenseMatrixType<T>())
+    if constexpr (util_isDenseMatrixType<T>())
         if (matr.cpuElems != NULL)
             for (qindex r=0; r<matr.numRows; r++)
                 if (matr.cpuElems[r] != NULL)
@@ -178,7 +193,7 @@ DiagMatr2 getDiagMatr2(std::vector<qcomp> in) {
 
 extern "C" CompMatr createCompMatr(int numQubits) {
     validate_envIsInit(__func__);
-    validate_newMatrixNumQubits(numQubits, __func__);
+    validate_newCompMatrParams(numQubits, __func__);
 
     // validation ensures these (and below mem sizes) never overflow
     qindex numRows = powerOf2(numQubits);
@@ -203,7 +218,7 @@ extern "C" CompMatr createCompMatr(int numQubits) {
     // only if outer CPU allocation succeeded, attempt to allocate each row array
     if (out.cpuElems != NULL)
         for (qindex r=0; r < numRows; r++)
-            out.cpuElems[r] = (qcomp*) calloc(numRows, sizeof **out.cpuElems); // NULL if failed
+            out.cpuElems[r] = cpu_allocAmps(numRows); // NULL if failed
 
     // if any of the above mallocs failed, below validation will memory leak; so free first (but don't set to NULL)
     freeAllMemoryIfAnyAllocsFailed(out);
@@ -233,7 +248,8 @@ extern "C" void syncCompMatr(CompMatr matr) {
     validate_matrixFields(matr, __func__);
     validate_matrixNewElemsDontContainUnsyncFlag(matr.cpuElems[0][0], __func__);
 
-    gpu_copyCpuToGpu(matr);
+    if (matr.gpuElems != NULL)
+        gpu_copyCpuToGpu(matr);
 }
 
 
@@ -247,7 +263,7 @@ extern "C" void syncCompMatr(CompMatr matr) {
 
 extern "C" DiagMatr createDiagMatr(int numQubits) {
     validate_envIsInit(__func__);
-    validate_newMatrixNumQubits(numQubits, __func__);
+    validate_newDiagMatrParams(numQubits, __func__);
 
     // validation ensures these (and below mem sizes) never overflow
     qindex numElems = powerOf2(numQubits);
@@ -261,17 +277,15 @@ extern "C" DiagMatr createDiagMatr(int numQubits) {
         .numQubits = numQubits,
         .numElems = numElems,
 
-        // const 2D CPU memory (NULL if failed, or containing NULLs)
-        .cpuElems = (qcomp*) malloc(numElems * sizeof *out.cpuElems), // NULL if failed,
+        // const 1D CPU memory (NULL if failed, or containing NULLs)
+        .cpuElems = cpu_allocAmps(numElems), // NULL if failed,
 
         // const 1D GPU memory (NULL if failed or not needed)
         .gpuElems = (isGpuAccel)? gpu_allocAmps(numElems) : NULL // first amp will be un-sync'd flag
     };
 
-    // if either of these mallocs failed, below validation will memory leak; so free first (but don't set to NULL)
+    // if any of the above mallocs failed, below validation will memory leak; so free first (but don't set to NULL)
     freeAllMemoryIfAnyAllocsFailed(out);
-
-    // check all CPU & GPU malloc and callocs succeeded (no attempted freeing if not)
     validate_newMatrixAllocs(out, numBytes, __func__);
 
     return out;
@@ -294,7 +308,87 @@ extern "C" void syncDiagMatr(DiagMatr matr) {
     validate_matrixFields(matr, __func__);
     validate_matrixNewElemsDontContainUnsyncFlag(matr.cpuElems[0], __func__);
 
-    gpu_copyCpuToGpu(matr);
+    if (matr.gpuElems != NULL)
+        gpu_copyCpuToGpu(matr);
+}
+
+
+
+/*
+ * FULL-STATE MATRIX CONSTRUCTORS
+ *
+ * the public of which are de-mangled for both C++ and C compatibility
+ */
+
+
+FullStateDiagMatr validateAndCreateCustomFullStateDiagMatr(int numQubits, int useDistrib, const char* caller) {
+    validate_envIsInit(caller);
+    QuESTEnv env = getQuESTEnv();
+
+    // must validate parameters before passing them to autodeployer
+    validate_newFullStateDiagMatrParams(numQubits, useDistrib, caller);
+
+    // overwrite useDistrib if it was left as AUTO_FLAG
+    autodep_chooseFullStateDiagMatrDeployment(numQubits, useDistrib, env);
+
+    qindex numElems = powerOf2(numQubits);
+    qindex numElemsPerNode = numElems / (useDistrib? env.numNodes : 1); // divides evenly
+    qindex numBytesPerNode = numElemsPerNode * sizeof(qcomp);
+
+    FullStateDiagMatr out = {
+
+        // data deployment configuration; disable distrib if deployed to 1 node
+        .isDistributed = useDistrib && (env.numNodes > 1),
+
+        .numQubits = numQubits,
+        .numElems = numElems,
+        .numElemsPerNode = numElemsPerNode,
+
+        // 1D CPU memory (NULL if failed)
+        .cpuElems = cpu_allocAmps(numElemsPerNode),
+
+        // 1D GPU memory (NULL if failed or deliberately not allocated)
+        .gpuElems = (env.isGpuAccelerated)? gpu_allocAmps(numElemsPerNode) : NULL, // first amp will be un-sync'd flag
+    };
+
+    // if any of the above mallocs failed, below validation will memory leak; so free first (but don't set to NULL)
+    freeAllMemoryIfAnyAllocsFailed(out);
+    validate_newMatrixAllocs(out, numBytesPerNode, __func__);
+
+    return out;
+}
+
+
+extern "C" FullStateDiagMatr createCustomFullStateDiagMatr(int numQubits, int useDistrib) {
+
+    return validateAndCreateCustomFullStateDiagMatr(numQubits, useDistrib, __func__);
+}
+
+
+extern "C" FullStateDiagMatr createFullStateDiagMatr(int numQubits) {
+
+    return validateAndCreateCustomFullStateDiagMatr(numQubits, modeflag::USE_AUTO, __func__);
+}
+
+
+extern "C" void destroyFullStateDiagMatr(FullStateDiagMatr matrix) {
+    validate_matrixFields(matrix, __func__);
+
+    // free CPU array of rows
+    free(matrix.cpuElems);
+
+    // free flat GPU array if it exists
+    if (matrix.gpuElems != NULL)
+        gpu_deallocAmps(matrix.gpuElems);
+}
+
+
+extern "C" void syncFullStateDiagMatr(FullStateDiagMatr matr) {
+    validate_matrixFields(matr, __func__);
+    validate_matrixNewElemsDontContainUnsyncFlag(matr.cpuElems[0], __func__);
+
+    if (matr.gpuElems != NULL)
+        gpu_copyCpuToGpu(matr);
 }
 
 
@@ -317,9 +411,8 @@ void validateAndSetCompMatrElems(CompMatr out, T elems, const char* caller) {
     // serially copy values to CPU memory
     populateCompMatrElems(out.cpuElems, elems, out.numRows);
 
-    // overwrite GPU elements (including unsync flag)
-    if (out.gpuElems != NULL)
-        gpu_copyCpuToGpu(out);
+    // overwrite GPU elements (including unsync flag); validation gauranteed to pass
+    syncCompMatr(out); 
 }
 
 extern "C" void setCompMatrFromPtr(CompMatr out, qcomp** elems) {
@@ -371,7 +464,7 @@ void setCompMatr(CompMatr out, std::vector<std::vector<qcomp>> in) {
 /*
  * OVERLOADED VARIABLE-SIZE DIAGONAL MATRIX INITIALISERS
  *
- * visible to both C and C++, although C++ additionally gets a vector overload.
+ * visible to both C and C++, although C++ additionally gets vector overloads.
  */
 
 
@@ -382,9 +475,8 @@ extern "C" void setDiagMatr(DiagMatr out, qcomp* in) {
     // overwrite CPU memory
     memcpy(out.cpuElems, in, out.numElems * sizeof(qcomp));
 
-    // overwrite GPU elements (including unsync flag)
-    if (out.gpuElems != NULL)
-        gpu_copyCpuToGpu(out);
+    // overwrite GPU elements (including unsync flag); validation gauranteed to pass
+    syncDiagMatr(out);
 }
 
 void setDiagMatr(DiagMatr out, std::vector<qcomp> in) {
@@ -398,6 +490,35 @@ void setDiagMatr(DiagMatr out, std::vector<qcomp> in) {
 }
 
 
+extern "C" void setFullStateDiagMatr(FullStateDiagMatr out, qindex startInd, qcomp* in, qindex numElems) {
+    validate_matrixFields(out, __func__);
+    validate_matrixNewElemsDontContainUnsyncFlag(in[0], __func__);
+    validate_fullStateDiagMatrNewElems(out, startInd, numElems, __func__);
+
+    // if the matrix is non-distributed, we update every node's duplicated CPU amps
+    if (!out.isDistributed)
+        memcpy(&out.cpuElems[startInd], in, numElems * sizeof(qcomp));
+
+    // distributed nodes containing no targeted elements do nothing
+    else if (!util_areAnyElemsWithinThisNode(out.numElemsPerNode, startInd, numElems))
+        return;
+
+    // but distributed nodes containing one or more targeted elems overwrite this subset
+    else {
+        util_IndexRange range = util_getLocalIndRangeOfElemsWithinThisNode(out.numElemsPerNode, startInd, numElems);
+        memcpy(&out.cpuElems[range.localDistribStartInd], &in[range.localDuplicStartInd], range.numElems * sizeof(qcomp));
+    }
+
+    // overwrite GPU; validation gauranteed to succeed
+    syncFullStateDiagMatr(out);
+}
+
+void setFullStateDiagMatr(FullStateDiagMatr out, qindex startInd, std::vector<qcomp> in) {
+
+    setFullStateDiagMatr(out, startInd, in.data(), in.size());
+}
+
+
 
 /*
  * C & C++ MATRIX REPORTERS
@@ -406,44 +527,37 @@ void setDiagMatr(DiagMatr out, std::vector<qcomp> in) {
  */
 
 
-// type T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2 or DiagMatr
+// type T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr, FullStateDiagMatr
 template <class T>
 void printMatrixHeader(T matr) {
 
-    // produce exact type string, e.g. DiagMatr2
-    std::string nameStr = (isDenseMatrixType<T>())? "CompMatr" : "DiagMatr";
-    if (isFixedSizeMatrixType<T>())
-        nameStr += form_str(matr.numQubits);
+    // determine how many nodes the matrix is distributed between (if it's a distributable type)
+    int numNodes = (util_isDistributedMatrix(matr))? getQuESTEnv().numNodes : 1;
 
-    // find memory (bytes) to store elements; equal to that of a non-distributed Qureg (statevec or dens-matr)
-    size_t elemMem = mem_getLocalMemoryRequired(matr.numQubits, isDenseMatrixType<T>(), 1); // 1 node
+    // find memory (bytes) to store elements
+    size_t elemMem = mem_getLocalMatrixMemoryRequired(matr.numQubits, util_isDenseMatrixType<T>(), numNodes);
 
     // find memory (bytes) of other struct fields; fixed-size sizeof includes arrays, var-size does not
     size_t otherMem = sizeof(matr);
-    if (isFixedSizeMatrixType<T>())
+    if (util_isFixedSizeMatrixType<T>())
         otherMem -= elemMem;
 
-    // find dimension; illegal field access in wrong branch removed at compile-time
-    qindex dim;
-    if constexpr (isDenseMatrixType<T>())
-        dim = matr.numRows;
-    else
-        dim = matr.numElems;
-
-    form_printMatrixInfo(nameStr, matr.numQubits, dim, elemMem, otherMem);
+    form_printMatrixInfo(util_getMatrixTypeName<T>(), matr.numQubits, util_getMatrixDim(matr), elemMem, otherMem, numNodes);
 }
 
 
-// type T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2 or DiagMatr
+// type T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr, FullStateDiagMatr
 template<class T> 
-void rootPrintMatrix(T matrix) {
-    
-    // only root note prints, to avoid spam in distributed settings
-    if (comm_getRank() != 0)
-        return;
+void validateAndPrintMatrix(T matr, const char* caller) {
+    validate_matrixFields(matr, caller);
 
-    printMatrixHeader(matrix);
-    form_printMatrix(matrix);
+    // syncable matrices must be synced before reporting (though only CPU elems are printed)
+    if constexpr (!util_isFixedSizeMatrixType<T>())
+        validate_matrixIsSynced(matr, caller);
+
+    // form_ functions will handle distributed coordination
+    printMatrixHeader(matr);
+    form_printMatrix(matr);
 }
 
 
@@ -451,21 +565,24 @@ void rootPrintMatrix(T matrix) {
 extern "C" {
     
     void reportCompMatr1(CompMatr1 matr) {
-        rootPrintMatrix(matr);
+        validateAndPrintMatrix(matr, __func__);
     }
     void reportCompMatr2(CompMatr2 matr) {
-        rootPrintMatrix(matr);
+        validateAndPrintMatrix(matr, __func__);
     }
     void reportCompMatr(CompMatr matr) {
-        rootPrintMatrix(matr);
+        validateAndPrintMatrix(matr, __func__);
     }
     void reportDiagMatr1(DiagMatr1 matr) {
-        rootPrintMatrix(matr);
+        validateAndPrintMatrix(matr, __func__);
     }
     void reportDiagMatr2(DiagMatr2 matr) {
-        rootPrintMatrix(matr);
+        validateAndPrintMatrix(matr, __func__);
     }
     void reportDiagMatr(DiagMatr matr) {
-        rootPrintMatrix(matr);
+        validateAndPrintMatrix(matr, __func__);
+    }
+    void reportFullStateDiagMatr(FullStateDiagMatr matr) {
+        validateAndPrintMatrix(matr, __func__);
     }
 }

--- a/quest/src/comm/comm_config.cpp
+++ b/quest/src/comm/comm_config.cpp
@@ -131,6 +131,11 @@ int comm_getRank() {
 }
 
 
+bool comm_isRootNode() {
+    return comm_getRank() == 0;
+}
+
+
 int comm_getNumNodes() {
 #if ENABLE_DISTRIBUTION
 

--- a/quest/src/comm/comm_config.hpp
+++ b/quest/src/comm/comm_config.hpp
@@ -9,35 +9,6 @@
 
 
 
-/*
- * MPI COMPLEX TYPE FLAG
- */
-
-#if ENABLE_DISTRIBUTION
-
-    #if (FLOAT_PRECISION == 1)
-        #define MPI_QCOMP MPI_CXX_FLOAT_COMPLEX
-
-    #elif (FLOAT_PRECISION == 2)
-        #define MPI_QCOMP MPI_CXX_DOUBLE_COMPLEX
-
-    // sometimes 'MPI_CXX_LONG_DOUBLE_COMPLEX' isn't defined
-    #elif (FLOAT_PRECISION == 4) && defined(MPI_CXX_LONG_DOUBLE_COMPLEX)
-        #define MPI_QCOMP MPI_CXX_LONG_DOUBLE_COMPLEX
-
-    // in that case, fall back to the C type (identical memory layout)
-    #else
-        #define MPI_QCOMP MPI_C_LONG_DOUBLE_COMPLEX
-    #endif
-
-#endif
-
-
-
-/*
- * MPI ENVIRONMENT MANAGEMENT
- */
-
 bool comm_isMpiCompiled();
 
 bool comm_isMpiGpuAware();
@@ -49,6 +20,8 @@ void comm_init();
 void comm_end();
 
 int comm_getRank();
+
+bool comm_isRootNode();
 
 int comm_getNumNodes();
 

--- a/quest/src/comm/comm_routines.cpp
+++ b/quest/src/comm/comm_routines.cpp
@@ -78,6 +78,32 @@ qindex MAX_MESSAGE_LENGTH = powerOf2(28);
 
 
 /*
+ * MPI COMPLEX TYPE FLAG
+ */
+
+
+#if ENABLE_DISTRIBUTION
+
+    #if (FLOAT_PRECISION == 1)
+        #define MPI_QCOMP MPI_CXX_FLOAT_COMPLEX
+
+    #elif (FLOAT_PRECISION == 2)
+        #define MPI_QCOMP MPI_CXX_DOUBLE_COMPLEX
+
+    // sometimes 'MPI_CXX_LONG_DOUBLE_COMPLEX' isn't defined
+    #elif (FLOAT_PRECISION == 4) && defined(MPI_CXX_LONG_DOUBLE_COMPLEX)
+        #define MPI_QCOMP MPI_CXX_LONG_DOUBLE_COMPLEX
+
+    // in that case, fall back to the C type (identical memory layout)
+    #else
+        #define MPI_QCOMP MPI_C_LONG_DOUBLE_COMPLEX
+    #endif
+
+#endif
+
+
+
+/*
  * MESSAGE SIZES
  */
 

--- a/quest/src/core/autodeployer.hpp
+++ b/quest/src/core/autodeployer.hpp
@@ -12,17 +12,19 @@
 
 
 
-#define MIN_NUM_LOCAL_QUBITS_FOR_AUTO_MULTITHREADING 8
+#define MIN_NUM_LOCAL_QUBITS_FOR_AUTO_QUREG_MULTITHREADING 8
 
-#define MIN_NUM_LOCAL_QUBITS_FOR_AUTO_GPU_ACCELERATION 12
+#define MIN_NUM_LOCAL_QUBITS_FOR_AUTO_QUREG_GPU_ACCELERATION 12
 
-#define MIN_NUM_LOCAL_QUBITS_FOR_AUTO_DISTRIBUTION 26
+#define MIN_NUM_LOCAL_QUBITS_FOR_AUTO_QUREG_DISTRIBUTION 26
 
 
 
 void autodep_chooseQuESTEnvDeployment(int &useDistrib, int &useGpuAccel, int &useMultithread);
 
 void autodep_chooseQuregDeployment(int numQubits, int isDensMatr, int &useDistrib, int &useGpuAccel, int &useMultithread, QuESTEnv env);
+
+void autodep_chooseFullStateDiagMatrDeployment(int numQubits, int &useDistrib, QuESTEnv env);
 
 
 

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -21,7 +21,7 @@
 
 void raiseInternalError(std::string errorMsg) {
 
-    if (comm_getRank() == 0)
+    if (comm_isRootNode())
         std::cout 
             << "\n\n"
             << "A fatal internal QuEST error occurred. "
@@ -52,6 +52,11 @@ void error_validationMessageVarNotSubstituted(std::string msg, std::string var) 
 void error_validationMessageContainedUnsubstitutedVars(std::string msg) {
 
     raiseInternalError("User input validation failed and an error string was prepared. However, the message contained unexpected (and potentially ill-formed) unsubstituted variables. The message was:\n" + msg + "\n");
+}
+
+void error_validationEncounteredUnsupportedDistributedDenseMatrix() {
+
+    raiseInternalError("User input validation processed a matrix it believed was both dense and distributed, though no such data structure currently exists.");
 }
 
 
@@ -257,6 +262,11 @@ void error_cuQuantumInitOrFinalizedButNotCompiled() {
 /*
  * UTILITY ERRORS 
  */
+
+void error_nodeUnexpectedlyContainedNoElems() {
+
+    raiseInternalError("A function queried which distributed elements within a specified range overlapped the node's stored elements, but the node contained no overlap. This situation should have been prior handled."); 
+}
 
 void assert_shiftedQuregIsDensMatr(Qureg qureg) {
     if (!qureg.isDensityMatrix)

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -25,6 +25,8 @@ void error_validationMessageVarNotSubstituted(std::string msg, std::string var);
 
 void error_validationMessageContainedUnsubstitutedVars(std::string msg);
 
+void error_validationEncounteredUnsupportedDistributedDenseMatrix();
+
 
 
 /*
@@ -64,7 +66,6 @@ void assert_validCommBounds(Qureg qureg, qindex sendInd, qindex recvInd, qindex 
 void assert_quregIsDistributed(Qureg qureg);
 
 void assert_pairRankIsDistinct(Qureg qureg, int pairRank);
-
 
 
 
@@ -126,8 +127,9 @@ void error_cuQuantumInitOrFinalizedButNotCompiled();
  * UTILITY ERRORS 
  */
 
-void assert_shiftedQuregIsDensMatr(Qureg qureg);
+void error_nodeUnexpectedlyContainedNoElems();
 
+void assert_shiftedQuregIsDensMatr(Qureg qureg);
 
 
 

--- a/quest/src/core/formatter.hpp
+++ b/quest/src/core/formatter.hpp
@@ -89,16 +89,15 @@ static std::string defaultTableIndent = "  ";
  * MATRIX PRINTING
  */
 
-void form_printMatrixInfo(std::string nameStr, int numQubits, qindex dim, size_t elemMem, size_t otherMem);
+void form_printMatrixInfo(std::string nameStr, int numQubits, qindex dim, size_t elemMem, size_t otherMem, int numNodes=1);
 
 void form_printMatrix(CompMatr1 matr, std::string indent=defaultMatrIndent);
 void form_printMatrix(CompMatr2 matr, std::string indent=defaultMatrIndent);
 void form_printMatrix(CompMatr  matr, std::string indent=defaultMatrIndent);
-
 void form_printMatrix(DiagMatr1 matr, std::string indent=defaultMatrIndent);
 void form_printMatrix(DiagMatr2 matr, std::string indent=defaultMatrIndent);
 void form_printMatrix(DiagMatr  matr, std::string indent=defaultMatrIndent);
-
+void form_printMatrix(FullStateDiagMatr matr, std::string indent=defaultMatrIndent);
 
 
 /*

--- a/quest/src/core/memory.hpp
+++ b/quest/src/core/memory.hpp
@@ -32,19 +32,22 @@ qindex mem_tryGetLocalRamCapacityInBytes();
 
 bool mem_canQuregFitInMemory(int numQubits, bool isDensMatr, int numNodes, qindex memBytesPerNode);
 
+bool mem_canMatrixFitInMemory(int numQubits, bool isDense, int numNodes, qindex memBytesPerNode);
+
 int mem_getEffectiveNumStateVecQubitsPerNode(int numQubits, bool isDensMatr, int numNodes);
 
 int mem_getMinNumQubitsForDistribution(int numNodes);
 
-int mem_getMaxNumQubitsWhichCanFitInMemory(bool isDensMatr, int numNodes, qindex memBytesPerNode);
+int mem_getMaxNumQuregQubitsWhichCanFitInMemory(bool isDensMatr, int numNodes, qindex memBytesPerNode);
 
 int mem_getMaxNumQubitsBeforeIndexOverflow(bool isDensMatr);
 
 int mem_getMaxNumQubitsBeforeLocalMemSizeofOverflow(bool isDensMatr, int numNodes);
 
-size_t mem_getLocalMemoryRequired(int numQubits, bool isDensMatr, int numNodes);
+size_t mem_getLocalMatrixMemoryRequired(int numQubits, bool isDenseMatrix, int numNodes);
 
-size_t mem_getLocalMemoryRequired(qindex numAmpsPerNode);
+size_t mem_getLocalQuregMemoryRequired(int numQubits, bool isDensityMatr, int numNodes);
+size_t mem_getLocalQuregMemoryRequired(qindex numAmpsPerNode);
 
 qindex mem_getTotalGlobalMemoryUsed(Qureg qureg);
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -8,7 +8,10 @@
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/utilities.hpp"
+#include "quest/src/comm/comm_config.hpp"
+#include "quest/src/comm/comm_routines.hpp"
 
+#include <algorithm>
 #include <complex>
 
 
@@ -127,6 +130,16 @@ bool util_isUnitary(DiagMatr matrix) {
     return isUnitary(matrix.cpuElems, matrix.numElems);
 }
 
+bool util_isUnitary(FullStateDiagMatr matrix) {
+
+    // we must check all node's sub-diagonals satisfy unitarity
+    bool res = isUnitary(matrix.cpuElems, matrix.numElems);
+    if (comm_isInit())
+        res = comm_isTrueOnAllNodes(res);
+
+    return res;
+}
+
 
 
 /*
@@ -137,4 +150,59 @@ int util_getShifted(int qubit, Qureg qureg) {
     assert_shiftedQuregIsDensMatr(qureg);
     
     return qubit + qureg.numQubits;
+}
+
+
+
+/*
+ * DISTRIBUTED ELEMENTS INDEXING
+ */
+
+bool util_areAnyElemsWithinThisNode(int numElemsPerNode, qindex elemStartInd, qindex numInds) {
+
+    qindex elemEndIndExcl = elemStartInd + numInds;
+    qindex nodeStartInd = comm_getRank() * numElemsPerNode;
+    qindex nodeEndIndExcl = nodeStartInd + numElemsPerNode;
+
+    // 'no' if all targeted elems occur after this node
+    if (elemStartInd >= nodeEndIndExcl)
+        return false;
+
+    // 'no' if all targeted elems occur before this node
+    if (elemEndIndExcl <= nodeStartInd)
+        return false;
+
+    // otherwise yes; this node MUST contain one or more targeted elems
+    return true;
+}
+
+util_IndexRange util_getLocalIndRangeOfElemsWithinThisNode(int numElemsPerNode, qindex elemStartInd, qindex numInds) {
+
+    if (!util_areAnyElemsWithinThisNode(numElemsPerNode, elemStartInd, numInds))
+        error_nodeUnexpectedlyContainedNoElems();
+
+    // global indices of the user's targeted elements
+    qindex elemEndInd = elemStartInd + numInds;
+
+    // global indices of all elements contained in the node
+    qindex nodeStartInd = numElemsPerNode * comm_getRank();
+    qindex nodeEndInd   = nodeStartInd + numElemsPerNode;
+
+    // global indices of user's targeted elements which are contained within node
+    qindex globalRangeStartInd = std::max(elemStartInd, nodeStartInd);
+    qindex globalRangeEndInd   = std::min(elemEndInd,   nodeEndInd);
+    qindex numLocalElems       = globalRangeEndInd - globalRangeStartInd;
+
+    // local indices of user's targeted elements to overwrite
+    qindex localRangeStartInd = globalRangeStartInd % numElemsPerNode;
+    qindex localRangeEndInd   = localRangeStartInd + numLocalElems;
+
+    // local indices of user's passed elements that correspond to above
+    qindex localOffsetInd = globalRangeStartInd - elemStartInd;
+    
+    return (util_IndexRange) {
+        .localDistribStartInd = localRangeStartInd,
+        .localDuplicStartInd = localOffsetInd,
+        .numElems = numLocalElems
+    };
 }

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -177,8 +177,46 @@ namespace report {
     std::string NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE = 
         "Cannot create a matrix which acts upon ${NUM_QUBITS} qubits; must target one or more qubits.";
 
-    std::string NEW_MATRIX_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
-        "Cannot create a matrix which acts upon ${NUM_QUBITS} qubits since the necessary memory size (${QCOMP_BYTES} * 2^${DUB_QUBITS} bytes) would overflow size_t, and be intractably slow to serially process. The maximum size matrix targets ${MAX_QUBITS} qubits.";
+
+    std::string NEW_DIAG_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX =
+        "Cannot create a diagonal matrix of ${NUM_QUBITS} qubits: the matrix would contain more elements (2^${NUM_QUBITS}) than the maximum which can be addressed by the qindex type (2^${MAX_QUBITS}).";
+
+    std::string NEW_COMP_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX =
+        "Cannot create a dense matrix of ${NUM_QUBITS} qubits: the matrix would contain more elements (4^${NUM_QUBITS}) than the maximum which can be addressed by the qindex type (4^${MAX_QUBITS}).";
+
+
+    std::string NEW_LOCAL_COMP_MATR_MEM_WOULD_EXCEED_SIZEOF =
+        "Cannot create a local, dense matrix of ${NUM_QUBITS} qubits because the necessary memory (in bytes) would overflow size_t. In this deployment, the maximum number of qubits in such a matrix is ${MAX_QUBITS}.";
+
+    std::string NEW_LOCAL_DIAG_MATR_MEM_WOULD_EXCEED_SIZEOF =
+        "Cannot create a local, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (in bytes) would overflow size_t. In this deployment, the maximum number of qubits in such a matrix is ${MAX_QUBITS}.";
+
+    std::string NEW_DISTRIB_DIAG_MATR_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
+        "Cannot create a diagonal matrix of ${NUM_QUBITS} qubits distributed over ${NUM_NODES} nodes because the necessary local memory (in bytes) of each node would overflow size_t. In this deployment, the maximum number of qubits in such a matrix is ${MAX_QUBITS}.";
+
+
+    std::string NEW_DISTRIB_DIAG_MATR_HAS_TOO_FEW_AMPS =
+        "Cannot create a diagonal matrix of ${NUM_QUBITS} distributed between ${NUM_NODES} nodes because each node would contain fewer than one element. The minimum number of qubits in such a matrix is ${MIN_QUBITS}. Consider disabling distribution for this matrix.";
+
+
+    std::string NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_CPU_MEM =
+        "Cannot create a local, dense matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 4^${NUM_QUBITS} bytes) exceeds the available RAM of ${RAM_SIZE} bytes.";
+
+    std::string NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM =
+        "Cannot create a local, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 2^${NUM_QUBITS} bytes) exceeds the available RAM of ${RAM_SIZE} bytes.";
+
+    std::string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM =
+        "Cannot create a diagonal matrix of ${NUM_QUBITS} qubits distributed between ${NUM_NODES} because the necessary memory per node (${QCOMP_BYTES} * 2^${NUM_QB_MINUS_LOG_NODES} bytes) exceeds the local available RAM of ${RAM_SIZE} bytes.";
+
+
+    std::string NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_GPU_MEM =
+        "Cannot create a local, GPU-accelerated, dense matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 4^${NUM_QUBITS} bytes) exceeds the available GPU memory of ${VRAM_SIZE} bytes.";
+
+    std::string NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
+        "Cannot create a local, GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 2^${NUM_QUBITS} bytes) exceeds the available GPU memory of ${VRAM_SIZE} bytes.";
+
+    std::string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
+        "Cannot create a GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits distributed between ${NUM_NODES} because the necessary memory per node (${QCOMP_BYTES} * 2^${NUM_QB_MINUS_LOG_NODES} bytes) exceeds the local available GPU memory of ${RAM_SIZE} bytes.";
 
 
     std::string NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED = 
@@ -186,6 +224,45 @@ namespace report {
 
     std::string NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED = 
         "Attempted allocation of GPU memory (${NUM_BYTES} bytes in VRAM) failed.";
+
+
+    std::string NEW_DISTRIB_MATRIX_IN_NON_DISTRIB_ENV = 
+        "Cannot distribute a matrix in a non-distributed environment.";
+
+    std::string INVALID_OPTION_FOR_MATRIX_IS_DISTRIB = 
+        "Argument 'useDistrib' must be 1 or 0 to respectively indicate whether or not to distribute the new matrix, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
+
+
+
+    /*
+     * MATRIX INITIALISATION
+     */
+
+    std::string MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
+        "The new elements contained a reserved, forbidden value as the first element, used internally to detect that whether GPU memory has not synchronised. The value was intended to be extremely unlikely to be used by users - go buy a lottery ticket! If you insist on using this value in the first element, add a numerically insignificant perturbation.";
+
+
+    std::string COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS =
+        "Incompatible number of rows (${NUM_GIVEN_ROWS}) of elements given to overwrite a ${NUM_QUBITS}-qubit CompMatr, which expects ${NUM_EXPECTED_ROWS} rows.";
+
+    std::string COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM =
+        "One or more rows contained an incompatible number of elements (${NUM_GIVEN_ELEMS}). The ${NUM_QUBITS}-qubit CompMatr expects a square ${EXPECTED_DIM}x${EXPECTED_DIM} matrix.";
+
+    std::string DIAG_MATR_WRONG_NUM_NEW_ELEMS = 
+        "Incompatible number of elements (${NUM_GIVEN_ELEMS}) assigned to a ${NUM_QUBITS}-qubit DiagMatr, which expects ${NUM_EXPECTED_ELEMS} elements.";
+    
+
+    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_INVALID_START_INDEX =
+        "Invalid start index (${START_IND}), which must be non-negative and smaller than the total number of diagonal elements in the matrix (${MATR_NUM_ELEMS}).";
+
+    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_IS_NON_POSITIVE =
+        "Invalid number of new elements (${NUM_ELEMS}). Must be greater than zero.";
+
+    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_EXCEEDS_MAX_NUM =
+        "The given number of new elements (${NEW_NUM_ELEMS}) exceeds the total number of diagonal elements in the matrix (${MATR_NUM_ELEMS}).";
+
+    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_EXCEEDS_END_INDEX =
+        "The specified range of elements to set (at indices ${START_IND} to ${END_IND_EXCL} exclusive) exceeds the bounds of the diagonal matrix (of ${MATR_NUM_ELEMS} total elements).";
 
 
     /*
@@ -224,8 +301,15 @@ namespace report {
         "Invalid DiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
 
 
-    std::string MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
-        "The new elements contained a reserved, forbidden value as the first element, used internally to detect that whether GPU memory has not synchronised. The value was intended to be extremely unlikely to be used by users - go buy a lottery ticket! If you insist on using this value in the first element, add a numerically insignificant perturbation.";
+    std::string INVALID_FULL_STATE_DIAG_MATR_FIELDS = 
+        "Invalid FullStateDiagMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createFullStateDiagMatr().";
+
+    std::string INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC =
+        "Invalid FullStateDiagMatr. The CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createFullStateDiagMatr().";
+
+    std::string INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC =
+        "Invalid FullStateDiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createFullStateDiagMatr().";
+
 
     std::string COMP_MATR_NOT_SYNCED_TO_GPU = 
         "The CompMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncCompMatr() after manually modifying elements, or overwrite all elements with setCompMatr().";
@@ -233,19 +317,18 @@ namespace report {
     std::string DIAG_MATR_NOT_SYNCED_TO_GPU = 
         "The DiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncDiagMatr() after manually modifying elements, or overwrite all elements with setDiagMatr().";
 
+    std::string FULL_STATE_DIAG_MATR_NOT_SYNCED_TO_GPU = 
+        "The FullStateDiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncFullStateDiagMatr() after manually modifying elements, or overwrite elements in batch with setFullStateDiagMatr().";
 
-    std::string COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS =
-        "Incompatible number of rows (${NUM_GIVEN_ROWS}) of elements given to overwrite a ${NUM_QUBITS}-qubit CompMatr, which expects ${NUM_EXPECTED_ROWS} rows.";
-
-    std::string COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM =
-        "One or more rows contained an incompatible number of elements (${NUM_GIVEN_ELEMS}). The ${NUM_QUBITS}-qubit CompMatr expects a square ${EXPECTED_DIM}x${EXPECTED_DIM} matrix.";
-
-    std::string DIAG_MATR_WRONG_NUM_NEW_ELEMS = 
-        "Incompatible number of elements (${NUM_GIVEN_ELEMS}) assigned to a ${NUM_QUBITS}-qubit DiagMatr, which expects ${NUM_EXPECTED_ELEMS} elements.";
-    
 
     std::string MATRIX_NOT_UNITARY = 
         "The given matrix was not (approximately) unitary.";
+
+    std::string FULL_STATE_DIAG_MATR_MISMATCHES_QUREG_DIM =
+        "The given FullStateDiagMatr operates upon a different number of qubits (${NUM_MATR_QUBITS}) than exists in the Qureg (${NUM_QUREG_QUBITS}).";
+
+    std::string FULL_STATE_DIAG_MATR_IS_DISTRIB_BUT_QUREG_ISNT =
+        "The given FullStateDiagMatr is distributed but the Qureg is not, which is forbidden. Consider disabling distribution for this matrix via createCustomFullStateDiagMatr().";
 
 
     /*
@@ -274,7 +357,7 @@ namespace report {
 void default_invalidQuESTInputError(const char* msg, const char* func) {
 
     // safe to call even before MPI has been setup
-    if (comm_getRank() == 0)
+    if (comm_isRootNode())
         std::cout 
             << "QuEST encountered a validation error during function '" << func << "':\n"
             << msg << "\nExiting..." 
@@ -628,6 +711,7 @@ void assertQuregFitsInGpuMem(int numQubits, int isDensMatr, int isDistrib, int i
         vars["${NUM_GPUS}"] = numQuregNodes;
 
         // require expensive node consensus in case of heterogeneous GPU hardware or loads
+        assertAllNodesAgreeThat(quregFitsInMem, report::NEW_QUREG_CANNOT_FIT_INTO_POTENTIALLY_DISTRIB_CURRENT_GPU_MEM, vars, caller);
     }
 }
 
@@ -682,6 +766,8 @@ void validate_quregFields(Qureg qureg, const char* caller) {
     valid &= (qureg.isDensityMatrix == 0 || qureg.isDensityMatrix == 1);
     valid &= (qureg.numAmps == powerOf2(((qureg.isDensityMatrix)? 2:1) * qureg.numQubits));
 
+    // we do not bother checking slightly more involved fields like numAmpsPerNode
+
     tokenSubs vars = {
         {"${DENS_MATR}", qureg.isDensityMatrix},
         {"${NUM_QUBITS}", qureg.numQubits},
@@ -706,35 +792,238 @@ void validate_quregFields(Qureg qureg, const char* caller) {
  * MATRIX CREATION
  */
 
-void assertNewMatrixNotTooBig(int numQubits, const char* caller) {
+void assertMatrixDeployFlagsRecognised(int isDistrib, const char* caller) {
 
-    // assert the total memory (in bytes) to store the matrix
-    // (i.e. all of its row arrays combined) does not exceed
-    // max size_t, so sizeof doesn't overflow. We may never
-    // actually need to compute all memory, but the threshold
-    // for causing this overflow is already impractically huge,
-    // and this is the 'smallest' max-size threshold we can test
-    // without querying RAM and VRAM occupancy. We can't do the
-    // latter ever since the CompMatr might never be dispatched
-    // to the GPU.
+    // deployment flags must be boolean or auto
+    assertThat(
+        isDistrib == 0 || isDistrib == 1 || isDistrib == modeflag::USE_AUTO, 
+        report::INVALID_OPTION_FOR_MATRIX_IS_DISTRIB,
+        {{"${AUTO_DEPLOYMENT_FLAG}", modeflag::USE_AUTO}}, caller);
+}
 
-    // the total ComplexMatrixN memory equals that of a same-size density matrix
-    bool isDensMatr = true;
-    int maxQubits = mem_getMaxNumQubitsBeforeIndexOverflow(isDensMatr);
+void assertMatrixDeploysEnabledByEnv(int isDistrib, int envIsDistrib, const char* caller) {
+
+    // cannot deploy to backend not already enabled by the environment
+    if (!envIsDistrib)
+        assertThat(isDistrib == 0 || isDistrib == modeflag::USE_AUTO, report::NEW_DISTRIB_MATRIX_IN_NON_DISTRIB_ENV, caller);
+}
+
+void assertMatrixNonEmpty(int numQubits, const char* caller) {
+
+    assertThat(numQubits >= 1, report::NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE, caller);
+}
+
+void assertMatrixTotalNumElemsDontExceedMaxIndex(int numQubits, bool isDense, const char* caller) {
+
+    int maxNumQubits = mem_getMaxNumQubitsBeforeIndexOverflow(isDense);
+
+    std::string msg = (isDense)?
+        report::NEW_DIAG_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX :
+        report::NEW_COMP_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX ;
+
+    tokenSubs vars = {
+        {"${NUM_QUBITS}", numQubits}, 
+        {"${MAX_QUBITS}", maxNumQubits}};
+
+    assertThat(numQubits <= maxNumQubits, msg, vars, caller);
+}
+
+void assertMatrixLocalMemDoesntExceedMaxSizeof(int numQubits, bool isDense, int isDistrib, int numEnvNodes, const char* caller) {
+
+    // 'isDistrib' can be 0 (user-disabled, or matrix is a local type), 1 (user-forced)
+    // or -1 (automatic; the type can be distributed but the user has not forced it). 
+    // Currently, only distributed diagonal matrices are supported, so isDistrib must be
+    // concreely 0 for dense matrices.
+    if (isDense && isDistrib != 0)
+        error_validationEncounteredUnsupportedDistributedDenseMatrix();
+
+    // assume distributed (unless it is force disabled), because that reduces the memory required
+    // per node and is ergo more permissive - and the auto-deployer would never choose non-distribution
+    // in a distributed env if the memory would exceed the max sizeof!
+    int numMatrNodes = (isDistrib == 0)? 1 : numEnvNodes;
+
+    // the diag matrix would have the same cost as a statevector Qureg, and be distributed as such
+    int maxNumQubits = mem_getMaxNumQubitsBeforeLocalMemSizeofOverflow(isDense, numMatrNodes);
+
+    // make error message specific to whether the matrix is distributed or non-distributed type;
+    // non-distributed matrices (e.g. CompMatr) should only ever cause the local error message
+    std::string msg = (numMatrNodes > 1)?
+        report::NEW_DISTRIB_DIAG_MATR_LOCAL_MEM_WOULD_EXCEED_SIZEOF :
+        ((isDense)?
+            report::NEW_LOCAL_COMP_MATR_MEM_WOULD_EXCEED_SIZEOF :
+            report::NEW_LOCAL_DIAG_MATR_MEM_WOULD_EXCEED_SIZEOF);
+    
+    tokenSubs vars = {
+        {"${NUM_QUBITS}", numQubits},
+        {"${MAX_QUBITS}", maxNumQubits}};
+    if (numMatrNodes > 1)
+        vars["${NUM_NODES}"] = numMatrNodes;
+
+    assertThat(numQubits <= maxNumQubits, msg, vars, caller);
+}
+
+void assertMatrixNotDistributedOverTooManyNodes(int numQubits, bool isDense, int isDistrib, int numEnvNodes, const char* caller) {
+
+    // 'isDistrib' can be 0 (user-disabled, or matrix is a local type), 1 (user-forced)
+    // or -1 (automatic; the type can be distributed but the user has not forced it). 
+    // Currently, only distributed diagonal matrices are supported, so isDistrib must be
+    // concreely 0 for dense matrices.
+    if (isDense && isDistrib != 0)
+        error_validationEncounteredUnsupportedDistributedDenseMatrix();
+
+    // only need to validate when distribution is forced (auto-deployer will never over-distribute,
+    // and non-distributed types (like CompMatr) will pass isDistrib=0
+    if (isDistrib != 1)
+        return;
+
+    // distributed diagonal matrices require at least 1 element per node, and while we
+    // don't yet support distributed complex matrices, let's for now assume they would
+    // require having at leat 1 column per node, like density matrix Quregs do.
+    int minQubits = mem_getMinNumQubitsForDistribution(numEnvNodes);
+
+    std::string msg = report::NEW_DISTRIB_DIAG_MATR_HAS_TOO_FEW_AMPS;
+    tokenSubs vars = {
+        {"${NUM_QUBITS}", numQubits},
+        {"${MIN_QUBITS}", minQubits},
+        {"${NUM_NODES}",  numEnvNodes}};
+        
+    assertThat(numQubits >= minQubits, msg, vars, caller);
+}
+
+void assertMatrixFitsInCpuMem(int numQubits, bool isDense, int isDistrib, int numEnvNodes, const char* caller) {
+
+    // 'isDistrib' can be 0 (user-disabled, or matrix is a local type), 1 (user-forced)
+    // or -1 (automatic; the type can be distributed but the user has not forced it). 
+    // Currently, only distributed diagonal matrices are supported, so isDistrib must be
+    // concreely 0 for dense matrices.
+    if (isDense && isDistrib != 0)
+        error_validationEncounteredUnsupportedDistributedDenseMatrix();
+
+    // attempt to fetch RAM, and simply return if we fail; if we unknowingly
+    // didn't have enough RAM, then alloc validation will trigger later
+    size_t memPerNode = 0;
+    try {
+        memPerNode = mem_tryGetLocalRamCapacityInBytes();
+    } catch(mem::COULD_NOT_QUERY_RAM e) {
+        return;
+    }
+
+    // check whether matrix (considering if distributed) fits between node memory(s).
+    // note this sets numMatrNodes=1 only when distribution is impossible/switched-off,
+    // but not when it would later be automatically disabled. That's fine; the auto-deployer
+    // will never disable distribution if the RAM can't store the entire matrix, so we 
+    // don't need to validate the auto-deployed-to-non-distributed scenario. We only need to 
+    // ensure that auto-deploying-to-distribution is permitted by memory capacity. Note too
+    // that the distinction between (env.isDistributed) and (env.numNodes>1) is unimportant
+    // for matrix structs because they never store communication buffers.
+    int numMatrNodes = (isDistrib == 0)? 1 : numEnvNodes;
+    bool matrFitsInMem = mem_canMatrixFitInMemory(numQubits, isDense, numMatrNodes, memPerNode);
+
+    // specialise error message to whether matrix is distributed and dense or diag
+    std::string msg = (isDense)?
+        report::NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_CPU_MEM :
+        ((numMatrNodes == 1)?
+            report::NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM :
+            report::NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM );
 
     tokenSubs vars = {
         {"${NUM_QUBITS}",  numQubits},
-        {"${MAX_QUBITS}",  maxQubits},
-        {"${DUB_QUBITS}",   2*numQubits},
-        {"${QCOMP_BYTES}", sizeof(qcomp)}};
+        {"${QCOMP_BYTES}", sizeof(qcomp)},
+        {"${RAM_SIZE}",    memPerNode}};
 
-    assertThat(numQubits < maxQubits, report::NEW_MATRIX_LOCAL_MEM_WOULD_EXCEED_SIZEOF, vars, caller);
+    if (numMatrNodes > 1) {
+        vars["${NUM_NODES}"] = numMatrNodes;
+        vars["${NUM_QB_MINUS_LOG_NODES}"] = numQubits - logBase2(numMatrNodes);
+    }
+    
+    // seek expensive node consensus in case of heterogeneous RAM - alas this may induce
+    // unnecessary slowdown (due to sync and broadcast) in applications allocating many
+    // small matrices in the heap. If this turns out to be the case, we could opt to
+    // enforce consensus only when the needed memory is large (e.g. >1GB) and ergo the 
+    // chance of it fitting into some node RAM but not others isn't negligible.
+    assertAllNodesAgreeThat(matrFitsInMem, msg, vars, caller);
 }
 
-void validate_newMatrixNumQubits(int numQubits, const char* caller) {
+void assertMatrixFitsInGpuMem(int numQubits, bool isDense, int isDistrib, int isEnvGpuAccel, int numEnvNodes, const char* caller) {
 
-    assertThat(numQubits >= 1, report::NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE, caller);
-    assertNewMatrixNotTooBig(numQubits, caller);
+    // 'isDistrib' can be 0 (user-disabled, or matrix is a local type), 1 (user-forced)
+    // or -1 (automatic; the type can be distributed but the user has not forced it). 
+    // Currently, only distributed diagonal matrices are supported, so isDistrib must be
+    // concreely 0 for dense matrices.
+    if (isDense && isDistrib != 0)
+        error_validationEncounteredUnsupportedDistributedDenseMatrix();
+
+    // matrix GPU memory will always be allocated when env is GPU-accelerated
+    if (!isEnvGpuAccel)
+        return;
+
+    // we consult the current available local GPU memory (being more strict than is possible for RAM)
+    size_t localCurrGpuMem = gpu_getCurrentAvailableMemoryInBytes();
+
+    // check whether matrix (considering if distributed) fits between node memory(s).
+    // note this sets numMatrNodes=1 only when distribution is impossible/switched-off,
+    // but not when it would later be automatically disabled. That's fine; the auto-deployer
+    // will never disable distribution if the local GPU can't store the entire matrix, so we 
+    // don't need to validate the auto-deployed-to-non-distributed scenario. We only need to 
+    // ensure that auto-deploying-to-distribution is permitted by memory capacity. Note too
+    // that the distinction between (env.isDistributed) and (env.numNodes>1) is unimportant
+    // for matrix structs because they never store communication buffers.
+    int numMatrNodes = (isDistrib == 0)? 1 : numEnvNodes;
+    bool matrFitsInMem = mem_canMatrixFitInMemory(numQubits, isDense, numMatrNodes, localCurrGpuMem);
+
+    // specialise error message to whether matrix is distributed and dense or diag
+    std::string msg = (isDense)?
+        report::NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_GPU_MEM :
+        ((numMatrNodes == 1)?
+            report::NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM :
+            report::NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM );
+
+    tokenSubs vars = {
+        {"${NUM_QUBITS}",  numQubits},
+        {"${QCOMP_BYTES}", sizeof(qcomp)},
+        {"${VRAM_SIZE}",   localCurrGpuMem}};
+        
+    if (numMatrNodes > 1) {
+        vars["${NUM_NODES}"] = numMatrNodes;
+        vars["${NUM_QB_MINUS_LOG_NODES}"] = numQubits - logBase2(numMatrNodes);
+    }
+    
+    // seek expensive node consensus in case of heterogeneous GPU hardware - alas this may 
+    // induce unnecessary slowdown (due to sync and broadcast) in applications allocating many
+    // small matrices in the GPU. If this turns out to be the case, we could opt to
+    // enforce consensus only when the needed memory is large (e.g. >1GB) and ergo the 
+    // chance of it fitting into some GPU's memory but not others isn't negligible.
+    assertAllNodesAgreeThat(matrFitsInMem, msg, vars, caller);
+}
+
+void assertNewMatrixParamsAreValid(int numQubits, int useDistrib, bool isDenseType, const char* caller) {
+    validate_envIsInit(caller);
+    QuESTEnv env = getQuESTEnv();
+
+    assertMatrixNonEmpty(numQubits, caller);
+    assertMatrixTotalNumElemsDontExceedMaxIndex(numQubits, isDenseType, caller);
+    assertMatrixLocalMemDoesntExceedMaxSizeof(numQubits,  isDenseType, useDistrib, env.numNodes, caller);
+    assertMatrixNotDistributedOverTooManyNodes(numQubits, isDenseType, useDistrib, env.numNodes, caller);
+    assertMatrixFitsInCpuMem(numQubits, isDenseType, useDistrib, env.numNodes, caller);
+    assertMatrixFitsInGpuMem(numQubits, isDenseType, useDistrib, env.isGpuAccelerated, env.numNodes, caller);
+}
+
+void validate_newCompMatrParams(int numQubits, const char* caller) {
+
+    int useDistrib = 0;
+    bool isDenseType = true;
+    assertNewMatrixParamsAreValid(numQubits, useDistrib, isDenseType, caller);
+}
+void validate_newDiagMatrParams(int numQubits, const char* caller) {
+
+    int useDistrib = 0;
+    bool isDenseType = false;
+    assertNewMatrixParamsAreValid(numQubits, useDistrib, isDenseType, caller);
+}
+void validate_newFullStateDiagMatrParams(int numQubits, int useDistrib, const char* caller) {
+
+    bool isDenseType = false;
+    assertNewMatrixParamsAreValid(numQubits, useDistrib, isDenseType, caller);
 }
 
 void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller) {
@@ -757,6 +1046,21 @@ void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller
 void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller) {
     tokenSubs vars = {{"${NUM_BYTES}", numBytes}};
 
+    // we expensively get node consensus about malloc failure, in case of heterogeneous hardware/loads
+
+    // assert CPU array of rows was malloc'd successfully
+    assertAllNodesAgreeThat(matr.cpuElems != NULL, report::NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED, vars, caller);
+
+    // optionally assert GPU memory was malloc'd successfully
+    if (getQuESTEnv().isGpuAccelerated)
+        assertAllNodesAgreeThat(matr.gpuElems != NULL, report::NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED, vars, caller);
+}
+
+void validate_newMatrixAllocs(FullStateDiagMatr matr, qindex numBytes, const char* caller) {
+    tokenSubs vars = {{"${NUM_BYTES}", numBytes}};
+
+    // we expensively get node consensus about malloc failure, in case of heterogeneous hardware/loads
+
     // assert CPU array of rows was malloc'd successfully
     assertAllNodesAgreeThat(matr.cpuElems != NULL, report::NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED, vars, caller);
 
@@ -775,7 +1079,7 @@ void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller
 template <class T>
 void assertMatrixFieldsAreValid(T matr, int expectedNumQb, std::string errMsg, const char* caller) {
 
-    qindex dim = getMatrixDim(matr);
+    qindex dim = util_getMatrixDim(matr);
     tokenSubs vars = {
         {"${NUM_QUBITS}", matr.numQubits},
         {"${NUM_ROWS}",   dim}};
@@ -784,9 +1088,14 @@ void assertMatrixFieldsAreValid(T matr, int expectedNumQb, std::string errMsg, c
     // where the error message string already contains the expected numQb
     assertThat(matr.numQubits == expectedNumQb, errMsg, vars, caller);
 
+    // validate .numQubits and .numRows or .numElems
     qindex expectedDim = powerOf2(matr.numQubits);
     assertThat(matr.numQubits >= 1, errMsg, vars, caller);
     assertThat(dim == expectedDim,  errMsg, vars, caller);
+
+    // we do not bother checking slightly more involved fields like numAmpsPerNode - there's
+    // no risk that they're wrong (because they're constant), we've only sought to ensure the
+    // matrix was properly initialised and doesn't contain random data, which we have already.
 }
 
 // T can be CompMatr or DiagMatr (the only matrix structs with pointers)
@@ -805,6 +1114,7 @@ void assertMatrixAllocsAreValid(T matr, std::string cpuErrMsg, std::string gpuEr
     // serially process each row pointer.
 
     // optionally assert GPU memory is allocated
+    validate_envIsInit(caller);
     if (getQuESTEnv().isGpuAccelerated)
         assertThat(matr.gpuElems != NULL, gpuErrMsg, caller);
 }
@@ -829,9 +1139,14 @@ void validate_matrixFields(DiagMatr matr, const char* caller) {
     assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_DIAG_MATR_FIELDS, caller);
     assertMatrixAllocsAreValid(matr, report::INVALID_DIAG_MATR_CPU_MEM_ALLOC, report::INVALID_DIAG_MATR_GPU_MEM_ALLOC, caller);
 }
+void validate_matrixFields(FullStateDiagMatr matr, const char* caller) {
+    assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_FULL_STATE_DIAG_MATR_FIELDS, caller);
+    assertMatrixAllocsAreValid(matr, report::INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC, report::INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC, caller);
+}
 
 void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller) {
 
+    // CompMatr accept 2D elems   
     qindex dim = powerOf2(numQubits);
     tokenSubs vars = {
         {"${NUM_QUBITS}",        numQubits},
@@ -862,6 +1177,37 @@ void validate_matrixNumNewElems(int numQubits, std::vector<qcomp> elems, const c
     assertThat(elems.size() == dim, report::DIAG_MATR_WRONG_NUM_NEW_ELEMS, vars, caller);
 }
 
+void validate_fullStateDiagMatrNewElems(FullStateDiagMatr matr, qindex startInd, qindex numElems, const char* caller) {
+
+    assertThat(
+        startInd >= 0 && startInd < matr.numElems, 
+        report::FULL_STATE_DIAG_MATR_NEW_ELEMS_INVALID_START_INDEX, 
+        {{"${START_IND}", startInd}, {"${MATR_NUM_ELEMS}", matr.numElems}},
+        caller);
+
+    assertThat(
+        numElems > 0,
+        report::FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_IS_NON_POSITIVE, 
+        {{"${NUM_ELEMS}", numElems}}, caller);
+
+    assertThat(
+        numElems <= matr.numElems,
+        report::FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_EXCEEDS_MAX_NUM, 
+        {{"${NEW_NUM_ELEMS}", numElems}, {"${MATR_NUM_ELEMS}", matr.numElems}},
+        caller);
+
+    qindex endIndExcl = startInd + numElems;
+    tokenSubs vars = {
+        {"${START_IND}",      startInd},
+        {"${MATR_NUM_ELEMS}", matr.numElems},
+        {"${END_IND_EXCL}",   endIndExcl}};
+       
+    assertThat(
+        endIndExcl <= matr.numElems, 
+        report::FULL_STATE_DIAG_MATR_NEW_ELEMS_EXCEEDS_END_INDEX,  
+        vars, caller);
+}
+
 void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller) {
 
     // we permit the matrix to contain the GPU-mem-unsync flag in CPU-only mode,
@@ -869,7 +1215,10 @@ void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* c
     if (!getQuESTEnv().isGpuAccelerated)
         return;
 
-    assertThat(!gpu_doCpuAmpsHaveUnsyncMemFlag(firstElem), report::MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG, caller);
+    // to work with distributed FullStateDiagMatr, whereby we wish to check that
+    // every node's GPU elems have been overwritten (not just e.g. the root node's),
+    // we need to gather expensive consensus on the validity. 
+    assertAllNodesAgreeThat(!gpu_doCpuAmpsHaveUnsyncMemFlag(firstElem), report::MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG, caller);
 }
 
 // type T can be CompMatr or DiagMatr
@@ -880,7 +1229,7 @@ void assertMatrixIsSynced(T matr, std::string errMsg, const char* caller) {
     validate_matrixFields(matr, caller);
 
     // we don't need to perform any sync check in CPU-only mode
-    if (matr.gpuElems != NULL)
+    if (matr.gpuElems == NULL)
         return;
 
     // check if GPU amps have EVER been overwritten; we sadly cannot check the LATEST changes were pushed though
@@ -911,6 +1260,9 @@ void validate_matrixIsSynced(CompMatr matr, const char* caller) {
 void validate_matrixIsSynced(DiagMatr matr, const char* caller) {
     assertMatrixIsSynced(matr, report::DIAG_MATR_NOT_SYNCED_TO_GPU, caller);
 }
+void validate_matrixIsSynced(FullStateDiagMatr matr, const char* caller) {
+    assertMatrixIsSynced(matr, report::FULL_STATE_DIAG_MATR_NOT_SYNCED_TO_GPU, caller);
+}
 
 void validate_matrixIsUnitary(CompMatr1 matr, const char* caller) {
     validate_matrixFields(matr, caller);
@@ -935,6 +1287,33 @@ void validate_matrixIsUnitary(DiagMatr2 matr, const char* caller) {
 void validate_matrixIsUnitary(DiagMatr matr, const char* caller) {
     validate_matrixIsSynced(matr, caller); // also checks fields
     assertMatrixIsUnitary(matr, caller);
+}
+void validate_matrixIsUnitary(FullStateDiagMatr matr, const char* caller) {
+    validate_matrixIsSynced(matr, caller); // also checks fields
+    assertMatrixIsUnitary(matr, caller);
+}
+
+void validate_matrixIsCompatibleWithQureg(FullStateDiagMatr matr, Qureg qureg, const char* caller) {
+
+    // we do not need to define this function for the other matrix types,
+    // since their validation will happen through validaiton of the
+    // user-given list of target qubits. But we do need to define it for
+    // FullStatedDiagMatr to check both distribution compatibility, and
+    // that dimensions match
+
+    tokenSubs vars = {
+        {"${MATR_NUM_QUBITS}",  matr.numQubits},
+        {"${QUREG_NUM_QUBITS}", qureg.numQubits}};
+
+    // dimensions must match
+    assertThat(matr.numQubits == qureg.numQubits, report::FULL_STATE_DIAG_MATR_MISMATCHES_QUREG_DIM, vars, caller);
+
+    // when matrix is duplicated on every node, its application is trivial
+    if (!matr.isDistributed)
+        return;
+
+    // but when it's distributed, so too must be the qureg so that comm isn't necessary (don't pass vars)
+    assertThat(qureg.isDistributed, report::FULL_STATE_DIAG_MATR_IS_DISTRIB_BUT_QUREG_ISNT, caller);
 }
 
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -216,7 +216,7 @@ namespace report {
         "Cannot create a local, GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 2^${NUM_QUBITS} bytes) exceeds the available GPU memory of ${VRAM_SIZE} bytes.";
 
     std::string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
-        "Cannot create a GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits distributed between ${NUM_NODES} because the necessary memory per node (${QCOMP_BYTES} * 2^${NUM_QB_MINUS_LOG_NODES} bytes) exceeds the local available GPU memory of ${RAM_SIZE} bytes.";
+        "Cannot create a GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits distributed between ${NUM_NODES} because the necessary memory per node (${QCOMP_BYTES} * 2^${NUM_QB_MINUS_LOG_NODES} bytes) exceeds the local available GPU memory of ${VRAM_SIZE} bytes.";
 
 
     std::string NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED = 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -60,10 +60,13 @@ void validate_quregFields(Qureg qureg, const char* caller);
  * MATRIX CREATION
  */
 
-void validate_newMatrixNumQubits(int numQubits, const char* caller);
+void validate_newCompMatrParams(int numQubits, const char* caller);
+void validate_newDiagMatrParams(int numQubits, const char* caller);
+void validate_newFullStateDiagMatrParams(int numQubits, int useDistrib, const char* caller);
 
 void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller);
 void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller);
+void validate_newMatrixAllocs(FullStateDiagMatr matr, qindex numBytes, const char* caller);
 
 
 
@@ -77,14 +80,18 @@ void validate_matrixFields(CompMatr  matr, const char* caller);
 void validate_matrixFields(DiagMatr1 matr, const char* caller);
 void validate_matrixFields(DiagMatr2 matr, const char* caller);
 void validate_matrixFields(DiagMatr  matr, const char* caller);
+void validate_matrixFields(FullStateDiagMatr matr, const char* caller);
 
 void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller);
 void validate_matrixNumNewElems(int numQubits, std::vector<qcomp> elems, const char* caller);
 
 void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller);
 
+void validate_fullStateDiagMatrNewElems(FullStateDiagMatr matr, qindex startInd, qindex numElems, const char* caller);
+
 void validate_matrixIsSynced(CompMatr matr, const char* caller);
 void validate_matrixIsSynced(DiagMatr matr, const char* caller);
+void validate_matrixIsSynced(FullStateDiagMatr matr, const char* caller);
 
 void validate_matrixIsUnitary(CompMatr1 matr, const char* caller);
 void validate_matrixIsUnitary(CompMatr2 matr, const char* caller);
@@ -92,6 +99,9 @@ void validate_matrixIsUnitary(CompMatr  matr, const char* caller);
 void validate_matrixIsUnitary(DiagMatr1 matr, const char* caller);
 void validate_matrixIsUnitary(DiagMatr2 matr, const char* caller);
 void validate_matrixIsUnitary(DiagMatr  matr, const char* caller);
+void validate_matrixIsUnitary(FullStateDiagMatr matr, const char* caller);
+
+void validate_matrixIsCompatibleWithQureg(FullStateDiagMatr matr, Qureg qureg, const char* caller);
 
 
 

--- a/quest/src/cpu/cpu_config.cpp
+++ b/quest/src/cpu/cpu_config.cpp
@@ -72,7 +72,8 @@ int cpu_getNumOpenmpProcessors() {
 
 qcomp* cpu_allocAmps(qindex numLocalAmps) {
 
-    // we call calloc over malloc in order to fail immediately if mem isn't available
+    // we call calloc over malloc in order to fail immediately if mem isn't available;
+    // caller must handle NULL result
     return (qcomp*) calloc(numLocalAmps, sizeof(qcomp));
 }
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -269,7 +269,7 @@ const qcomp UNSYNCED_GPU_MEM_FLAG = qcomp(3.141592653, 12345.67890);
 qcomp* gpu_allocAmps(qindex numLocalAmps) {
 #if ENABLE_GPU_ACCELERATION
 
-    size_t numBytes = mem_getLocalMemoryRequired(numLocalAmps);
+    size_t numBytes = mem_getLocalQuregMemoryRequired(numLocalAmps);
 
     // attempt to malloc
     qcomp* ptr;
@@ -373,6 +373,21 @@ void gpu_copyCpuToGpu(DiagMatr matr) {
         error_gpuCopyButMatrixNotGpuAccelerated();
 
     size_t numBytes = matr.numElems * sizeof(qcomp);
+    CUDA_CHECK( cudaMemcpy(matr.gpuElems, matr.cpuElems, numBytes, cudaMemcpyHostToDevice) );
+    
+#else
+    error_gpuCopyButGpuNotCompiled();
+#endif
+}
+
+
+void gpu_copyCpuToGpu(FullStateDiagMatr matr) {
+#if ENABLE_GPU_ACCELERATION
+
+    if (matr.gpuElems == NULL || ! getQuESTEnv().isGpuAccelerated)
+        error_gpuCopyButMatrixNotGpuAccelerated();
+
+    size_t numBytes = matr.numElemsPerNode * sizeof(qcomp);
     CUDA_CHECK( cudaMemcpy(matr.gpuElems, matr.cpuElems, numBytes, cudaMemcpyHostToDevice) );
     
 #else

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -83,6 +83,7 @@ void gpu_copyGpuToCpu(Qureg qureg);
 
 void gpu_copyCpuToGpu(CompMatr matr);
 void gpu_copyCpuToGpu(DiagMatr matr);
+void gpu_copyCpuToGpu(FullStateDiagMatr matr);
 
 bool gpu_haveGpuAmpsBeenSynced(qcomp* gpuArr);
 


### PR DESCRIPTION
and associated functions like
- createFullStateDiagMatr
- createCustomFullStateDiagMatr
- syncFullStateDiagMatr
- destroyFullStateDiagMatr
- setFullStateDiagMatr
- setInlineFullStateDiagMatr
- reportFullStateDiagMatr

Additionally:
- added validation that all heap-memory matrix types can fit into RAM and VRAM, and don't overflow index types, etc
- added FullStateDiagMatr auto-distributer
- updated matrix initialisation examples
- made all nodes free all memory if any node fails Qureg allocs
- added internal convenience comm_isRootNode()
- moved MPI types out of config header, into routines source, since they're never needed externally
- added internal matrix typing utilities