### PR TITLE
accelerating matrix validation

### DIFF
--- a/quest/include/debug.h
+++ b/quest/include/debug.h
@@ -15,6 +15,9 @@ extern "C" {
 
 void invalidQuESTInputError(const char* msg, const char* func);
 
+void setValidationOn();
+void setValidationOff();
+
 
 
 // end de-mangler

--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -84,6 +84,10 @@ typedef struct {
     const int numQubits;
     const qindex numRows;
 
+    // unitarity determined at sync; 0 or 1, or -1 to indicate unknown (when validation disabled).
+    // flag is stored in heap so even copies of structs are mutable, but pointer is immutable
+    int* const isUnitary;
+
     // 2D CPU memory; not const, so users can overwrite addresses (e.g. with NULL)
     qcomp** cpuElems;
 
@@ -132,6 +136,10 @@ typedef struct {
     const int numQubits;
     const qindex numElems;
 
+    // unitarity determined at sync; 0 or 1, or -1 to indicate unknown (when validation disabled).
+    // flag is stored in heap so even copies of structs are mutable, but pointer is immutable
+    int* const isUnitary;
+
     // CPU memory; not const, so users can overwrite addresses (e.g. with NULL)
     qcomp* cpuElems;
 
@@ -158,6 +166,10 @@ typedef struct {
 
     // will equal numElems if distribution is disabled at runtime (e.g. via autodeployment)
     const qindex numElemsPerNode;
+
+    // unitarity determined at sync; 0 or 1, or -1 to indicate unknown (when validation disabled).
+    // flag is stored in heap so even copies of structs are mutable, but pointer is immutable
+    int* const isUnitary;
 
     // CPU memory; not const, so users can overwrite addresses (e.g. with NULL)
     qcomp* cpuElems;

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -2,3 +2,21 @@
  * API definitions for debugging QuEST behaviour, or controlling
  * input validation.
  */
+
+#include "quest/src/core/validation.hpp"
+
+
+// enable invocation by both C and C++ binaries
+extern "C" {
+
+
+void setValidationOn() {
+    validate_setValidationOn();
+}
+
+void setValidationOff() {
+    validate_setValidationOff();
+}
+
+
+} // end de-name mangler

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -11,11 +11,11 @@ extern "C" {
 
 
 void setValidationOn() {
-    validate_setValidationOn();
+    validate_enable();
 }
 
 void setValidationOff() {
-    validate_setValidationOff();
+    validate_disable();
 }
 
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -110,6 +110,16 @@ qindex util_getMatrixDim(T matr) {
         return matr.numElems;
 }
 
+// T can be CompMatr, DiagMatr, FullStateDiagMatr
+template<class T>
+qcomp util_getFirstLocalElem(T matr) {
+
+    if constexpr (util_isDenseMatrixType<T>())
+        return matr.cpuElems[0][0];
+    else
+        return matr.cpuElems[0];
+}
+
 
 
 /*

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -15,6 +15,15 @@
 
 
 /*
+ * VALIDATION TOGGLE
+ */
+
+void validate_setValidationOn();
+void validate_setValidationOff();
+
+
+
+/*
  * ENVIRONMENT CREATION
  */
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -15,12 +15,22 @@
 
 
 /*
+ *  MATRIX ATTRIBUTE FLAGS
+ */
+
+const int validate_UNITARITY_UNKNOWN_FLAG = -1;
+
+
+
+/*
  * VALIDATION TOGGLE
  */
 
-void validate_setValidationOn();
-void validate_setValidationOff();
+void validate_enable();
 
+void validate_disable();
+
+bool validate_isEnabled();
 
 
 /*


### PR DESCRIPTION
# problem

I was intending to bind field `.isUnitary` to large (heap-memory) matrices, assessed at runtime inside functions like `syncCompMatr()`. This would enable unitarity to be assessed _once_ before repeated application of a matrix to a `Qureg`, avoiding duplicate computation; especially worthwhile for full-state operators like `FullStateDiagMatr`. This would integrate nicely with the new validation toggle - when validation is off, `sync*()` would set `.isUnitarity = -1` to indicate it was unknown. If validation was later restored and that same matrix passed to a simulation function like `multiQubitUnitary()`, unitarity could be lazily evaluated at that moment, overwriting the matrix's field to preclude later repeated evaluation.

Alas, this isn't directly possible with a value (like `int`) field - the QuEST API passes structs by value/copy! Functions like `sync*()` cannot modify the passed matrix struct's `.isUnitary` field. Even making just the `sync*()` functions accept pointers (already grossly inconsistent), the lazily deferred evaluation of `isUnitary` after a validation toggle would remain impossible. That would mean unitarity is wastefully re-evaluated at every invocation of e.g. `multiQubitUnitary()` until the next call to `sync*()`. That's user-astonishing; why should a user need to re-synch their unmodified matrix after toggling validation back on? 

We could at least avoid silent wasteful re-evaluation by throwing a validation error when the user passes a struct with unknown unitarity (`.isUnitary=-1`), and validation is _on_. The error can instruct users to recall `sync*()` on any matrix which was previously sync'd while validation was off. It's a shame fresh evaluation isn't automatic, but not unreasonable.

Beware however that users may be passing the API structs through several layers of their own functions before passing a pointer to `sync*()`. That is, the pass-by-copy nature of the QuEST API may encourage them to think all structs are immutable, so the struct modified `sync*(ptr)` might already be a stack copy, keeping the 'outer most' instance unchanged. On some occassions, that will make validation will fail; structs reaching validation remain un-synced. But on other occassions, if a user syncs correctly but later uncorrectly, the heap amps will be modified but the stack `.isUnitary` will _not_, corrupting the field.

> Note that disabling validation before calling `sync*()` would only be necessary when a user wishes to avoid even a _single_ calculation of unitarity. If they can permit _one_ unitarity check, then they can simply call `sync*()` _before_ disabling validation and unitarity will be thereafter forever known (until the next `sync*()`).

# hacky solution

We could make `isUnitary` a pointer to a single int in heap memory, heh! Then all copies of the "same" struct retain access to the flag, which is modifiable. We can even defensively make the pointer const to avoid a leak! This idea isn't __too__ hideous; we only need this `isUnitary` field in structs that already have heap memory.