### PR TITLE
renamed deployment macros

### DIFF
--- a/quest/include/modes.h
+++ b/quest/include/modes.h
@@ -9,47 +9,47 @@
 
 // ensure all mode flags are defined
 
-#ifndef ENABLE_DISTRIBUTION
-    #error "Compiler must define ENABLE_DISTRIBUTION"
+#ifndef COMPILE_MPI
+    #error "Compiler must define COMPILE_MPI"
 #endif
 
-#ifndef ENABLE_MULTITHREADING
-    #error "Compiler must define ENABLE_MULTITHREADING"
+#ifndef COMPILE_OPENMP
+    #error "Compiler must define COMPILE_OPENMP"
 #endif
 
-#ifndef ENABLE_GPU_ACCELERATION
-    #error "Compiler must define ENABLE_GPU_ACCELERATION"
+#ifndef COMPILE_CUDA
+    #error "Compiler must define COMPILE_CUDA"
 #endif
 
-#ifndef ENABLE_CUQUANTUM
-    #error "Compiler must define ENABLE_CUQUANTUM"
+#ifndef COMPILE_CUQUANTUM
+    #error "Compiler must define COMPILE_CUQUANTUM"
 #endif
 
 
 
 // ensure all mode flags are valid values
 
-#if ! (ENABLE_DISTRIBUTION == 0 || ENABLE_DISTRIBUTION == 1)
-    #error "Macro ENABLE_DISTRIBUTION must have value 0 or 1"
+#if ! (COMPILE_MPI == 0 || COMPILE_MPI == 1)
+    #error "Macro COMPILE_MPI must have value 0 or 1"
 #endif
 
-#if ! (ENABLE_MULTITHREADING == 0 || ENABLE_MULTITHREADING == 1)
-    #error "Macro ENABLE_MULTITHREADING must have value 0 or 1"
+#if ! (COMPILE_OPENMP == 0 || COMPILE_OPENMP == 1)
+    #error "Macro COMPILE_OPENMP must have value 0 or 1"
 #endif
 
-#if ! (ENABLE_GPU_ACCELERATION == 0 || ENABLE_GPU_ACCELERATION == 1)
-    #error "Macro ENABLE_GPU_ACCELERATION must have value 0 or 1"
+#if ! (COMPILE_CUDA == 0 || COMPILE_CUDA == 1)
+    #error "Macro COMPILE_CUDA must have value 0 or 1"
 #endif
 
-#if ! (ENABLE_CUQUANTUM == 0 || ENABLE_CUQUANTUM == 1)
-    #error "Macro ENABLE_CUQUANTUM must have value 0 or 1"
+#if ! (COMPILE_CUQUANTUM == 0 || COMPILE_CUQUANTUM == 1)
+    #error "Macro COMPILE_CUQUANTUM must have value 0 or 1"
 #endif
 
 
 
 // ensure mode flags are compatible
 
-#if ENABLE_CUQUANTUM && ! ENABLE_GPU_ACCELERATION
+#if COMPILE_CUQUANTUM && ! COMPILE_CUDA
     #error "Cannot enable cuQuantum without simultaneously enabling GPU-acceleration"
 #endif
 

--- a/quest/include/precision.h
+++ b/quest/include/precision.h
@@ -69,7 +69,7 @@
  * CHECK PRECISION TYPES ARE COMPATIBLE WITH DEPLOYMENT
  */
 
-#if ENABLE_GPU_ACCELERATION && (FLOAT_PRECISION == 4)
+#if COMPILE_CUDA && (FLOAT_PRECISION == 4)
     #error "A quad floating-point precision (FLOAT_PRECISION=4, i.e. long double) is not supported by GPU deployment"
 #endif
 
@@ -77,8 +77,8 @@
 // as is necessary when performing multithreaded reductions of amplitudes.
 // We could support MSVC by separately reducing the real and imaginary components,
 // but Bill Gates would have to wrestle me into submission.
-#if ENABLE_MULTITHREADING && defined(_MSC_VER)
-    #error "Cannot use multi-threading on Windows"
+#if COMPILE_OPENMP && defined(_MSC_VER)
+    #error "Cannot use OpenMP multi-threading on Windows"
 #endif
 
 

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -317,12 +317,12 @@ void printQuregAutoDeployments(bool isDensMatr) {
 
         // else prepare string summarising the new deployments (trailing space is fine)
         std::string value = "";
-        if (useDistrib)
-            value += "[mpi] ";
+        if (useMulti)
+            value += "[omp] "; // ordered by #qubits to attempt consistent printed columns
         if (useGpuAccel)
             value += "[gpu] ";
-        if (useMulti)
-            value += "[omp] ";
+        if (useDistrib)
+            value += "[mpi] ";
 
         // log the #qubits of the deployment change
         rows.push_back({form_str(numQubits) + " qubits", value});

--- a/quest/src/comm/comm_routines.cpp
+++ b/quest/src/comm/comm_routines.cpp
@@ -13,7 +13,7 @@
 
 #include <vector>
 
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
     #include <mpi.h>
 #endif
 
@@ -82,7 +82,7 @@ qindex MAX_MESSAGE_LENGTH = powerOf2(28);
  */
 
 
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     #if (FLOAT_PRECISION == 1)
         #define MPI_QCOMP MPI_CXX_FLOAT_COMPLEX
@@ -131,7 +131,7 @@ void getMessageConfig(qindex *messageSize, qindex *numMessages, qindex numAmps) 
 
 
 void exchangeArrays(qcomp* send, qcomp* recv, qindex numElems, int pairRank) {
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     // each message is asynchronously dispatched with a final wait, as per arxiv.org/abs/2308.07402
 
@@ -165,7 +165,7 @@ void exchangeArrays(qcomp* send, qcomp* recv, qindex numElems, int pairRank) {
 
 
 void asynchSendArray(qcomp* send, qindex numElems, int pairRank) {
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     // we will not track nor wait for the asynch send; instead, the caller will later comm_sync()
     MPI_Request nullReq = MPI_REQUEST_NULL;
@@ -185,7 +185,7 @@ void asynchSendArray(qcomp* send, qindex numElems, int pairRank) {
 
 
 void receiveArray(qcomp* dest, qindex numElems, int pairRank) {
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     // expect the data in multiple messages
     qindex messageSize, numMessages;
@@ -385,7 +385,7 @@ void comm_exchangeAmpsToBuffers(Qureg qureg, int pairRank) {
 
 
 void comm_sendAmpsToRoot(int sendRank, qcomp* send, qcomp* recv, qindex numAmps) {
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     // only the sender and root nodes need to continue
     int recvRank = 0;
@@ -421,7 +421,7 @@ void comm_sendAmpsToRoot(int sendRank, qcomp* send, qcomp* recv, qindex numAmps)
 
 
 void comm_reduceAmp(qcomp* localAmp) {
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     qcomp* globalAmp;
     MPI_Allreduce(localAmp, globalAmp, 1, MPI_QCOMP, MPI_SUM, MPI_COMM_WORLD);
@@ -434,7 +434,7 @@ void comm_reduceAmp(qcomp* localAmp) {
 
 
 bool comm_isTrueOnAllNodes(bool val) {
-#if ENABLE_DISTRIBUTION
+#if COMPILE_MPI
 
     // perform global AND and broadcast result back to all nodes
     int local = (int) val;

--- a/quest/src/core/bitwise.hpp
+++ b/quest/src/core/bitwise.hpp
@@ -18,7 +18,7 @@
  * performance benefit when these functions are called in tight loops.
  */
 
-#if ENABLE_GPU_ACCELERATION && (defined(__NVCC__) || defined(__HIPCC__))
+#if COMPILE_CUDA && (defined(__NVCC__) || defined(__HIPCC__))
     #define INLINE __forceinline__ __device__ __host__
 #else
     #define INLINE inline __attribute__((always_inline))

--- a/quest/src/cpu/cpu_config.cpp
+++ b/quest/src/cpu/cpu_config.cpp
@@ -8,12 +8,12 @@
 #include "quest/src/core/errors.hpp"
 
 
-#if ENABLE_MULTITHREADING && !defined(_OPENMP)
-    #error "Attempted to compile in multithreaded mode without enabling OpenMP."
+#if COMPILE_OPENMP && !defined(_OPENMP)
+    #error "Attempted to compile in multithreaded mode without enabling OpenMP in the compiler flags."
 #endif
 
 
-#if ENABLE_MULTITHREADING
+#if COMPILE_OPENMP
     #include <omp.h>
 #endif
 
@@ -23,7 +23,7 @@
  * ENABLE OPENMP REDUCTION OF qcomp (except on MSVC compilers)
  */
 
-#if defined(ENABLE_MULTITHREADING) && !defined(_MSC_VER)
+#if defined(COMPILE_OPENMP) && !defined(_MSC_VER)
      #pragma omp declare reduction(+ : qcomp : omp_out += omp_in ) initializer( omp_priv = omp_orig )
 #endif
 
@@ -35,12 +35,12 @@
 
 
 bool cpu_isOpenmpCompiled() {
-    return (bool) ENABLE_MULTITHREADING;
+    return (bool) COMPILE_OPENMP;
 }
 
 
 int cpu_getCurrentNumThreads() {
-#if ENABLE_MULTITHREADING
+#if COMPILE_OPENMP
     int n = -1;
 
     #pragma omp parallel shared(n)
@@ -55,7 +55,7 @@ int cpu_getCurrentNumThreads() {
 
 
 int cpu_getNumOpenmpProcessors() {
-#if ENABLE_MULTITHREADING
+#if COMPILE_OPENMP
     return omp_get_num_procs();
 #else
     error_cpuThreadsQueriedButEnvNotMultithreaded();

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -19,7 +19,7 @@
  * CUDA ERROR HANDLING
  */
 
-#if ENABLE_GPU_ACCELERATION
+#if COMPILE_CUDA
 
 #define CUDA_CHECK(cmd) do { assertCudaCallSucceeded((int) (cmd), #cmd, __func__, __FILE__, __LINE__); } while (0)
 

--- a/quest/src/gpu/gpu_cuquantum.hpp
+++ b/quest/src/gpu/gpu_cuquantum.hpp
@@ -1,6 +1,6 @@
 /** @file
  * Subroutines which invoke cuQuantum. This file is only ever included
- * when ENABLE_CUQUANTUM=1 and ENABLE_GPU_ACCELERATION=1 so it can 
+ * when COMPILE_CUQUANTUM=1 and COMPILE_CUDA=1 so it can 
  * safely invoke CUDA signatures without guards.
  */
 
@@ -15,16 +15,16 @@
 #define GPU_CUQUANTUM_HPP
 
 
-#if ! ENABLE_CUQUANTUM
+#if ! COMPILE_CUQUANTUM
     #error "A file being compiled somehow included gpu_cuquantum.hpp despite QuEST not being compiled in cuQuantum mode."
 #endif
 
-#if ! ENABLE_GPU_ACCELERATION
+#if ! COMPILE_CUDA
     #error "A file being compiled somehow included gpu_cuquantum.hpp despite QuEST not being compiled in GPU-accelerated mode."
 #endif
 
 #ifndef __NVCC__
-    #error "A file which included gpu_cuquantum.hpp was not being compiled with an NVIDIA CUDA compiler."
+    #error "A file which included gpu_cuquantum.hpp was attemptedly compiled with a non-CUDA compiler."
 #endif
 
 

--- a/quest/src/gpu/gpu_kernels.hpp
+++ b/quest/src/gpu/gpu_kernels.hpp
@@ -1,7 +1,7 @@
 /** @file
  * Custom CUDA kernels invoked by gpu.cpp, usually only necessary when
  * there is no equivalent utility in Thrust (or cuQuantum, when it is
- * targeted). This file is only ever included when ENABLE_GPU_ACCELERATION=1 
+ * targeted). This file is only ever included when COMPILE_CUDA=1 
  * so it can safely invoke CUDA signatures without guards.
  */
 
@@ -14,7 +14,7 @@
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/gpu/gpu_types.hpp"
 
-#if ! ENABLE_GPU_ACCELERATION
+#if ! COMPILE_CUDA
     #error "A file being compiled somehow included gpu_kernels.hpp despite QuEST not being compiled in GPU-accelerated mode."
 #endif
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -16,24 +16,24 @@
 
 #include "quest/src/core/errors.hpp"
 
-#if ENABLE_GPU_ACCELERATION
+#if COMPILE_CUDA
     #include "quest/src/gpu/gpu_types.hpp"
     #include "quest/src/gpu/gpu_kernels.hpp"
     #include "quest/src/gpu/gpu_thrust.hpp"
 #endif
 
-#if ENABLE_CUQUANTUM
+#if COMPILE_CUQUANTUM
     #include "quest/src/gpu/gpu_cuquantum.hpp"
 #endif
 
 
 
 void gpu_statevec_oneTargetGate_subA(Qureg qureg, int target, CompMatr1 matrix) {
-#if ENABLE_CUQUANTUM
+#if COMPILE_CUQUANTUM
 
     cuquantum_statevec_oneTargetGate_subA(qureg, target, matrix);
 
-#elif ENABLE_GPU_ACCELERATION
+#elif COMPILE_CUDA
 
     qindex numIts = qureg.numAmpsPerNode / 2;
     qindex numBlocks = getNumBlocks(numIts);
@@ -51,7 +51,7 @@ void gpu_statevec_oneTargetGate_subA(Qureg qureg, int target, CompMatr1 matrix) 
 }
 
 void gpu_statevec_oneTargetGate_subB(Qureg qureg, qcomp fac0, qcomp fac1) {
-#if ENABLE_GPU_ACCELERATION
+#if COMPILE_CUDA
     
     qindex numIts = qureg.numAmpsPerNode;
     qindex numBlocks = getNumBlocks(numIts);

--- a/quest/src/gpu/gpu_thrust.hpp
+++ b/quest/src/gpu/gpu_thrust.hpp
@@ -1,13 +1,13 @@
 /** @file
  * Subroutines which invoke Thrust. This file is only ever included
- * when ENABLE_GPU_ACCELERATION=1 so it can safely invoke CUDA
+ * when COMPILE_CUDA=1 so it can safely invoke CUDA
  * signatures without guards.
  */
 
 #ifndef GPU_THRUST_HPP
 #define GPU_THRUST_HPP
 
-#if ! ENABLE_GPU_ACCELERATION
+#if ! COMPILE_CUDA
     #error "A file being compiled somehow included gpu_thrust.hpp despite QuEST not being compiled in GPU-accelerated mode."
 #endif
 

--- a/quest/src/gpu/gpu_types.hpp
+++ b/quest/src/gpu/gpu_types.hpp
@@ -1,6 +1,6 @@
 /** @file
  * CUDA-compatible complex types. This file is only ever included
- * when ENABLE_GPU_ACCELERATION=1 so it can safely invoke CUDA
+ * when COMPILE_CUDA=1 so it can safely invoke CUDA
  * signatures without guards. This is safe to re-include by
  * multiple files because typedef definition is legal in C++,
  * and all functions herein are inline. Furthermore, since it
@@ -14,7 +14,7 @@
 #include "quest/include/modes.h"
 #include "quest/include/types.h"
 
-#if ! ENABLE_GPU_ACCELERATION
+#if ! COMPILE_CUDA
     #error "A file being compiled somehow included gpu_types.hpp despite QuEST not being compiled in GPU-accelerated mode."
 #endif
 


### PR DESCRIPTION
from:
- ENABLE_DISTRIBUTION
- ENABLE_MULTITHREADING
- ENABLE_GPU_ACCELERATION
- ENABLE_CUQUANTUM

to:
- COMPILE_MPI
- COMPILE_OPENMP
- COMPILE_CUDA
- COMPILE_CUQUANTUM

This is to better reflect their effect in-code since compiling the latter technologies does not necessitate the enabling of the corresponding deployments at runtime. For example, consider when the user compiles MPI but disables distribution when creating the QuESTEnv at runtime. In that scenario, the ENABLE_DISTRIBUTION precompiler guards are misleading; the user has NOT enabled distribution and so calling MPI API functions therein compiles but will throw an internal error at runtime (as happened during testing, inspiring this change).

We can abstract the nuances of compiling the deployment libraries from the user at compile-time by keeping high-level flag names in the build, such as "ENABLE_DISTRIBUTION".

TLDR; rename explicitly distinguishes the compilation and runtime enabling of deployment modes