### PR TITLE
added Pauli examples

### DIFF
--- a/examples/paulis/initialisation.c
+++ b/examples/paulis/initialisation.c
@@ -5,13 +5,25 @@
 
 
 /*
+ * distributed printing
+ */
+
+void rootPrint(const char* str) {
+
+    if (getQuESTEnv().rank == 0)
+        printf("\n%s\n", str);
+}
+
+
+
+/*
  * PauliStr
  */
 
 
 void demo_getInlinePauliStr() {
 
-    printf("\n[demo_getInlinePauliStr]\n");
+    rootPrint("[demo_getInlinePauliStr]");
 
     // can specify indices as {...} without temporary-array syntax 
     PauliStr a = getInlinePauliStr("XYZII", {4,3,2,1,0});
@@ -31,7 +43,7 @@ void demo_getInlinePauliStr() {
 
 void demo_getPauliStr() {
 
-    printf("\n[demo_getPauliStr]\n");
+    rootPrint("[demo_getPauliStr]");
 
     // in-line via temporary array
     PauliStr a = getPauliStr("XYZ", (int[]) {5,6,7}, 3);
@@ -69,7 +81,7 @@ void demo_getPauliStr() {
 
 void demo_createInlinePauliStrSum() {
 
-    printf("\n[demo_createInlinePauliStrSum]\n");
+    rootPrint("[demo_createInlinePauliStrSum]");
 
     // coeffs can be real, imag, or complex
     PauliStrSum a = createInlinePauliStrSum(
@@ -107,7 +119,7 @@ void demo_createInlinePauliStrSum() {
 
 void demo_createPauliStrSum() {
 
-    printf("\n[demo_createPauliStrSum]\n");
+    rootPrint("[demo_createPauliStrSum]");
 
     // inline using temporary arrays
     PauliStrSum a = createPauliStrSum(
@@ -149,7 +161,7 @@ void demo_createPauliStrSum() {
 
 void demo_createPauliStrSumFromFile() {
 
-    printf("\n[demo_createPauliStrSumFromFile]\n");
+    rootPrint("[demo_createPauliStrSumFromFile]");
 
     char *fn = "test.txt";
 
@@ -173,7 +185,7 @@ void demo_createPauliStrSumFromFile() {
 
 void demo_createPauliStrSumFromReversedFile() {
 
-    printf("\n[demo_createPauliStrSumFromReversedFile]\n");
+    rootPrint("[demo_createPauliStrSumFromReversedFile]");
 
     PauliStrSum a = createPauliStrSumFromReversedFile("test.txt");
     reportPauliStrSum(a);

--- a/examples/paulis/initialisation.c
+++ b/examples/paulis/initialisation.c
@@ -1,0 +1,203 @@
+#include "quest.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+
+
+/*
+ * PauliStr
+ */
+
+
+void demo_getInlinePauliStr() {
+
+    printf("\n[demo_getInlinePauliStr]\n");
+
+    // can specify indices as {...} without temporary-array syntax 
+    PauliStr a = getInlinePauliStr("XYZII", {4,3,2,1,0});
+    reportPauliStr(a);
+
+    // additionally accept 0-3 and lowercase
+    reportPauliStr(
+        getInlinePauliStr("0123ixyzIXYZ", {11,10,9,8, 7,6,5,4, 3,2,1,0})
+    );
+
+    // can specify arbitrary qubit indices of Paulis
+    reportPauliStr(
+        getInlinePauliStr("XXYYZZ", {5,50, 10,60, 30,40})
+    );
+}
+
+
+void demo_getPauliStr() {
+
+    printf("\n[demo_getPauliStr]\n");
+
+    // in-line via temporary array
+    PauliStr a = getPauliStr("XYZ", (int[]) {5,6,7}, 3);
+    reportPauliStr(a);
+
+    // string literal
+    int num = 3;
+    char paulis[] = "xxx";
+    int  qubits[] = {2,5,8};
+    reportPauliStr(
+        getPauliStr(paulis, qubits, num)
+    );
+
+    // heap arrays
+    int n = 64;
+    char* p = malloc(n * sizeof *p); // will have no terminal char
+    int*  q = malloc(n * sizeof *q);
+    for (int i=0; i<n; i++) {
+        p[i] = "IXYZ"[i%4];
+        q[i] = i;
+    }
+    reportPauliStr(
+        getPauliStr(p, q, n)
+    );
+    free(p);
+    free(q);
+}
+
+
+
+/*
+ * PauliStrSum
+ */
+
+
+void demo_createInlinePauliStrSum() {
+
+    printf("\n[demo_createInlinePauliStrSum]\n");
+
+    // coeffs can be real, imag, or complex
+    PauliStrSum a = createInlinePauliStrSum(
+        "0.123 XXIXX   \n"
+        "1.23i XYZXZ   \n"
+        "-1-6i IIIII   \n" // no multiline strings in C, grr
+    );
+    reportPauliStrSum(a);
+    destroyPauliStrSum(a);
+
+    // and use scientific notation, with any amount of whitespace
+    PauliStrSum b = createInlinePauliStrSum("\
+        + 5E2-1i     XYZ    \n\
+        - 1E-50i     IXY    \n\
+        + 1 - 6E-5i  IIX    \n\
+          0          III    \n\
+          5.         XXX    \n\
+           .5        ZZZ    \n\
+    ");
+    reportPauliStrSum(b);
+    destroyPauliStrSum(b);
+
+    // paulis can be lowercase and 0-3, with any whitespace
+    PauliStrSum c = createInlinePauliStrSum("\
+        2.5     0123 ixyz IXYZ                                 \n\
+        3.5     0iII 1xXX 2yYY                                 \n\
+                                                               \n\
+        -1.5E-15   -   5.123E-30i    0 0 0 0 0 0 0 0 1 1 1 1   \n\
+        1.5        +   5i            3 3 3 3 2 2 2 2 I X Y Z   \n\
+    ");
+    reportPauliStrSum(c);
+    destroyPauliStrSum(c);
+}
+
+
+void demo_createPauliStrSum() {
+
+    printf("\n[demo_createPauliStrSum]\n");
+
+    // inline using temporary arrays
+    PauliStrSum a = createPauliStrSum(
+        (PauliStr[]) {
+            getInlinePauliStr("XYZ", {1,2,3}),
+            getInlinePauliStr("XYZ", {1,2,3}),  // duplication allowed
+            getInlinePauliStr("XYZ", {1,2,5}),
+            getInlinePauliStr("xxx", {4,2,3}),
+            getInlinePauliStr("yyy", {1,2,3}),
+            getInlinePauliStr("zzz", {9,2,3}),
+            getInlinePauliStr("000", {1,2,3}),
+            getInlinePauliStr("111", {1,8,3}),
+            getInlinePauliStr("222", {8,2,3}),
+            getInlinePauliStr("333", {1,2,8}),
+            getInlinePauliStr("1xX", {1,6,3}) }, 
+        (qcomp[]) {
+            0.5, 0.2i, 0.9 + 2.131i, 1, 2, 3, 4, 5, 6, 7, 8 },
+        11
+    );
+    reportPauliStrSum(a);
+    destroyPauliStrSum(a);
+
+    // pre-allocated
+    int n = 64;
+    char* p = malloc(n * sizeof *p); // will have no terminal char
+    int*  q = malloc(n * sizeof *q);
+    for (int i=0; i<n; i++) {
+        p[i] = "IXYZ"[i%4];
+        q[i] = i;
+    }
+    int numTerms = 1;
+    PauliStr strings[] = {getPauliStr(p, q, n)};
+    qcomp coeffs[] = {-1E-40 + .45E2i};
+    PauliStrSum b = createPauliStrSum(strings, coeffs, numTerms);
+    reportPauliStrSum(b);
+    destroyPauliStrSum(b);
+}
+
+
+void demo_createPauliStrSumFromFile() {
+
+    printf("\n[demo_createPauliStrSumFromFile]\n");
+
+    char *fn = "test.txt";
+
+    // file contents can be identical to createInlinePauliStrSum input
+    FILE *f = fopen(fn, "w");
+    fprintf(f, "\
+        + 5E2-1i     XYZ    \n\
+        - 1E-50i     IXY    \n\
+        + 1 - 6E-5i  IIX    \n\
+          0          III    \n\
+          5.         IXX    \n\
+           .5        ZYX    \n\
+    ");
+    fclose(f);
+
+    PauliStrSum a = createPauliStrSumFromFile(fn);
+    reportPauliStrSum(a);
+    destroyPauliStrSum(a);
+}
+
+
+void demo_createPauliStrSumFromReversedFile() {
+
+    printf("\n[demo_createPauliStrSumFromReversedFile]\n");
+
+    PauliStrSum a = createPauliStrSumFromReversedFile("test.txt");
+    reportPauliStrSum(a);
+    destroyPauliStrSum(a);
+}
+
+
+
+/*
+ * main
+ */
+
+
+int main() {
+
+    initQuESTEnv();
+
+    demo_getInlinePauliStr();
+    demo_getPauliStr();
+    demo_createInlinePauliStrSum();
+    demo_createPauliStrSum();
+    demo_createPauliStrSumFromFile();
+    demo_createPauliStrSumFromReversedFile();
+
+    finalizeQuESTEnv();
+    return 0;
+}

--- a/examples/paulis/initialisation.cpp
+++ b/examples/paulis/initialisation.cpp
@@ -6,13 +6,25 @@
 
 
 /*
+ * distributed printing
+ */
+
+void rootPrint(std::string str) {
+
+    if (getQuESTEnv().rank == 0)
+        std::cout << std::endl << str << std::endl;
+}
+
+
+
+/*
  * PauliStr
  */
 
 
 void demo_getInlinePauliStr() {
 
-    std::cout << std::endl << "[demo_getInlinePauliStr]" << std::endl;
+    rootPrint("[demo_getInlinePauliStr]");
 
     // can specify indices as {...} without temporary-array syntax 
     PauliStr a = getInlinePauliStr("XYZII", {4,3,2,1,0});
@@ -32,7 +44,7 @@ void demo_getInlinePauliStr() {
 
 void demo_getPauliStr() {
 
-    std::cout << std::endl << "[demo_getPauliStr]" << std::endl;
+    rootPrint("[demo_getPauliStr]");
 
     // C++ can pass no indices to set Paulis upon rightmost qubits
     PauliStr a = getPauliStr("XYZ");
@@ -75,7 +87,7 @@ void demo_getPauliStr() {
 
 void demo_createInlinePauliStrSum() {
 
-    std::cout << std::endl << "[demo_createInlinePauliStrSum]" << std::endl;
+    rootPrint("[demo_createInlinePauliStrSum]");
 
     // coeffs can be real, imag, or complex (via C++ raw multilines)
     PauliStrSum a = createInlinePauliStrSum(R"(
@@ -113,7 +125,7 @@ void demo_createInlinePauliStrSum() {
 
 void demo_createPauliStrSum() {
 
-    std::cout << std::endl << "[demo_createPauliStrSum]" << std::endl;
+    rootPrint("[demo_createPauliStrSum]");
 
     // inline using C++ vector initialisers
     PauliStrSum a = createPauliStrSum(
@@ -151,7 +163,7 @@ void demo_createPauliStrSum() {
 
 void demo_createPauliStrSumFromFile() {
 
-    std::cout << std::endl << "[demo_createPauliStrSumFromFile]" << std::endl;
+    rootPrint("[demo_createPauliStrSumFromFile]");
 
     std::string fn = "test.txt";
 
@@ -176,7 +188,7 @@ void demo_createPauliStrSumFromFile() {
 
 void demo_createPauliStrSumFromReversedFile() {
 
-    std::cout << std::endl << "[demo_createPauliStrSumFromReversedFile]" << std::endl;
+    rootPrint("[demo_createPauliStrSumFromReversedFile]");
 
     PauliStrSum a = createPauliStrSumFromReversedFile("test.txt");
     reportPauliStrSum(a);

--- a/quest/include/paulis.h
+++ b/quest/include/paulis.h
@@ -60,7 +60,7 @@ typedef struct {
 #ifdef __cplusplus
 
     // C++ users can access the base C method
-    extern "C" PauliStr getPauliStr(char* paulis, int* indices, int numPaulis);
+    extern "C" PauliStr getPauliStr(const char* paulis, int* indices, int numPaulis);
 
     // but also get overloads to accept natural C++ string types (like literals)
     PauliStr getPauliStr(std::string paulis, int* indices, int numPaulis);
@@ -78,7 +78,7 @@ typedef struct {
 #else
 
     // C only supports passing a char array or string literal with a specified number of Paulis
-    PauliStr getPauliStr(char* paulis, int* indices, int numPaulis);
+    PauliStr getPauliStr(const char* paulis, int* indices, int numPaulis);
 
     // inline macro exploits the compile-time size of a string literal, and enables array
     // literals without the C99 inline temporary array syntax; we further give the array
@@ -103,10 +103,10 @@ extern "C" {
 
     PauliStrSum createPauliStrSum(PauliStr* strings, qcomp* coeffs, qindex numTerms);
 
-    PauliStrSum createInlinePauliStrSum(char* str);
+    PauliStrSum createInlinePauliStrSum(const char* str);
 
-    PauliStrSum createPauliStrSumFromFile(char* fn);
-    PauliStrSum createPauliStrSumFromReversedFile(char* fn);
+    PauliStrSum createPauliStrSumFromFile(const char* fn);
+    PauliStrSum createPauliStrSumFromReversedFile(const char* fn);
 
 #ifdef __cplusplus
 }

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -33,31 +33,10 @@ static const int MAX_NUM_PAULIS_PER_STR  = MAX_NUM_PAULIS_PER_MASK * 2;
  */
 
 
-int getPauliAt(PAULI_MASK_TYPE mask, int ind) {
+int getPauliFromMaskAt(PAULI_MASK_TYPE mask, int ind) {
 
     // get adjacent 2 bits at (ind+1, ind)
     return (mask >> (2*ind)) & 3;
-}
-
-int getPauliAt(PauliStr str, int ind) {
-
-    return (ind < MAX_NUM_PAULIS_PER_MASK)?
-        getPauliAt(str.lowPaulis,  ind) :
-        getPauliAt(str.highPaulis, ind - MAX_NUM_PAULIS_PER_MASK);
-}
-
-
-int getIndOfLefmostPauli(PauliStr str) {
-
-    int ind   = (str.highPaulis == 0)? 0 : MAX_NUM_PAULIS_PER_MASK;
-    auto mask = (str.highPaulis == 0)? str.lowPaulis : str.highPaulis;
-
-    while (mask) {
-        mask >>= 2;
-        ind++;
-    }
-
-    return ind - 1;
 }
 
 
@@ -83,6 +62,37 @@ void freeAllMemoryIfAnyAllocsFailed(PauliStrSum sum) {
     
     if (sum.coeffs != NULL)
         free(sum.coeffs);
+}
+
+
+
+/*
+ * INTERNAL UTILITIES
+ *
+ * callable by other internal files but which are not exposed in the header.
+ * Ergo other files must declare these functions as extern where needed.
+ */
+
+
+int paulis_getPauliAt(PauliStr str, int ind) {
+
+    return (ind < MAX_NUM_PAULIS_PER_MASK)?
+        getPauliFromMaskAt(str.lowPaulis,  ind) :
+        getPauliFromMaskAt(str.highPaulis, ind - MAX_NUM_PAULIS_PER_MASK);
+}
+
+
+int paulis_getIndOfLefmostPauli(PauliStr str) {
+
+    int ind   = (str.highPaulis == 0)? 0 : MAX_NUM_PAULIS_PER_MASK;
+    auto mask = (str.highPaulis == 0)? str.lowPaulis : str.highPaulis;
+
+    while (mask) {
+        mask >>= 2;
+        ind++;
+    }
+
+    return ind - 1;
 }
 
 
@@ -264,7 +274,7 @@ extern "C" void destroyPauliStrSum(PauliStrSum sum) {
 extern "C" void reportPauliStr(PauliStr str) {
 
     // avoid printing leftmost superfluous I operators
-    int numPaulis = 1 + getIndOfLefmostPauli(str);
+    int numPaulis = 1 + paulis_getIndOfLefmostPauli(str);
     form_printPauliStr(str, numPaulis);
 }
 

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -273,8 +273,8 @@ extern "C" void reportPauliStrSum(PauliStrSum str) {
     validate_pauliStrSumFields(str, __func__);
 
     // calculate memory usage
-    qindex numStrBytes   = sizeof(str.numTerms * sizeof *str.strings);
-    qindex numCoeffBytes = sizeof(str.numTerms * sizeof *str.coeffs);
+    qindex numStrBytes   = str.numTerms * sizeof *str.strings;
+    qindex numCoeffBytes = str.numTerms * sizeof *str.coeffs;
     qindex numStrucBytes = sizeof(str);
 
     // we don't bother checking for overflow since total memory scales

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -104,7 +104,7 @@ int paulis_getIndOfLefmostPauli(PauliStr str) {
  */
 
 
-extern "C" PauliStr getPauliStr(char* paulis, int* indices, int numPaulis) {
+extern "C" PauliStr getPauliStr(const char* paulis, int* indices, int numPaulis) {
     validate_newPauliStrParams(paulis, indices, numPaulis, MAX_NUM_PAULIS_PER_STR, __func__);
 
     // begin masks at all-identity 'I' = 0
@@ -208,7 +208,7 @@ PauliStrSum createPauliStrSum(std::vector<PauliStr> strings, std::vector<qcomp> 
 }
 
 
-extern "C" PauliStrSum createInlinePauliStrSum(char* str) {
+extern "C" PauliStrSum createInlinePauliStrSum(const char* str) {
 
     // str must be null-terminated
     return createInlinePauliStrSum(std::string(str));
@@ -221,7 +221,7 @@ PauliStrSum createInlinePauliStrSum(std::string str) {
 }
 
 
-extern "C" PauliStrSum createPauliStrSumFromFile(char* fn) {
+extern "C" PauliStrSum createPauliStrSumFromFile(const char* fn) {
 
     // fn must be null-terminated
     return createPauliStrSumFromFile(std::string(fn));
@@ -236,7 +236,7 @@ PauliStrSum createPauliStrSumFromFile(std::string fn) {
 }
 
 
-extern "C" PauliStrSum createPauliStrSumFromReversedFile(char* fn) {
+extern "C" PauliStrSum createPauliStrSumFromReversedFile(const char* fn) {
 
     // fn must be null-terminated
     return createPauliStrSumFromReversedFile(std::string(fn));

--- a/quest/src/core/formatter.cpp
+++ b/quest/src/core/formatter.cpp
@@ -677,8 +677,9 @@ void form_printTable(string title, vector<tuple<string, long long int>> rows, st
  */
 
 
-extern int getPauliAt(PauliStr str, int ind);
-extern int getIndOfLefmostPauli(PauliStr str);
+// we'll make use of these internal functions from paulis.cpp
+extern int paulis_getPauliAt(PauliStr str, int ind);
+extern int paulis_getIndOfLefmostPauli(PauliStr str);
 
 
 string getPauliStrAsString(PauliStr str, int maxNumQubits) {
@@ -688,7 +689,7 @@ string getPauliStrAsString(PauliStr str, int maxNumQubits) {
     // ugly but adequate
     string out = "";
     for (int i=maxNumQubits-1; i>=0; i--)
-        out += labels[getPauliAt(str, i)];
+        out += labels[paulis_getPauliAt(str, i)];
     
     return out;
 }
@@ -734,7 +735,7 @@ int getIndexOfLeftmostPauliAmongStrings(PauliStr* strings, qindex numStrings) {
     int maxInd = 0;
 
     for (qindex i=0; i<numStrings; i++) {
-        int ind = getIndOfLefmostPauli(strings[i]);
+        int ind = paulis_getIndOfLefmostPauli(strings[i]);
         if (ind > maxInd)
             maxInd = ind;
     }

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -1517,7 +1517,7 @@ void validate_initClassicalStateIndex(Qureg qureg, qindex ind, const char* calle
  * PAULI STRING CREATION
  */
 
-void assertCorrectNumPauliCharsBeforeTerminationChar(char* paulis, int numPaulis, const char* caller) {
+void assertCorrectNumPauliCharsBeforeTerminationChar(const char* paulis, int numPaulis, const char* caller) {
 
     char termChar = '\0';
     int numCharsBeforeTerm = 0;
@@ -1530,7 +1530,7 @@ void assertCorrectNumPauliCharsBeforeTerminationChar(char* paulis, int numPaulis
     assertThat(numCharsBeforeTerm >= numPaulis, report::NEW_PAULI_STR_TERMINATION_CHAR_TOO_EARLY, vars, caller);
 }
 
-void assertRecognisedNewPaulis(char* paulis, int numPaulis, const char* caller) {
+void assertRecognisedNewPaulis(const char* paulis, int numPaulis, const char* caller) {
 
     // paulis might also contain '\0' char (string termination),  
     // but not before numPaulis (as prior validated)
@@ -1572,7 +1572,7 @@ void validate_newPauliStrNumPaulis(int numPaulis, int maxNumPaulis, const char* 
     assertThat(numPaulis <= maxNumPaulis, report::NEW_PAULI_STR_NUM_PAULIS_EXCEEDS_TYPE, vars, caller);
 }
 
-void validate_newPauliStrParams(char* paulis, int* indices, int numPaulis, int maxNumPaulis, const char* caller) {
+void validate_newPauliStrParams(const char* paulis, int* indices, int numPaulis, int maxNumPaulis, const char* caller) {
 
     // note we do not bother checking whether RAM has enough memory to contain
     // the new Pauli string, because the caller to this function has already

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -147,7 +147,7 @@ void validate_initClassicalStateIndex(Qureg qureg, qindex ind, const char* calle
  * PAULI STRINGS AND SUMS CREATION
  */
 
-void validate_newPauliStrParams(char* paulis, int* indices, int numPaulis, int maxNumPaulis, const char* caller);
+void validate_newPauliStrParams(const char* paulis, int* indices, int numPaulis, int maxNumPaulis, const char* caller);
 
 void validate_newPauliStrNumChars(int numPaulis, int numIndices, const char* caller); // called by C++ only
 


### PR DESCRIPTION
in addition to:
- patching memory reporting of `PauliStrSum`
- made signatures to accept `const char*` instead of `char*` for native support of C++ string literals
- tidying the cross-file function call between formatter and paulis 