### PR TITLE
renamed to setNumReportedItems

### DIFF
--- a/examples/matrices/reporting.c
+++ b/examples/matrices/reporting.c
@@ -14,7 +14,7 @@ void rootPrint(qindex num) {
     if (getQuESTEnv().rank != 0)
         return;
 
-    printf("\n\n>> set number of reported elements to %lld", num);
+    printf("\n\n>> set number of reported items to %lld", num);
 
     if (num == 0)
         printf(" (which means report all)");
@@ -38,7 +38,7 @@ void demo_CompMatr() {
     for (int i=0; i<len; i++) {
         qindex num = numReportElems[i];
         rootPrint(num);
-        setNumReportedMatrixElems(num);
+        setNumReportedItems(num);
         reportCompMatr(matr);
     }
 }
@@ -58,7 +58,7 @@ void demo_DiagMatr() {
     for (int i=0; i<len; i++) {
         qindex num = numReportElems[i];
         rootPrint(num);
-        setNumReportedMatrixElems(num);
+        setNumReportedItems(num);
         reportDiagMatr(matr);
     }
 }
@@ -79,7 +79,7 @@ void demo_FullStateDiagMatr() {
     for (int i=0; i<6; i++) {
         qindex num = numReportElems[i];
         rootPrint(num);
-        setNumReportedMatrixElems(num);
+        setNumReportedItems(num);
         reportFullStateDiagMatr(matr);
     }
 }

--- a/examples/matrices/reporting.cpp
+++ b/examples/matrices/reporting.cpp
@@ -14,7 +14,7 @@ void rootPrint(qindex num) {
     if (getQuESTEnv().rank != 0)
         return;
 
-    std::cout << "\n\n>> set number of reported elements to " << num;
+    std::cout << "\n\n>> set number of reported items to " << num;
 
     if (num == 0)
         std::cout << " (which means report all)";
@@ -34,7 +34,7 @@ void demo_CompMatr() {
 
     for (int num : {0, 12, 5, 1}) {
         rootPrint(num);
-        setNumReportedMatrixElems(num);
+        setNumReportedItems(num);
         reportCompMatr(matr);
     }
 }
@@ -50,7 +50,7 @@ void demo_DiagMatr() {
 
     for (int num : {0, 10}) {
         rootPrint(num);
-        setNumReportedMatrixElems(num);
+        setNumReportedItems(num);
         reportDiagMatr(matr);
     }
 }
@@ -68,7 +68,7 @@ void demo_FullStateDiagMatr() {
 
     for (int num : {0, 50, 30, 10, 5, 1}) {
         rootPrint(num);
-        setNumReportedMatrixElems(num);
+        setNumReportedItems(num);
         reportFullStateDiagMatr(matr);
     }
 }

--- a/quest/include/debug.h
+++ b/quest/include/debug.h
@@ -22,7 +22,7 @@ void invalidQuESTInputError(const char* msg, const char* func);
 void setValidationOn();
 void setValidationOff();
 
-void setNumReportedMatrixElems(qindex num);
+void setNumReportedItems(qindex num);
 
 
 

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -19,10 +19,10 @@ void setValidationOff() {
     validate_disable();
 }
 
-void setNumReportedMatrixElems(qindex num) {
-    validate_numReportedMatrixElems(num, __func__);
+void setNumReportedItems(qindex num) {
+    validate_numReportedItems(num, __func__);
 
-    form_setMaxNumPrintedMatrixElems(num);
+    form_setMaxNumPrintedItems(num);
 }
 
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -87,8 +87,8 @@ namespace report {
      * DEBUG UTILITIES
      */
 
-    std::string INVALID_NUM_REPORTED_MATRIX_ELEMS =
-        "Invalid parameter (${NUM_ELEMS}). Must specify a positive number of matrix elements to be reported, or 0 to indicate that all elements should be reported.";
+    std::string INVALID_NUM_REPORTED_ITEMS =
+        "Invalid parameter (${NUM_ITEMS}). Must specify a positive number of items to be reported, or 0 to indicate that all items should be reported.";
 
 
     /*
@@ -592,9 +592,9 @@ void validate_envIsInit(const char* caller) {
  * DEBUG UTILITIES
  */
 
-void validate_numReportedMatrixElems(qindex num, const char* caller) {
+void validate_numReportedItems(qindex num, const char* caller) {
 
-    assertThat(num >= 0, report::INVALID_NUM_REPORTED_MATRIX_ELEMS, {{"${NUM_ELEMS}", num}}, caller);
+    assertThat(num >= 0, report::INVALID_NUM_REPORTED_ITEMS, {{"${NUM_ITEMS}", num}}, caller);
 }
 
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -60,7 +60,7 @@ void validate_envIsInit(const char* caller);
  * DEBUG UTILITIES
  */
 
-void validate_numReportedMatrixElems(qindex num, const char* caller);
+void validate_numReportedItems(qindex num, const char* caller);
 
 
 


### PR DESCRIPTION
so that it can be used to modulate the truncation of other reported structures