### PR TITLE
tidied namespaces

### DIFF
--- a/examples/matrices/initialisation.cpp
+++ b/examples/matrices/initialisation.cpp
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <vector>
 
+using std::vector;
+
 
 /*
  * When compiling QuEST in C++ with 'double' or 'long double' precision,
@@ -51,7 +53,7 @@ void demo_getCompMatr() {
     reportCompMatr1(a);
 
     // 2D vector (C++ only)
-    std::vector<std::vector<qcomp>> vec {{-9,-8},{-7,-6}};
+    vector<vector<qcomp>> vec {{-9,-8},{-7,-6}};
     CompMatr1 b = getCompMatr1(vec);
     reportCompMatr1(b);
 
@@ -118,7 +120,7 @@ void demo_setCompMatr() {
     reportCompMatr(a);
 
     // 2D vector (C++ only)
-    std::vector<std::vector<qcomp>> vec {
+    vector<vector<qcomp>> vec {
         {-9,-8, -8, -9},
         {7, 7, 6, 6},
         {0, -1, -2, -3},
@@ -181,7 +183,7 @@ void demo_getDiagMatr() {
     reportDiagMatr1(a);
 
     // vector (C++ only)
-    std::vector<qcomp> vec {20_i, 30_i};
+    vector<qcomp> vec {20_i, 30_i};
     DiagMatr1 b = getDiagMatr1(vec);
     reportDiagMatr1(b);
 
@@ -227,7 +229,7 @@ void demo_setDiagMatr() {
     reportDiagMatr(a);
 
     // vector (C++ only)
-    std::vector<qcomp> vec {11, 22, 33, 44};
+    vector<qcomp> vec {11, 22, 33, 44};
     DiagMatr b = createDiagMatr(2);
     setDiagMatr(b, vec);
     reportDiagMatr(b);
@@ -275,7 +277,7 @@ void demo_setFullStateDiagMatr() {
     setFullStateDiagMatr(matr, 4, {5,6,7,8});
 
     // vector (C++ only)
-    std::vector<qcomp> vec {11, 22, 33, 44};
+    vector<qcomp> vec {11, 22, 33, 44};
     setFullStateDiagMatr(matr, 7, vec);
 
     // compile-time array must pass size

--- a/examples/paulis/initialisation.cpp
+++ b/examples/paulis/initialisation.cpp
@@ -3,6 +3,10 @@
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
+#include <vector>
+
+using std::vector;
+
 
 
 
@@ -154,8 +158,8 @@ void demo_createPauliStrSum() {
         p[i] = "IXYZ"[i%4];
         q[i] = i;
     }
-    std::vector<PauliStr> strings = {getPauliStr(p, q, n)};
-    std::vector<qcomp> coeffs = {-1E-40 + .45E2_i};
+    vector<PauliStr> strings = {getPauliStr(p, q, n)};
+    vector<qcomp> coeffs = {-1E-40 + .45E2_i};
     PauliStrSum b = createPauliStrSum(strings, coeffs);
     reportPauliStrSum(b);
     destroyPauliStrSum(b);

--- a/examples/reporters/paulis.cpp
+++ b/examples/reporters/paulis.cpp
@@ -5,6 +5,11 @@
 #include <vector>
 #include <time.h>
 
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
+
 
 
 /*
@@ -17,12 +22,12 @@ void rootPrint(qindex num) {
     if (getQuESTEnv().rank != 0)
         return;
 
-    std::cout << std::endl << std::endl << ">> set number of reported items to " << num;
+    cout << endl << endl << ">> set number of reported items to " << num;
 
     if (num == 0)
-        std::cout << " (which means report all)";
+        cout << " (which means report all)";
          
-    std::cout << std::endl << std::endl;
+    cout << endl << endl;
 }
 
 
@@ -52,13 +57,13 @@ void demo_PauliStr() {
 
 PauliStrSum prepareRandomPauliStrSum(int numQubits, int numTerms) {
 
-    std::vector<char> paulis(numQubits);
-    std::vector<int> qubits(numQubits);
+    vector<char> paulis(numQubits);
+    vector<int> qubits(numQubits);
     for (int i=0; i<numQubits; i++)
         qubits[i] = i;
 
-    std::vector<qcomp> coeffs(numTerms);
-    std::vector<PauliStr> strings(numTerms);
+    vector<qcomp> coeffs(numTerms);
+    vector<PauliStr> strings(numTerms);
     
     for (int i=0; i<numTerms; i++) {
         coeffs[i] = qcomp(
@@ -68,7 +73,7 @@ PauliStrSum prepareRandomPauliStrSum(int numQubits, int numTerms) {
         for (int j=0; j<numQubits; j++)
             paulis[j] = "IXYZ"[rand() % 4];
 
-        std::string seq = std::string(paulis.begin(), paulis.end());
+        string seq = string(paulis.begin(), paulis.end());
         strings[i] = getPauliStr(seq, qubits);
     }
 
@@ -82,7 +87,7 @@ void demo_PauliStrSum() {
     int numTerms = 100;
     PauliStrSum sum = prepareRandomPauliStrSum(numQubits, numTerms);
 
-    std::vector<int> numReportElems {0, 10, 2};
+    vector<int> numReportElems {0, 10, 2};
 
     for (int num : numReportElems) {
         rootPrint(num);

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -27,6 +27,8 @@
 // provides substrings (by, na, pm, etc) used by reportQuESTEnv
 using namespace printer_substrings;
 
+using std::string;
+
 
 
 /*
@@ -181,7 +183,7 @@ void printDeploymentInfo() {
 void printCpuInfo() {
 
     // assume RAM is unknown unless it can be queried
-    std::string ram = un;
+    string ram = un;
     try { 
         ram = printer_toStr(mem_tryGetLocalRamCapacityInBytes()) + by + pm; 
     } catch(mem::COULD_NOT_QUERY_RAM e){};
@@ -233,8 +235,8 @@ void printQuregSizeLimits(bool isDensMatr) {
     int numNodes = globalEnvPtr->numNodes;
 
     // by default, CPU limits are unknown (because memory query might fail)
-    std::string maxQbForCpu = un;
-    std::string maxQbForMpiCpu = un;
+    string maxQbForCpu = un;
+    string maxQbForMpiCpu = un;
 
     // max CPU registers are only determinable if RAM query succeeds
     try {
@@ -253,8 +255,8 @@ void printQuregSizeLimits(bool isDensMatr) {
     } catch(mem::COULD_NOT_QUERY_RAM e) {};
 
     // GPU limits are default N/A because they're always determinable when relevant
-    std::string maxQbForGpu = na;
-    std::string maxQbForMpiGpu = na;
+    string maxQbForGpu = na;
+    string maxQbForMpiGpu = na;
 
     // max GPU registers only relevant if env is GPU-accelerated
     if (globalEnvPtr->isGpuAccelerated) {
@@ -267,8 +269,8 @@ void printQuregSizeLimits(bool isDensMatr) {
     }
 
     // tailor table title to type of Qureg
-    std::string prefix = (isDensMatr)? "density matrix" : "statevector";
-    std::string title = prefix + " limits";
+    string prefix = (isDensMatr)? "density matrix" : "statevector";
+    string title = prefix + " limits";
 
     print_table(
         title, {
@@ -286,7 +288,7 @@ void printQuregSizeLimits(bool isDensMatr) {
 void printQuregAutoDeployments(bool isDensMatr) {
 
     // build all table rows dynamically before print
-    std::vector<std::tuple<std::string, std::string>> rows;
+    std::vector<std::tuple<string, string>> rows;
 
     // we will get auto-deployment for every possible number of qubits; silly but cheap and robust!
     int useDistrib,  useGpuAccel,  useMulti;
@@ -316,7 +318,7 @@ void printQuregAutoDeployments(bool isDensMatr) {
             continue; 
 
         // else prepare string summarising the new deployments (trailing space is fine)
-        std::string value = "";
+        string value = "";
         if (useMulti)
             value += "[omp] "; // ordered by #qubits to attempt consistent printed columns
         if (useGpuAccel)
@@ -334,8 +336,8 @@ void printQuregAutoDeployments(bool isDensMatr) {
     }
 
     // tailor table title to type of Qureg
-    std::string prefix = (isDensMatr)? "density matrix" : "statevector";
-    std::string title = prefix + " autodeployment";
+    string prefix = (isDensMatr)? "density matrix" : "statevector";
+    string title = prefix + " autodeployment";
     print_table(title, rows);
 }
 

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 
+using std::vector;
+
 
 
 /*
@@ -198,7 +200,7 @@ CompMatr1 getCompMatr1(qcomp in[2][2]) {
 CompMatr1 getCompMatr1(qcomp** in) {
     return getCompMatrFromElems<CompMatr1>(in, 1);
 }
-CompMatr1 getCompMatr1(std::vector<std::vector<qcomp>> in) {
+CompMatr1 getCompMatr1(vector<vector<qcomp>> in) {
     validate_matrixNumNewElems(1, in, __func__);
 
     return getCompMatrFromElems<CompMatr1>(in, 1);
@@ -210,7 +212,7 @@ CompMatr2 getCompMatr2(qcomp in[4][4]) {
 CompMatr2 getCompMatr2(qcomp** in) {
     return getCompMatrFromElems<CompMatr2>(in, 2);
 }
-CompMatr2 getCompMatr2(std::vector<std::vector<qcomp>> in) {
+CompMatr2 getCompMatr2(vector<vector<qcomp>> in) {
     validate_matrixNumNewElems(2, in, __func__);
 
     return getCompMatrFromElems<CompMatr2>(in, 2);
@@ -229,13 +231,13 @@ CompMatr2 getCompMatr2(std::vector<std::vector<qcomp>> in) {
  */
 
 
-DiagMatr1 getDiagMatr1(std::vector<qcomp> in) {
+DiagMatr1 getDiagMatr1(vector<qcomp> in) {
     validate_matrixNumNewElems(1, in, __func__);
 
     return getDiagMatr1(in.data());
 }
 
-DiagMatr2 getDiagMatr2(std::vector<qcomp> in) {
+DiagMatr2 getDiagMatr2(vector<qcomp> in) {
     validate_matrixNumNewElems(2, in, __func__);
 
     return getDiagMatr2(in.data());
@@ -471,7 +473,7 @@ void setCompMatr(CompMatr out, qcomp** in) {
     validateAndSetCompMatrElems(out, in, __func__);
 }
 
-void setCompMatr(CompMatr out, std::vector<std::vector<qcomp>> in) {
+void setCompMatr(CompMatr out, vector<vector<qcomp>> in) {
 
     // we validate dimension of 'in', which first requires validating 'out' fields
     validate_matrixFields(out, __func__);
@@ -501,7 +503,7 @@ extern "C" void setDiagMatr(DiagMatr out, qcomp* in) {
     syncDiagMatr(out);
 }
 
-void setDiagMatr(DiagMatr out, std::vector<qcomp> in) {
+void setDiagMatr(DiagMatr out, vector<qcomp> in) {
 
     // we validate dimension of 'in', which first requires validating 'out' fields
     validate_matrixFields(out, __func__);
@@ -531,7 +533,7 @@ extern "C" void setFullStateDiagMatr(FullStateDiagMatr out, qindex startInd, qco
     syncFullStateDiagMatr(out);
 }
 
-void setFullStateDiagMatr(FullStateDiagMatr out, qindex startInd, std::vector<qcomp> in) {
+void setFullStateDiagMatr(FullStateDiagMatr out, qindex startInd, vector<qcomp> in) {
 
     setFullStateDiagMatr(out, startInd, in.data(), in.size());
 }

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -16,6 +16,9 @@
 #include <vector>
 #include <string>
 
+using std::string;
+using std::vector;
+
 
 
 /*
@@ -132,7 +135,7 @@ extern "C" PauliStr getPauliStr(const char* paulis, int* indices, int numPaulis)
 
 }
 
-PauliStr getPauliStr(std::string paulis, int* indices, int numPaulis) {
+PauliStr getPauliStr(string paulis, int* indices, int numPaulis) {
 
     // additionally validate 'paulis' string has 'numPaulis' chars
     validate_newPauliStrNumChars(paulis.length(), numPaulis, __func__);
@@ -140,7 +143,7 @@ PauliStr getPauliStr(std::string paulis, int* indices, int numPaulis) {
     return getPauliStr(paulis.data(), indices, numPaulis); // validates
 }
 
-PauliStr getPauliStr(std::string paulis, std::vector<int> indices) {
+PauliStr getPauliStr(string paulis, vector<int> indices) {
 
     // additionally validate 'paulis' string has 'numPaulis' chars
     validate_newPauliStrNumChars(paulis.length(), indices.size(), __func__);
@@ -148,13 +151,13 @@ PauliStr getPauliStr(std::string paulis, std::vector<int> indices) {
     return getPauliStr(paulis.data(), indices.data(), indices.size()); // validates
 }
 
-PauliStr getPauliStr(std::string paulis) {
+PauliStr getPauliStr(string paulis) {
 
     // pedantically validate the string length isn't so long that it would stackoverflow a vector
     validate_newPauliStrNumPaulis(paulis.size(), MAX_NUM_PAULIS_PER_STR, __func__);
 
     // automatically target the bottom-most qubits, preserving rightmost is least significant
-    std::vector<int> indices(paulis.size());
+    vector<int> indices(paulis.size());
     for (int i=0; i<paulis.size(); i++)
         indices[i] = paulis.size() - 1 - i;
 
@@ -199,7 +202,7 @@ extern "C" PauliStrSum createPauliStrSum(PauliStr* strings, qcomp* coeffs, qinde
     return out;
 }
 
-PauliStrSum createPauliStrSum(std::vector<PauliStr> strings, std::vector<qcomp> coeffs) {
+PauliStrSum createPauliStrSum(vector<PauliStr> strings, vector<qcomp> coeffs) {
 
     // additionally validate 'strings' and 'coeffs' are the same length
     validate_newPauliStrSumMatchingListLens(strings.size(), coeffs.size(), __func__);
@@ -211,10 +214,10 @@ PauliStrSum createPauliStrSum(std::vector<PauliStr> strings, std::vector<qcomp> 
 extern "C" PauliStrSum createInlinePauliStrSum(const char* str) {
 
     // str must be null-terminated
-    return createInlinePauliStrSum(std::string(str));
+    return createInlinePauliStrSum(string(str));
 }
 
-PauliStrSum createInlinePauliStrSum(std::string str) {
+PauliStrSum createInlinePauliStrSum(string str) {
 
     bool rightIsLeastSig = true;
     return parser_validateAndParsePauliStrSum(str, rightIsLeastSig, __func__);
@@ -224,14 +227,14 @@ PauliStrSum createInlinePauliStrSum(std::string str) {
 extern "C" PauliStrSum createPauliStrSumFromFile(const char* fn) {
 
     // fn must be null-terminated
-    return createPauliStrSumFromFile(std::string(fn));
+    return createPauliStrSumFromFile(string(fn));
 }
 
-PauliStrSum createPauliStrSumFromFile(std::string fn) {
+PauliStrSum createPauliStrSumFromFile(string fn) {
     validate_canReadFile(fn, __func__);
 
     bool rightIsLeastSig = true;
-    std::string str = parser_loadFile(fn);
+    string str = parser_loadFile(fn);
     return parser_validateAndParsePauliStrSum(str, rightIsLeastSig, __func__);
 }
 
@@ -239,14 +242,14 @@ PauliStrSum createPauliStrSumFromFile(std::string fn) {
 extern "C" PauliStrSum createPauliStrSumFromReversedFile(const char* fn) {
 
     // fn must be null-terminated
-    return createPauliStrSumFromReversedFile(std::string(fn));
+    return createPauliStrSumFromReversedFile(string(fn));
 }
 
-PauliStrSum createPauliStrSumFromReversedFile(std::string fn) {
+PauliStrSum createPauliStrSumFromReversedFile(string fn) {
     validate_canReadFile(fn, __func__);
 
     bool rightIsLeastSig = false;
-    std::string str = parser_loadFile(fn);
+    string str = parser_loadFile(fn);
     return parser_validateAndParsePauliStrSum(str, rightIsLeastSig, __func__);
 }
 

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -22,6 +22,8 @@
 // provides substrings (by, na, pm, etc) used by reportQureg
 using namespace printer_substrings;
 
+using std::string;
+
 
 
 /*
@@ -170,7 +172,7 @@ void printDeploymentInfo(Qureg qureg) {
 void printDimensionInfo(Qureg qureg) {
 
     // 2^N = M or 2^N x 2^N = M
-    std::string str;
+    string str;
     str  = bt + printer_toStr(qureg.numQubits);
     str += (qureg.isDensityMatrix)? mu + str : "";
     str += eq + printer_toStr(qureg.numAmps);
@@ -187,8 +189,8 @@ void printDimensionInfo(Qureg qureg) {
 void printDistributionInfo(Qureg qureg) {
 
     // not applicable when not distributed
-    std::string nodesStr = na;
-    std::string ampsStr  = na;
+    string nodesStr = na;
+    string ampsStr  = na;
 
     // 2^N = M per node
     if (qureg.isDistributed) {
@@ -208,12 +210,12 @@ void printDistributionInfo(Qureg qureg) {
 void printMemoryInfo(Qureg qureg) {
 
     size_t localArrayMem = mem_getLocalQuregMemoryRequired(qureg.numAmpsPerNode);
-    std::string localMemStr = printer_toStr(localArrayMem) + by + ((qureg.isDistributed)? pn : "");
+    string localMemStr = printer_toStr(localArrayMem) + by + ((qureg.isDistributed)? pn : "");
 
     // precondition: no reportable fields are at risk of overflow as a qindex
     // type, EXCEPT aggregate total memory between distributed nodes (in bytes)
     qindex globalTotalMem = mem_getTotalGlobalMemoryUsed(qureg);
-    std::string globalMemStr = (globalTotalMem == 0)? "overflowed" : (printer_toStr(globalTotalMem) + by);
+    string globalMemStr = (globalTotalMem == 0)? "overflowed" : (printer_toStr(globalTotalMem) + by);
 
     print_table(
         "memory", {

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -15,15 +15,17 @@
 #include <iostream>
 #include <string>
 
+using std::string;
+
 
 
 /*
  * INTERNAL ERROR RESPONSE
  */
 
-void raiseInternalError(std::string errorMsg) {
+void raiseInternalError(string errorMsg) {
 
-    print(std::string("")
+    print(string("")
         + "\n\n"
         + "A fatal internal QuEST error occurred. "
         + errorMsg + " "
@@ -40,17 +42,17 @@ void raiseInternalError(std::string errorMsg) {
  * VALIDATION ERRORS
  */
 
-void error_validationMessageVarWasIllFormed(std::string msg, std::string illFormedVar) {
+void error_validationMessageVarWasIllFormed(string msg, string illFormedVar) {
 
     raiseInternalError("User input validation failed and an error string was attemptedly prepared, but an ill-formed variable was attempted substitution. This variable was \"" + illFormedVar + "\" and was attempted substitution into message:\n" + msg + "\n");
 }
 
-void error_validationMessageVarNotSubstituted(std::string msg, std::string var) {
+void error_validationMessageVarNotSubstituted(string msg, string var) {
 
     raiseInternalError("User input validation failed and an error string was attemptedly prepared. However, the internal variable \"" + var + "\" was unable to be found and substituted into the message, which was:\n" + msg + "\n");
 }
 
-void error_validationMessageContainedUnsubstitutedVars(std::string msg) {
+void error_validationMessageContainedUnsubstitutedVars(string msg) {
 
     raiseInternalError("User input validation failed and an error string was prepared. However, the message contained unexpected (and potentially ill-formed) unsubstituted variables. The message was:\n" + msg + "\n");
 }
@@ -237,7 +239,7 @@ void assert_gpuIsAccessible() {
 void error_cudaCallFailed(const char* msg, const char* func, const char* caller, const char* file, int line) {
 
     // using operator overloads to cast const char[] literals to std::string, to concat with const char*.
-    std::string err = "";
+    string err = "";
     err += "A CUDA (or cuQuantum) API function (\"";
     err += func;
     err += "\", called by \"";

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -13,17 +13,19 @@
 
 #include <string>
 
+using std::string;
+
 
 
 /*
  * VALIDATION ERRORS
  */
 
-void error_validationMessageVarWasIllFormed(std::string msg, std::string illFormedVar);
+void error_validationMessageVarWasIllFormed(string msg, string illFormedVar);
 
-void error_validationMessageVarNotSubstituted(std::string msg, std::string var);
+void error_validationMessageVarNotSubstituted(string msg, string var);
 
-void error_validationMessageContainedUnsubstitutedVars(std::string msg);
+void error_validationMessageContainedUnsubstitutedVars(string msg);
 
 void error_validationEncounteredUnsupportedDistributedDenseMatrix();
 

--- a/quest/src/core/parser.cpp
+++ b/quest/src/core/parser.cpp
@@ -22,9 +22,16 @@
 #include <stdexcept>
 #include <algorithm>
 
-
-// have mercy on me, boilerplate Gods
-using namespace std;
+using std::stold;
+using std::regex;
+using std::vector;
+using std::string;
+using std::smatch;
+using std::ifstream;
+using std::out_of_range;
+using std::stringstream;
+using std::sregex_iterator;
+using std::invalid_argument;
 
 
 
@@ -39,7 +46,7 @@ namespace patterns {
 
     // utilities
     string group(string in) { return "(?:" + in + ")"; } // groups sub-patterns to control eval order
-    string capt (string in) { return "(" + in + ")"; }   // captures sub-patterns for later extraction
+    string capt (string in) { return "("   + in + ")"; } // captures sub-patterns for later extraction
     string opt  (string in) { return group(in) + "?"; }  // groups and makes optional a sub-pattern
 
     // sub-numbers
@@ -231,7 +238,7 @@ void assertStringIsValidPauliStrSum(string lines, const char* caller) {
     qindex lineIndex = 0;
 
     // parse each line in-turn
-    istringstream stream(lines);
+    stringstream stream(lines);
 
     for (string line; getline(stream, line); lineIndex++) {
 
@@ -383,7 +390,7 @@ PauliStrSum parser_validateAndParsePauliStrSum(string lines, bool rightIsLeastSi
     vector<PauliStr> strings; strings.reserve(numLines);
     
     // parse each line in-turn
-    istringstream stream(lines);
+    stringstream stream(lines);
     for (string line; getline(stream, line); ) {
 
         // skip empty lines

--- a/quest/src/core/parser.hpp
+++ b/quest/src/core/parser.hpp
@@ -9,13 +9,15 @@
 
 #include <string>
 
+using std::string;
+
 
 
 /*
  * PARSING INDIVIDUAL PAULIS
  */
 
-const std::string parser_RECOGNISED_PAULI_CHARS = "0123ixyzIXYZ";
+const string parser_RECOGNISED_PAULI_CHARS = "0123ixyzIXYZ";
 
 int parser_getPauliIntFromChar(char ch);
 
@@ -25,7 +27,7 @@ int parser_getPauliIntFromChar(char ch);
  * PARSING PAULI STRING SUMS
  */
 
-PauliStrSum parser_validateAndParsePauliStrSum(std::string lines, bool rightIsLeastSignificant, const char* caller);
+PauliStrSum parser_validateAndParsePauliStrSum(string lines, bool rightIsLeastSignificant, const char* caller);
 
 
 
@@ -33,9 +35,9 @@ PauliStrSum parser_validateAndParsePauliStrSum(std::string lines, bool rightIsLe
  * FILE IO
  */
 
-bool parser_canReadFile(std::string fn);
+bool parser_canReadFile(string fn);
 
-std::string parser_loadFile(std::string fn);
+string parser_loadFile(string fn);
 
 
 

--- a/quest/src/core/printer.cpp
+++ b/quest/src/core/printer.cpp
@@ -20,11 +20,17 @@
 #include <tuple>
 #include <string>
 
-
-// I like to live dangerously; and I am willing to debate with the
-// most dogmatic C++ enthusiast about the unreadability of namespaces
-using namespace std;
 using namespace printer_substrings;
+
+using std::cout;
+using std::endl;
+using std::left;
+using std::setw;
+using std::tuple;
+using std::string;
+using std::vector;
+using std::setfill;
+using std::complex;
 
 
 
@@ -174,11 +180,11 @@ template <typename T>
 string floatToStr(T num, bool hideSign=false) {
 
     // write to stream (instead of calling to_string()) to auto-use scientific notation
-    ostringstream buffer;
+    std::stringstream buffer;
 
     // ensure +- is not shown if forced hidden
     if (hideSign) {
-        buffer << noshowpos;
+        buffer << std::noshowpos;
         if (num < 0)
             num *= -1;
     }
@@ -259,7 +265,7 @@ void print(const char* str) {
         cout << str << endl;
 }
 
-void print(std::string str) {
+void print(string str) {
     print(str.data());
 }
 
@@ -685,7 +691,7 @@ void print_table(string title, vector<tuple<string, long long int>> rows, string
     // convert all values to strings
     vector<tuple<string, string>> casted;
     for (auto const& [key, value] : rows)
-        casted.push_back({key, to_string(value)});
+        casted.push_back({key, std::to_string(value)});
 
     print_table(title, casted, indent);
 }
@@ -800,12 +806,12 @@ void print_pauliStrSum(PauliStrSum sum, string indent) {
     // choose coeffs padding to make consistent column alignment
     int maxTopCoeffWidth = getWidthOfWidestElem(sum.coeffs, numTopElems);
     int maxBotCoeffWidth = getWidthOfWidestElem(&(sum.coeffs[botElemsInd]), numBotElems);
-    int maxCoeffWidth = max(maxTopCoeffWidth, maxBotCoeffWidth);
+    int maxCoeffWidth = std::max(maxTopCoeffWidth, maxBotCoeffWidth);
 
     // choose the fixed number of Paulis to show (the min necessary to fit all non-truncated strings)
     int maxTopNumPaulis = 1 + getIndexOfLeftmostPauliAmongStrings(sum.strings, numTopElems);
     int maxBotNumPaulis = 1 + getIndexOfLeftmostPauliAmongStrings(&(sum.strings[botElemsInd]), numBotElems);
-    int maxNumPaulis = max(maxTopNumPaulis,maxBotNumPaulis);
+    int maxNumPaulis = std::max(maxTopNumPaulis,maxBotNumPaulis);
 
     // print all top elems
     printPauliStrSumSubset(sum, 0, numTopElems, maxCoeffWidth, maxNumPaulis, indent);

--- a/quest/src/core/printer.hpp
+++ b/quest/src/core/printer.hpp
@@ -9,12 +9,17 @@
 #include "quest/include/matrices.h"
 #include "quest/include/paulis.h"
 
-#include <vector>
 #include <tuple>
+#include <vector>
 #include <complex>
 #include <string>
 #include <sstream>
 #include <type_traits>
+
+using std::tuple;
+using std::string;
+using std::vector;
+using std::complex;
 
 
 
@@ -30,13 +35,13 @@ void printer_setMaxNumPrintedItems(qindex num);
  * TYPE NAME STRINGS
  */
 
-std::string printer_getQrealType();
+string printer_getQrealType();
 
-std::string printer_getQcompType();
+string printer_getQcompType();
 
-std::string printer_getQindexType();
+string printer_getQindexType();
 
-std::string printer_getFloatPrecisionFlag();
+string printer_getFloatPrecisionFlag();
 
 
 
@@ -48,11 +53,11 @@ std::string printer_getFloatPrecisionFlag();
 // type T can be int, qindex, float, double, long double.
 // this more specific printer_toStr() definition is called when passing complex
 template <typename T>
-std::string printer_toStr(std::complex<T> num);
+string printer_toStr(complex<T> num);
 
 // type T can be any non-complex type recognised by ostringstream!
 template<typename T> 
-std::string printer_toStr(T expr) {
+string printer_toStr(T expr) {
 
     // write to buffer (rather than use to_string()) so that floating-point numbers
     // are automatically converted to scientific notation when necessary
@@ -68,15 +73,15 @@ std::string printer_toStr(T expr) {
  */
 
 namespace printer_substrings { 
-    extern std::string eq;
-    extern std::string mu;
-    extern std::string by;
-    extern std::string pn;
-    extern std::string pg;
-    extern std::string pm;
-    extern std::string bt;
-    extern std::string na;
-    extern std::string un;
+    extern string eq;
+    extern string mu;
+    extern string by;
+    extern string pn;
+    extern string pg;
+    extern string pm;
+    extern string bt;
+    extern string na;
+    extern string un;
 }
 
 
@@ -89,8 +94,8 @@ namespace printer_substrings {
  * static to avoid symbol duplication by repeated header inclusion.
  */
 
-static std::string defaultMatrIndent  = "    ";
-static std::string defaultTableIndent = "  ";
+static string defaultMatrIndent  = "    ";
+static string defaultTableIndent = "  ";
 
 
 
@@ -99,7 +104,7 @@ static std::string defaultTableIndent = "  ";
  */
 
 void print(const char* str);
-void print(std::string str);
+void print(string str);
 void print(qcomp num);
 
 
@@ -108,15 +113,15 @@ void print(qcomp num);
  * MATRIX PRINTING
  */
 
-void print_matrixInfo(std::string nameStr, int numQubits, qindex dim, size_t elemMem, size_t otherMem, int numNodes=1);
+void print_matrixInfo(string nameStr, int numQubits, qindex dim, size_t elemMem, size_t otherMem, int numNodes=1);
 
-void print_matrix(CompMatr1 matr, std::string indent=defaultMatrIndent);
-void print_matrix(CompMatr2 matr, std::string indent=defaultMatrIndent);
-void print_matrix(CompMatr  matr, std::string indent=defaultMatrIndent);
-void print_matrix(DiagMatr1 matr, std::string indent=defaultMatrIndent);
-void print_matrix(DiagMatr2 matr, std::string indent=defaultMatrIndent);
-void print_matrix(DiagMatr  matr, std::string indent=defaultMatrIndent);
-void print_matrix(FullStateDiagMatr matr, std::string indent=defaultMatrIndent);
+void print_matrix(CompMatr1 matr, string indent=defaultMatrIndent);
+void print_matrix(CompMatr2 matr, string indent=defaultMatrIndent);
+void print_matrix(CompMatr  matr, string indent=defaultMatrIndent);
+void print_matrix(DiagMatr1 matr, string indent=defaultMatrIndent);
+void print_matrix(DiagMatr2 matr, string indent=defaultMatrIndent);
+void print_matrix(DiagMatr  matr, string indent=defaultMatrIndent);
+void print_matrix(FullStateDiagMatr matr, string indent=defaultMatrIndent);
 
 
 
@@ -124,8 +129,8 @@ void print_matrix(FullStateDiagMatr matr, std::string indent=defaultMatrIndent);
  * TABLE PRINTING
  */
 
-void print_table(std::string title, std::vector<std::tuple<std::string, std::string>>   rows, std::string indent=defaultTableIndent);
-void print_table(std::string title, std::vector<std::tuple<std::string, long long int>> rows, std::string indent=defaultTableIndent);
+void print_table(string title, vector<tuple<string, string>>   rows, string indent=defaultTableIndent);
+void print_table(string title, vector<tuple<string, long long int>> rows, string indent=defaultTableIndent);
 
 
 
@@ -137,7 +142,7 @@ void print_pauliStr(PauliStr str, int numQubits);
 
 void print_pauliStrSumInfo(qindex numTerms, qindex numBytes);
 
-void print_pauliStrSum(PauliStrSum sum, std::string indent=defaultMatrIndent);
+void print_pauliStrSum(PauliStrSum sum, string indent=defaultMatrIndent);
 
 
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -12,6 +12,8 @@
 #include <type_traits>
 #include <string>
 
+using std::is_same_v;
+
 
 
 /*
@@ -26,18 +28,18 @@ constexpr bool util_isDenseMatrixType() {
 
     // CompMatr are "dense", storing all 2D elements
     if constexpr (
-        std::is_same_v<T, CompMatr1> ||
-        std::is_same_v<T, CompMatr2> ||
-        std::is_same_v<T, CompMatr>
+        is_same_v<T, CompMatr1> ||
+        is_same_v<T, CompMatr2> ||
+        is_same_v<T, CompMatr>
     )
         return true;
 
     // DiagMatr are "sparse", storing only the diagonals
     if constexpr (
-        std::is_same_v<T, DiagMatr1> ||
-        std::is_same_v<T, DiagMatr2> ||
-        std::is_same_v<T, DiagMatr>  ||
-        std::is_same_v<T, FullStateDiagMatr>
+        is_same_v<T, DiagMatr1> ||
+        is_same_v<T, DiagMatr2> ||
+        is_same_v<T, DiagMatr>  ||
+        is_same_v<T, FullStateDiagMatr>
     )
         return false;
 
@@ -51,10 +53,10 @@ template<class T>
 constexpr bool util_isFixedSizeMatrixType() {
 
     return (
-        std::is_same_v<T, CompMatr1> ||
-        std::is_same_v<T, CompMatr2> ||
-        std::is_same_v<T, DiagMatr1> ||
-        std::is_same_v<T, DiagMatr2>
+        is_same_v<T, CompMatr1> ||
+        is_same_v<T, CompMatr2> ||
+        is_same_v<T, DiagMatr1> ||
+        is_same_v<T, DiagMatr2>
     );
 }
 
@@ -62,7 +64,7 @@ constexpr bool util_isFixedSizeMatrixType() {
 template<class T>
 constexpr bool util_isDistributableMatrixType() {
 
-    return (std::is_same_v<T, FullStateDiagMatr>);
+    return (is_same_v<T, FullStateDiagMatr>);
 }
 
 // T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr, FullStateDiagMatr
@@ -79,21 +81,21 @@ bool util_isDistributedMatrix(T matr) {
 template<class T>
 std::string util_getMatrixTypeName() {
     
-    if constexpr (std::is_same_v<T, CompMatr1>)
+    if constexpr (is_same_v<T, CompMatr1>)
         return "CompMatr1";
-    if constexpr (std::is_same_v<T, CompMatr2>)
+    if constexpr (is_same_v<T, CompMatr2>)
         return "CompMatr2";
-    if constexpr (std::is_same_v<T, CompMatr>)
+    if constexpr (is_same_v<T, CompMatr>)
         return "CompMatr";
     
-    if constexpr (std::is_same_v<T, DiagMatr1>)
+    if constexpr (is_same_v<T, DiagMatr1>)
         return "DiagMatr1";
-    if constexpr (std::is_same_v<T, DiagMatr2>)
+    if constexpr (is_same_v<T, DiagMatr2>)
         return "DiagMatr2";
-    if constexpr (std::is_same_v<T, DiagMatr>)
+    if constexpr (is_same_v<T, DiagMatr>)
         return "DiagMatr";
 
-    if constexpr (std::is_same_v<T, FullStateDiagMatr>)
+    if constexpr (is_same_v<T, FullStateDiagMatr>)
         return "FullStateDiagMatr";
 
     // no need to create a new error for this situation I think

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -28,6 +28,9 @@
 #include <vector>
 #include <map>
 
+using std::string;
+using std::vector;
+
 
 
 /*
@@ -43,40 +46,40 @@ namespace report {
      *  ENVIRONMENT CREATION
      */
 
-    std::string QUEST_ENV_ALREADY_INIT =
+    string QUEST_ENV_ALREADY_INIT =
         "The QuEST environment has already been initialised. This can only be performed once during program execution.";
 
-    std::string QUEST_ENV_ALREADY_FINAL =
+    string QUEST_ENV_ALREADY_FINAL =
         "The QuEST environment has already been finalised, and can thereafter never be re-initialised since this leads to undefined MPI behaviour.";
 
 
-    std::string INVALID_OPTION_FOR_ENV_IS_DISTRIB =
+    string INVALID_OPTION_FOR_ENV_IS_DISTRIB =
         "Argument 'useDistrib' must be 1 or 0 to respectively indicate whether or not to distribute the new environment, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
-    std::string INVALID_OPTION_FOR_ENV_IS_GPU_ACCEL =
+    string INVALID_OPTION_FOR_ENV_IS_GPU_ACCEL =
         "Argument 'useGpuAccel' must be 1 or 0 to respectively indicate whether or not to GPU-accelerate the new environment, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
-    std::string INVALID_OPTION_FOR_ENV_IS_MULTITHREAD =
+    string INVALID_OPTION_FOR_ENV_IS_MULTITHREAD =
         "Argument 'useMultithread' must be 1 or 0 to respectively indicate whether or not to enable multithreading in the new environment, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
 
-    std::string CANNOT_MULTITHREAD_ENV_WITHOUT_OPENMP_COMPILATION =
+    string CANNOT_MULTITHREAD_ENV_WITHOUT_OPENMP_COMPILATION =
         "Cannot create a multithreaded environment because the QuEST source was not compiled with OpenMP enabled.";
 
-    std::string CANNOT_DISTRIB_ENV_WITHOUT_MPI_COMMPILATION =
+    string CANNOT_DISTRIB_ENV_WITHOUT_MPI_COMMPILATION =
         "Cannot create a distributed environment because the QuEST source was not compiled with MPI enabled.";
 
-    std::string CANNOT_GPU_ACCEL_ENV_WITH_GPU_COMPILATION =
+    string CANNOT_GPU_ACCEL_ENV_WITH_GPU_COMPILATION =
         "Cannot create a GPU-accelerated environment because the QuEST source was not compiled with GPU acceleration.";
 
 
-    std::string CANNOT_GPU_ACCEL_ENV_WITH_NO_AVAILABLE_GPUS =
+    string CANNOT_GPU_ACCEL_ENV_WITH_NO_AVAILABLE_GPUS =
         "Cannot create a GPU-accelerated environment because there are no GPUs available.";
 
-    std::string CANNOT_DISTRIB_ENV_BETWEEN_NON_POW_2_NODES =
+    string CANNOT_DISTRIB_ENV_BETWEEN_NON_POW_2_NODES =
         "Cannot distribute QuEST between ${NUM_NODES} nodes; must use a power-of-2 number of nodes.";
 
-    std::string CUQUANTUM_DEPLOYED_ON_GPU_WITHOUT_MEM_POOLS =
+    string CUQUANTUM_DEPLOYED_ON_GPU_WITHOUT_MEM_POOLS =
         "Cannot use cuQuantum since your GPU does not support memory pools. Please recompile with cuQuantum disabled to fall-back to using Thrust and custom kernels.";
 
     
@@ -84,7 +87,7 @@ namespace report {
      * EXISTING QUESTENV
      */
 
-    std::string QUEST_ENV_NOT_INIT =
+    string QUEST_ENV_NOT_INIT =
         "The QuEST environment is not initialised. Please first call initQuESTEnv() or initCustomQuESTEnv().";
 
 
@@ -92,7 +95,7 @@ namespace report {
      * DEBUG UTILITIES
      */
 
-    std::string INVALID_NUM_REPORTED_ITEMS =
+    string INVALID_NUM_REPORTED_ITEMS =
         "Invalid parameter (${NUM_ITEMS}). Must specify a positive number of items to be reported, or 0 to indicate that all items should be reported.";
 
 
@@ -100,79 +103,79 @@ namespace report {
      * QUREG CREATION
      */
 
-    std::string NON_POSITIVE_NUM_QUBITS_IN_CREATE_QUREG =
+    string NON_POSITIVE_NUM_QUBITS_IN_CREATE_QUREG =
         "Cannot create Qureg of ${NUM_QUBITS} qubits; must contain one or more qubits.";
 
 
-    std::string NEW_STATEVEC_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX = 
+    string NEW_STATEVEC_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX = 
         "Cannot create Qureg of ${NUM_QUBITS} qubits: the statevector would contain more amplitudes (2^${NUM_QUBITS}) than the maximum which can be addressed by the qindex type (2^${MAX_QUBITS}). See reportQuESTEnv().";
 
-    std::string NEW_DENSMATR_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX = 
+    string NEW_DENSMATR_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX = 
         "Cannot create density Qureg of ${NUM_QUBITS} qubits: the density matrix would contain more amplitudes (4^${NUM_QUBITS}) than can be addressed by the qindex type (4^${MAX_QUBITS}). See reportQuESTEnv().";
 
-    std::string NEW_STATEVEC_QUREG_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
+    string NEW_STATEVEC_QUREG_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
         "Cannot create Qureg of ${NUM_QUBITS} qubits distributed over ${NUM_NODES} nodes because the necessary local memory (in bytes) of each node would overflow size_t. In this deployment, the maximum number of qubits in a statevector Qureg is ${MAX_QUBITS}. See reportQuESTEnv().";
 
-    std::string NEW_DENSMATR_QUREG_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
+    string NEW_DENSMATR_QUREG_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
         "Cannot create density Qureg of ${NUM_QUBITS} qubits distributed over ${NUM_NODES} nodes because the necessary local memory (in bytes) of each node would overflow size_t. In this deployment, the maximum number of qubits in a density-matrix Qureg is ${MAX_QUBITS}. See reportQuESTEnv().";
 
-    std::string NEW_DISTRIB_STATEVEC_QUREG_HAS_TOO_FEW_AMPS = 
+    string NEW_DISTRIB_STATEVEC_QUREG_HAS_TOO_FEW_AMPS = 
         "Cannot create a distributed Qureg of only ${NUM_QUBITS} qubits between ${NUM_NODES} nodes, because each node would contain fewer than one amplitude of the statevector. The minimum size is ${MIN_QUBITS} qubits; see reportQuESTEnv(). Consider disabling distribution for this Qureg.";
 
-    std::string NEW_DISTRIB_DENSMATR_QUREG_HAS_TOO_FEW_AMPS = 
+    string NEW_DISTRIB_DENSMATR_QUREG_HAS_TOO_FEW_AMPS = 
         "Cannot create a distributed density Qureg of only ${NUM_QUBITS} qubits between ${NUM_NODES} nodes, because each node would contain fewer than a column's worth of amplitudes of the density matrix. The minimum size is ${MIN_QUBITS} qubits; see reportQuESTEnv(). Consider disabling distribution for this Qureg.";
 
 
-    std::string INVALID_OPTION_FOR_QUREG_IS_DENSMATR = 
+    string INVALID_OPTION_FOR_QUREG_IS_DENSMATR = 
         "Argument 'isDensityMatrix' must be 1 or 0 to respectively indicate whether the Qureg should be instantiated as a potentially-mixed density matrix or a strictly-pure state-vector.";
 
-    std::string INVALID_OPTION_FOR_QUREG_IS_DISTRIB = 
+    string INVALID_OPTION_FOR_QUREG_IS_DISTRIB = 
         "Argument 'useDistrib' must be 1 or 0 to respectively indicate whether or not to distribute the new Qureg, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
-    std::string INVALID_OPTION_FOR_QUREG_IS_GPU_ACCEL = 
+    string INVALID_OPTION_FOR_QUREG_IS_GPU_ACCEL = 
         "Argument 'useGpuAccel' must be 1 or 0 to respetively indicate whether or not to GPU-accelerate the new Qureg, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
-    std::string INVALID_OPTION_FOR_QUREG_IS_MULTITHREAD = 
+    string INVALID_OPTION_FOR_QUREG_IS_MULTITHREAD = 
         "Argument 'useMultithread' must be 1 or 0 to respectively indicate whether or not to use multithreading when processing the new Qureg, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
 
-    std::string NEW_DISTRIB_QUREG_IN_NON_DISTRIB_ENV =
+    string NEW_DISTRIB_QUREG_IN_NON_DISTRIB_ENV =
         "Cannot distribute a Qureg when in a non-distributed QuEST environment.";
 
-    std::string NEW_GPU_QUREG_IN_NON_GPU_ACCEL_ENV =
+    string NEW_GPU_QUREG_IN_NON_GPU_ACCEL_ENV =
         "Cannot allocate a Qureg to a GPU when in a non-GPU-accelerated QuEST environment.";
 
-    std::string NEW_MULTITHREAD_QUREG_IN_NON_MULTITHREAD_ENV =
+    string NEW_MULTITHREAD_QUREG_IN_NON_MULTITHREAD_ENV =
         "Cannot enable multithreaded processing of a Qureg created in a non-multithreaded QuEST environment.";
 
 
-    std::string NEW_GPU_QUREG_CANNOT_USE_MULTITHREADING = 
+    string NEW_GPU_QUREG_CANNOT_USE_MULTITHREADING = 
         "Cannot simultaneously GPU-accelerate and multithread a Qureg. Please disable multithreading, or set it to ${AUTO_DEPLOYMENT_FLAG} for QuEST to automatically disable it when deploying to GPU.";
 
 
-    std::string NEW_QUREG_CANNOT_FIT_INTO_NON_DISTRIB_CPU_MEM =
+    string NEW_QUREG_CANNOT_FIT_INTO_NON_DISTRIB_CPU_MEM =
         "The non-distributed Qureg (isDensity=${IS_DENS}) of ${NUM_QUBITS} qubits would be too large (${QCOMP_BYTES} * ${EXP_BASE}^${NUM_QUBITS} bytes) to fit into a single node's RAM (${RAM_SIZE} bytes). See reportQuESTEnv(), and consider using distribution.";
 
-    std::string NEW_QUREG_CANNOT_FIT_INTO_POTENTIALLY_DISTRIB_CPU_MEM = 
+    string NEW_QUREG_CANNOT_FIT_INTO_POTENTIALLY_DISTRIB_CPU_MEM = 
         "The distributed Qureg (isDensity=${IS_DENS}) of ${NUM_QUBITS} qubits, together with its commnication buffer, would be too large (2 * ${QCOMP_BYTES} * ${EXP_BASE}^${NUM_QUBITS} bytes) to fit into the combined RAM of all ${NUM_NODES} nodes (${NUM_NODES} * ${RAM_SIZE} bytes). See reportQuESTEnv().";
 
-    std::string NEW_QUREG_CANNOT_FIT_INTO_NON_DISTRIB_CURRENT_GPU_MEM =
+    string NEW_QUREG_CANNOT_FIT_INTO_NON_DISTRIB_CURRENT_GPU_MEM =
         "The non-distributed GPU-accelerated Qureg (isDensity=${IS_DENS}) of ${NUM_QUBITS} qubits would be too large (${QCOMP_BYTES} * ${EXP_BASE}^${NUM_QUBITS} bytes) to fit into a single node's available GPU memory (currently ${MIN_VRAM_AVAIL} bytes free). Consider additionally using distribution, or disabling GPU-acceleration (though this may greatly increase runtime).";
 
-    std::string NEW_QUREG_CANNOT_FIT_INTO_POTENTIALLY_DISTRIB_CURRENT_GPU_MEM =
+    string NEW_QUREG_CANNOT_FIT_INTO_POTENTIALLY_DISTRIB_CURRENT_GPU_MEM =
         "The distributed GPU-accelerated Qureg (isDensity=${IS_DENS}) of ${NUM_QUBITS} qubits, together with its commnication buffer, is too large; one or more of the ${NUM_GPUS} GPUs has insufficient available memory (only ${MIN_VRAM_AVAIL} bytes) to store its Qureg partition (${QCOMP_BYTES} * 2^${LOG2_NUM_AMPS} bytes) bytes. Consider disabling GPU-acceleration.";
 
 
-    std::string NEW_QUREG_CPU_AMPS_ALLOC_FAILED = 
+    string NEW_QUREG_CPU_AMPS_ALLOC_FAILED = 
         "Allocation of memory to store the CPU amplitudes failed.";
 
-    std::string NEW_QUREG_GPU_AMPS_ALLOC_FAILED = 
+    string NEW_QUREG_GPU_AMPS_ALLOC_FAILED = 
         "Allocation of memory to store the GPU amplitudes failed.";
 
-    std::string NEW_QUREG_CPU_COMM_BUFFER_ALLOC_FAILED = 
+    string NEW_QUREG_CPU_COMM_BUFFER_ALLOC_FAILED = 
         "Allocation of memory for the distributed CPU communication buffer failed.";
 
-    std::string NEW_QUREG_GPU_COMM_BUFFER_ALLOC_FAILED = 
+    string NEW_QUREG_GPU_COMM_BUFFER_ALLOC_FAILED = 
         "Allocation of memory for the distributed GPU communication buffer failed.";
 
 
@@ -180,7 +183,7 @@ namespace report {
      * EXISTING QUREG
      */
 
-    std::string INVALID_QUREG_FIELDS = 
+    string INVALID_QUREG_FIELDS = 
         "Invalid Qureg; invalid or incompatible fields isDensityMatrix=${DENS_MATR}, numQubits=${NUM_QUBITS}, numAmps=${NUM_AMPS}. It is likely this Qureg was not initialised with createQureg().";
 
 
@@ -188,62 +191,62 @@ namespace report {
      * MATRIX CREATION
      */
 
-    std::string NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE = 
+    string NEW_MATRIX_NUM_QUBITS_NOT_POSITIVE = 
         "Cannot create a matrix which acts upon ${NUM_QUBITS} qubits; must target one or more qubits.";
 
 
-    std::string NEW_DIAG_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX =
+    string NEW_DIAG_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX =
         "Cannot create a diagonal matrix of ${NUM_QUBITS} qubits: the matrix would contain more elements (2^${NUM_QUBITS}) than the maximum which can be addressed by the qindex type (2^${MAX_QUBITS}).";
 
-    std::string NEW_COMP_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX =
+    string NEW_COMP_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX =
         "Cannot create a dense matrix of ${NUM_QUBITS} qubits: the matrix would contain more elements (4^${NUM_QUBITS}) than the maximum which can be addressed by the qindex type (4^${MAX_QUBITS}).";
 
 
-    std::string NEW_LOCAL_COMP_MATR_MEM_WOULD_EXCEED_SIZEOF =
+    string NEW_LOCAL_COMP_MATR_MEM_WOULD_EXCEED_SIZEOF =
         "Cannot create a local, dense matrix of ${NUM_QUBITS} qubits because the necessary memory (in bytes) would overflow size_t. In this deployment, the maximum number of qubits in such a matrix is ${MAX_QUBITS}.";
 
-    std::string NEW_LOCAL_DIAG_MATR_MEM_WOULD_EXCEED_SIZEOF =
+    string NEW_LOCAL_DIAG_MATR_MEM_WOULD_EXCEED_SIZEOF =
         "Cannot create a local, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (in bytes) would overflow size_t. In this deployment, the maximum number of qubits in such a matrix is ${MAX_QUBITS}.";
 
-    std::string NEW_DISTRIB_DIAG_MATR_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
+    string NEW_DISTRIB_DIAG_MATR_LOCAL_MEM_WOULD_EXCEED_SIZEOF =
         "Cannot create a diagonal matrix of ${NUM_QUBITS} qubits distributed over ${NUM_NODES} nodes because the necessary local memory (in bytes) of each node would overflow size_t. In this deployment, the maximum number of qubits in such a matrix is ${MAX_QUBITS}.";
 
 
-    std::string NEW_DISTRIB_DIAG_MATR_HAS_TOO_FEW_AMPS =
+    string NEW_DISTRIB_DIAG_MATR_HAS_TOO_FEW_AMPS =
         "Cannot create a diagonal matrix of ${NUM_QUBITS} distributed between ${NUM_NODES} nodes because each node would contain fewer than one element. The minimum number of qubits in such a matrix is ${MIN_QUBITS}. Consider disabling distribution for this matrix.";
 
 
-    std::string NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_CPU_MEM =
+    string NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_CPU_MEM =
         "Cannot create a local, dense matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 4^${NUM_QUBITS} bytes) exceeds the available RAM of ${RAM_SIZE} bytes.";
 
-    std::string NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM =
+    string NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM =
         "Cannot create a local, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 2^${NUM_QUBITS} bytes) exceeds the available RAM of ${RAM_SIZE} bytes.";
 
-    std::string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM =
+    string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM =
         "Cannot create a diagonal matrix of ${NUM_QUBITS} qubits distributed between ${NUM_NODES} because the necessary memory per node (${QCOMP_BYTES} * 2^${NUM_QB_MINUS_LOG_NODES} bytes) exceeds the local available RAM of ${RAM_SIZE} bytes.";
 
 
-    std::string NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_GPU_MEM =
+    string NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_GPU_MEM =
         "Cannot create a local, GPU-accelerated, dense matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 4^${NUM_QUBITS} bytes) exceeds the available GPU memory of ${VRAM_SIZE} bytes.";
 
-    std::string NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
+    string NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
         "Cannot create a local, GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits because the necessary memory (${QCOMP_BYTES} * 2^${NUM_QUBITS} bytes) exceeds the available GPU memory of ${VRAM_SIZE} bytes.";
 
-    std::string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
+    string NEW_DISTRIB_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM =
         "Cannot create a GPU-accelerated, diagonal matrix of ${NUM_QUBITS} qubits distributed between ${NUM_NODES} because the necessary memory per node (${QCOMP_BYTES} * 2^${NUM_QB_MINUS_LOG_NODES} bytes) exceeds the local available GPU memory of ${VRAM_SIZE} bytes.";
 
 
-    std::string NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED = 
+    string NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED = 
         "Attempted allocation of memory (${NUM_BYTES} bytes in RAM) failed.";
 
-    std::string NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED = 
+    string NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED = 
         "Attempted allocation of GPU memory (${NUM_BYTES} bytes in VRAM) failed.";
 
 
-    std::string NEW_DISTRIB_MATRIX_IN_NON_DISTRIB_ENV = 
+    string NEW_DISTRIB_MATRIX_IN_NON_DISTRIB_ENV = 
         "Cannot distribute a matrix in a non-distributed environment.";
 
-    std::string INVALID_OPTION_FOR_MATRIX_IS_DISTRIB = 
+    string INVALID_OPTION_FOR_MATRIX_IS_DISTRIB = 
         "Argument 'useDistrib' must be 1 or 0 to respectively indicate whether or not to distribute the new matrix, or ${AUTO_DEPLOYMENT_FLAG} to let QuEST choose automatically.";
 
 
@@ -252,30 +255,30 @@ namespace report {
      * MATRIX INITIALISATION
      */
 
-    std::string MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
+    string MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
         "The new elements contained a reserved, forbidden value as the first element, used internally to detect that whether GPU memory has not synchronised. The value was intended to be extremely unlikely to be used by users - go buy a lottery ticket! If you insist on using this value in the first element, add a numerically insignificant perturbation.";
 
 
-    std::string COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS =
+    string COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS =
         "Incompatible number of rows (${NUM_GIVEN_ROWS}) of elements given to overwrite a ${NUM_QUBITS}-qubit CompMatr, which expects ${NUM_EXPECTED_ROWS} rows.";
 
-    std::string COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM =
+    string COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM =
         "One or more rows contained an incompatible number of elements (${NUM_GIVEN_ELEMS}). The ${NUM_QUBITS}-qubit CompMatr expects a square ${EXPECTED_DIM}x${EXPECTED_DIM} matrix.";
 
-    std::string DIAG_MATR_WRONG_NUM_NEW_ELEMS = 
+    string DIAG_MATR_WRONG_NUM_NEW_ELEMS = 
         "Incompatible number of elements (${NUM_GIVEN_ELEMS}) assigned to a ${NUM_QUBITS}-qubit DiagMatr, which expects ${NUM_EXPECTED_ELEMS} elements.";
     
 
-    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_INVALID_START_INDEX =
+    string FULL_STATE_DIAG_MATR_NEW_ELEMS_INVALID_START_INDEX =
         "Invalid start index (${START_IND}), which must be non-negative and smaller than the total number of diagonal elements in the matrix (${MATR_NUM_ELEMS}).";
 
-    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_IS_NON_POSITIVE =
+    string FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_IS_NON_POSITIVE =
         "Invalid number of new elements (${NUM_ELEMS}). Must be greater than zero.";
 
-    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_EXCEEDS_MAX_NUM =
+    string FULL_STATE_DIAG_MATR_NEW_ELEMS_NUM_EXCEEDS_MAX_NUM =
         "The given number of new elements (${NEW_NUM_ELEMS}) exceeds the total number of diagonal elements in the matrix (${MATR_NUM_ELEMS}).";
 
-    std::string FULL_STATE_DIAG_MATR_NEW_ELEMS_EXCEEDS_END_INDEX =
+    string FULL_STATE_DIAG_MATR_NEW_ELEMS_EXCEEDS_END_INDEX =
         "The specified range of elements to set (at indices ${START_IND} to ${END_IND_EXCL} exclusive) exceeds the bounds of the diagonal matrix (of ${MATR_NUM_ELEMS} total elements).";
 
 
@@ -283,65 +286,65 @@ namespace report {
      * EXISTING MATRIX
      */
 
-    std::string INVALID_COMP_MATR_1_FIELDS =
+    string INVALID_COMP_MATR_1_FIELDS =
         "Invalid CompMatr1. Targeted ${NUM_QUBITS} qubits (instead of 1) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 2x2). It is likely this matrix was not initialised with getCompMatr1().";
 
-    std::string INVALID_COMP_MATR_2_FIELDS =
+    string INVALID_COMP_MATR_2_FIELDS =
         "Invalid CompMatr2. Targeted ${NUM_QUBITS} qubits (instead of 2) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 4x4). It is likely this matrix was not initialised with getCompMatr2().";
 
-    std::string INVALID_COMP_MATR_FIELDS =
+    string INVALID_COMP_MATR_FIELDS =
         "Invalid CompMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createCompMatr().";
 
-    std::string INVALID_COMP_MATR_CPU_MEM_ALLOC =
+    string INVALID_COMP_MATR_CPU_MEM_ALLOC =
         "Invalid CompMatr. One or more rows of the 2D CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createCompMatr().";
 
-    std::string INVALID_COMP_MATR_GPU_MEM_ALLOC =
+    string INVALID_COMP_MATR_GPU_MEM_ALLOC =
         "Invalid CompMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createCompMatr().";
 
 
-    std::string INVALID_DIAG_MATR_1_FIELDS =
+    string INVALID_DIAG_MATR_1_FIELDS =
         "Invalid DiagMatr1. Targeted ${NUM_QUBITS} qubits (instead of 1) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 2x2). It is likely this matrix was not initialised with getDiagMatr1().";
 
-    std::string INVALID_DIAG_MATR_2_FIELDS =
+    string INVALID_DIAG_MATR_2_FIELDS =
         "Invalid DiagMatr2. Targeted ${NUM_QUBITS} qubits (instead of 2) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 4x4). It is likely this matrix was not initialised with getDiagMatr2().";
 
-    std::string INVALID_DIAG_MATR_FIELDS =
+    string INVALID_DIAG_MATR_FIELDS =
         "Invalid DiagMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createDiagMatr().";
 
-    std::string INVALID_DIAG_MATR_CPU_MEM_ALLOC =
+    string INVALID_DIAG_MATR_CPU_MEM_ALLOC =
         "Invalid DiagMatr. The CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
 
-    std::string INVALID_DIAG_MATR_GPU_MEM_ALLOC =
+    string INVALID_DIAG_MATR_GPU_MEM_ALLOC =
         "Invalid DiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
 
 
-    std::string INVALID_FULL_STATE_DIAG_MATR_FIELDS = 
+    string INVALID_FULL_STATE_DIAG_MATR_FIELDS = 
         "Invalid FullStateDiagMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createFullStateDiagMatr().";
 
-    std::string INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC =
+    string INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC =
         "Invalid FullStateDiagMatr. The CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createFullStateDiagMatr().";
 
-    std::string INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC =
+    string INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC =
         "Invalid FullStateDiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createFullStateDiagMatr().";
 
 
-    std::string COMP_MATR_NOT_SYNCED_TO_GPU = 
+    string COMP_MATR_NOT_SYNCED_TO_GPU = 
         "The CompMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncCompMatr() after manually modifying elements, or overwrite all elements with setCompMatr().";
 
-    std::string DIAG_MATR_NOT_SYNCED_TO_GPU = 
+    string DIAG_MATR_NOT_SYNCED_TO_GPU = 
         "The DiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncDiagMatr() after manually modifying elements, or overwrite all elements with setDiagMatr().";
 
-    std::string FULL_STATE_DIAG_MATR_NOT_SYNCED_TO_GPU = 
+    string FULL_STATE_DIAG_MATR_NOT_SYNCED_TO_GPU = 
         "The FullStateDiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncFullStateDiagMatr() after manually modifying elements, or overwrite elements in batch with setFullStateDiagMatr().";
 
 
-    std::string MATRIX_NOT_UNITARY = 
+    string MATRIX_NOT_UNITARY = 
         "The given matrix was not (approximately) unitary.";
 
-    std::string FULL_STATE_DIAG_MATR_MISMATCHES_QUREG_DIM =
+    string FULL_STATE_DIAG_MATR_MISMATCHES_QUREG_DIM =
         "The given FullStateDiagMatr operates upon a different number of qubits (${NUM_MATR_QUBITS}) than exists in the Qureg (${NUM_QUREG_QUBITS}).";
 
-    std::string FULL_STATE_DIAG_MATR_IS_DISTRIB_BUT_QUREG_ISNT =
+    string FULL_STATE_DIAG_MATR_IS_DISTRIB_BUT_QUREG_ISNT =
         "The given FullStateDiagMatr is distributed but the Qureg is not, which is forbidden. Consider disabling distribution for this matrix via createCustomFullStateDiagMatr().";
 
 
@@ -349,26 +352,26 @@ namespace report {
      * PAULI STRING CREATION
      */
 
-    std::string NEW_PAULI_STR_NON_POSITIVE_NUM_PAULIS =
+    string NEW_PAULI_STR_NON_POSITIVE_NUM_PAULIS =
         "Invalid number of Paulis (${NUM_PAULIS}). The Pauli string must contain at least one Pauli operator, which is permittedly identity.";
     
-    std::string NEW_PAULI_STR_NUM_PAULIS_EXCEEDS_TYPE =
+    string NEW_PAULI_STR_NUM_PAULIS_EXCEEDS_TYPE =
         "Cannot make a Pauli string of ${NUM_PAULIS} Paulis since this exceeds the maximum of ${MAX_PAULIS} imposed by the typing of PauliStr's fields.";
     
     // TODO: replace BAD_CHAR ascii code with actual character, once tokenSubs is generalised to any-type
-    std::string NEW_PAULI_STR_UNRECOGNISED_PAULI_CHAR = 
+    string NEW_PAULI_STR_UNRECOGNISED_PAULI_CHAR = 
         "Given an unrecognised Pauli character (ASCII code ${BAD_CHAR}) at index ${CHAR_IND}. Each character must be one of I X Y Z (or lower case), or equivalently 0 1 2 3'.";
 
-    std::string NEW_PAULI_STR_TERMINATION_CHAR_TOO_EARLY =
+    string NEW_PAULI_STR_TERMINATION_CHAR_TOO_EARLY =
         "The given string contained fewer characters (${TERM_IND}) than the specified number of Pauli operators (${NUM_PAULIS}).";
 
-    std::string NEW_PAULI_STR_INVALID_INDEX =
+    string NEW_PAULI_STR_INVALID_INDEX =
         "Invalid index (${BAD_IND}). Pauli indices must be non-negative and cannot equal nor exceed the maximum number of representable Pauli operators (${MAX_PAULIS}).";
 
-    std::string NEW_PAULI_STR_DUPLICATED_INDEX =
+    string NEW_PAULI_STR_DUPLICATED_INDEX =
         "The Pauli indices contained a duplicate. Indices must be unique.";
 
-    std::string NEW_PAULI_STR_DIFFERENT_NUM_CHARS_AND_INDS = 
+    string NEW_PAULI_STR_DIFFERENT_NUM_CHARS_AND_INDS = 
         "Given a different number of Pauli operators (${NUM_PAULIS}) and their qubit indices (${NUM_INDS}).";
 
 
@@ -376,16 +379,16 @@ namespace report {
      * PAULI STRING SUM CREATION
      */
 
-    std::string NEW_PAULI_STR_SUM_NON_POSITIVE_NUM_STRINGS =
+    string NEW_PAULI_STR_SUM_NON_POSITIVE_NUM_STRINGS =
         "Cannot create a sum with ${NUM_TERMS} terms. The number of terms must be a positive integer.";
 
-    std::string NEW_PAULI_STR_SUM_DIFFERENT_NUM_STRINGS_AND_COEFFS =
+    string NEW_PAULI_STR_SUM_DIFFERENT_NUM_STRINGS_AND_COEFFS =
         "Given a different number of Pauli strings (${NUM_STRS}) and coefficients ${NUM_COEFFS}.";
 
-    std::string NEW_PAULI_STR_SUM_STRINGS_ALLOC_FAILED = 
+    string NEW_PAULI_STR_SUM_STRINGS_ALLOC_FAILED = 
         "Attempted allocation of the PauliStrSum's ${NUM_TERMS}-term array of Pauli strings (${NUM_BYTES} bytes total) unexpectedly failed.";
 
-    std::string NEW_PAULI_STR_SUM_COEFFS_ALLOC_FAILED =
+    string NEW_PAULI_STR_SUM_COEFFS_ALLOC_FAILED =
         "Attempted allocation of the PauliStrSum's ${NUM_TERMS}-term array of coefficients (${NUM_BYTES} bytes total) unexpectedly failed.";
 
 
@@ -393,16 +396,16 @@ namespace report {
      * PAULI STRING SUM PARSING
      */
 
-    std::string PARSED_PAULI_STR_SUM_UNINTERPRETABLE_LINE = 
+    string PARSED_PAULI_STR_SUM_UNINTERPRETABLE_LINE = 
         "Could not interpret line ${LINE_NUMBER} as a coefficient followed by a sequence of Pauli operators.";
 
-    std::string PARSED_PAULI_STR_SUM_INCONSISTENT_NUM_PAULIS_IN_LINE =
+    string PARSED_PAULI_STR_SUM_INCONSISTENT_NUM_PAULIS_IN_LINE =
         "Line ${LINE_NUMBER} specified ${NUM_LINE_PAULIS} Pauli operators which is inconsistent with the number of Paulis of the previous lines (${NUM_PAULIS}).";
 
-    std::string PARSED_PAULI_STR_SUM_COEFF_IS_INVALID =
+    string PARSED_PAULI_STR_SUM_COEFF_IS_INVALID =
         "The coefficient of line ${LINE_NUMBER} could not be converted to a qcomp, possibly due to it exceeding the valid numerical range.";
 
-    std::string PARSED_STRING_IS_EMPTY =
+    string PARSED_STRING_IS_EMPTY =
         "The given string was empty (contained only whitespace characters) and could not be parsed.";
 
 
@@ -410,7 +413,7 @@ namespace report {
      * EXISTING PAULI STRING SUM
      */
 
-    std::string INVALID_PAULI_STR_SUM_FIELDS =
+    string INVALID_PAULI_STR_SUM_FIELDS =
         "The given PauliStrSum had invalid fields (.numTerms=${NUM_TERMS}), which is likely a result from not being correctly initialised by createPauliStrSum().";
 
 
@@ -418,7 +421,7 @@ namespace report {
      * QUREG INITIALISATIONS
      */
 
-    std::string INVALID_STATE_INDEX = 
+    string INVALID_STATE_INDEX = 
         "Classical state index ${STATE_IND} is invalid for the given ${NUM_QUBITS} qubit Qureg. Index must be greater than or equal to zero, and cannot equal nor exceed the number of unique classical states (2^${NUM_QUBITS} = ${NUM_STATES}).";
 
     
@@ -426,7 +429,7 @@ namespace report {
      * OPERATOR PARAMETERS
      */
     
-    std::string INVALID_TARGET_QUBIT = 
+    string INVALID_TARGET_QUBIT = 
         "Invalid target qubit (${TARGET}). Must be greater than or equal to zero, and less than the number of qubits in the Qureg (${NUM_QUBITS}).";
 
 
@@ -435,7 +438,7 @@ namespace report {
      */
 
     // TODO: embed filename into error message when tokenSubs supports strings
-    std::string CANNOT_READ_FILE = 
+    string CANNOT_READ_FILE = 
         "Could not load and read the given file. Make sure the file exists and is readable as plaintext.";
 }
 
@@ -449,7 +452,7 @@ namespace report {
 void default_invalidQuESTInputError(const char* msg, const char* func) {
 
     // safe to call even before MPI has been setup
-    print(std::string("")
+    print(string("")
         + "QuEST encountered a validation error during function " 
         + "'" + func + "':\n" + msg + "\n"
         + "Exiting...");
@@ -510,43 +513,43 @@ bool validate_isEnabled() {
 
 // map like "${X}" -> 5, with max-size signed int values to prevent overflows.
 // in C++11, these can be initialised with {{"${X}", 5}, ...}
-using tokenSubs = std::map<std::string, long long int>;
+using tokenSubs = std::map<string, long long int>;
 
-std::string getStringWithSubstitutedVars(std::string oldStr, tokenSubs varsAndVals) {
+string getStringWithSubstitutedVars(string oldStr, tokenSubs varsAndVals) {
 
-    std::string newStr = oldStr;
+    string newStr = oldStr;
 
     // substitute every var,val pair into newStr
     for (auto varAndVal : varsAndVals) {
 
         // unpack var -> val
-        std::string var = std::get<0>(varAndVal);
-        std::string val = std::to_string(std::get<1>(varAndVal));
+        string var = std::get<0>(varAndVal);
+        string val = std::to_string(std::get<1>(varAndVal));
 
         // assert var is well-formed 
         if (var[0] != '$' || var[1] != '{' || var.back() != '}' )
             error_validationMessageVarWasIllFormed(newStr, var);
 
         // assert var appears at least once in string
-        if (newStr.find(var) == std::string::npos)
+        if (newStr.find(var) == string::npos)
             error_validationMessageVarNotSubstituted(newStr, var);
 
         // replace every occurrence of var with val
         size_t ind = newStr.find(var);
-        while (ind != std::string::npos) {
+        while (ind != string::npos) {
             newStr = newStr.replace(ind, var.length(), val);
             ind = newStr.find(var, ind);
         }
     }
 
     // assert there is no $ left in the strings
-    if (newStr.find("$") != std::string::npos)
+    if (newStr.find("$") != string::npos)
         error_validationMessageContainedUnsubstitutedVars(newStr);
 
     return newStr;
 }
 
-void assertThat(bool valid, std::string msg, const char* func) {
+void assertThat(bool valid, string msg, const char* func) {
 
     // skip validation if user has disabled
     if (!isValidationEnabled)
@@ -562,13 +565,13 @@ void assertThat(bool valid, std::string msg, const char* func) {
         invalidQuESTInputError(msg.c_str(), func);
 }
 
-void assertThat(bool valid, std::string msg, tokenSubs vars, const char* func) {
+void assertThat(bool valid, string msg, tokenSubs vars, const char* func) {
 
-    std::string newMsg = getStringWithSubstitutedVars(msg, vars);
+    string newMsg = getStringWithSubstitutedVars(msg, vars);
     assertThat(valid, newMsg, func);
 }
 
-void assertAllNodesAgreeThat(bool valid, std::string msg, const char* func) {
+void assertAllNodesAgreeThat(bool valid, string msg, const char* func) {
 
     // skip below consensus broadcast if user has disabled validation
     if (!isValidationEnabled)
@@ -586,9 +589,9 @@ void assertAllNodesAgreeThat(bool valid, std::string msg, const char* func) {
     assertThat(valid, msg, func);
 }
 
-void assertAllNodesAgreeThat(bool valid, std::string msg, tokenSubs vars, const char* func) {
+void assertAllNodesAgreeThat(bool valid, string msg, tokenSubs vars, const char* func) {
 
-    std::string newMsg = getStringWithSubstitutedVars(msg, vars);
+    string newMsg = getStringWithSubstitutedVars(msg, vars);
     assertAllNodesAgreeThat(valid, newMsg, func);
 }
 
@@ -739,7 +742,7 @@ void assertQuregTotalNumAmpsDontExceedMaxIndex(int numQubits, int isDensMatr, co
     int maxNumQubits = mem_getMaxNumQubitsBeforeIndexOverflow(isDensMatr);
 
     // make message specific to statevector or density matrix
-    std::string msg = (isDensMatr)? 
+    string msg = (isDensMatr)? 
         report::NEW_DENSMATR_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX : 
         report::NEW_STATEVEC_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX ;
     tokenSubs vars = {
@@ -762,7 +765,7 @@ void assertQuregLocalMemDoesntExceedMaxSizeof(int numQubits, int isDensMatr, int
         {"${NUM_NODES}",  numQuregNodes},
         {"${MAX_QUBITS}", maxNumQubits}};
 
-    std::string msg = (isDensMatr)?
+    string msg = (isDensMatr)?
         report::NEW_DENSMATR_QUREG_LOCAL_MEM_WOULD_EXCEED_SIZEOF :
         report::NEW_STATEVEC_QUREG_LOCAL_MEM_WOULD_EXCEED_SIZEOF;
 
@@ -776,7 +779,7 @@ void assertQuregNotDistributedOverTooManyNodes(int numQubits, int isDensMatr, in
         return;
 
     // make message specific to statevector or density matrix
-    std::string msg = (isDensMatr)? report::NEW_DISTRIB_DENSMATR_QUREG_HAS_TOO_FEW_AMPS : report::NEW_DISTRIB_STATEVEC_QUREG_HAS_TOO_FEW_AMPS;
+    string msg = (isDensMatr)? report::NEW_DISTRIB_DENSMATR_QUREG_HAS_TOO_FEW_AMPS : report::NEW_DISTRIB_STATEVEC_QUREG_HAS_TOO_FEW_AMPS;
     tokenSubs vars = {
         {"${NUM_QUBITS}", numQubits},
         {"${NUM_NODES}",  env.numNodes},
@@ -807,7 +810,7 @@ void assertQuregFitsInCpuMem(int numQubits, int isDensMatr, int isDistrib, QuEST
     bool quregFitsInMem = mem_canQuregFitInMemory(numQubits, isDensMatr, numQuregNodes, memPerNode);
 
     // make error message specific to whether qureg is local or distributed
-    std::string msg = (numQuregNodes == 1)?
+    string msg = (numQuregNodes == 1)?
         report::NEW_QUREG_CANNOT_FIT_INTO_NON_DISTRIB_CPU_MEM :
         report::NEW_QUREG_CANNOT_FIT_INTO_POTENTIALLY_DISTRIB_CPU_MEM;
 
@@ -969,7 +972,7 @@ void assertMatrixTotalNumElemsDontExceedMaxIndex(int numQubits, bool isDense, co
 
     int maxNumQubits = mem_getMaxNumQubitsBeforeIndexOverflow(isDense);
 
-    std::string msg = (isDense)?
+    string msg = (isDense)?
         report::NEW_DIAG_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX :
         report::NEW_COMP_MATR_NUM_ELEMS_WOULD_EXCEED_QINDEX ;
 
@@ -999,7 +1002,7 @@ void assertMatrixLocalMemDoesntExceedMaxSizeof(int numQubits, bool isDense, int 
 
     // make error message specific to whether the matrix is distributed or non-distributed type;
     // non-distributed matrices (e.g. CompMatr) should only ever cause the local error message
-    std::string msg = (numMatrNodes > 1)?
+    string msg = (numMatrNodes > 1)?
         report::NEW_DISTRIB_DIAG_MATR_LOCAL_MEM_WOULD_EXCEED_SIZEOF :
         ((isDense)?
             report::NEW_LOCAL_COMP_MATR_MEM_WOULD_EXCEED_SIZEOF :
@@ -1033,7 +1036,7 @@ void assertMatrixNotDistributedOverTooManyNodes(int numQubits, bool isDense, int
     // require having at leat 1 column per node, like density matrix Quregs do.
     int minQubits = mem_getMinNumQubitsForDistribution(numEnvNodes);
 
-    std::string msg = report::NEW_DISTRIB_DIAG_MATR_HAS_TOO_FEW_AMPS;
+    string msg = report::NEW_DISTRIB_DIAG_MATR_HAS_TOO_FEW_AMPS;
     tokenSubs vars = {
         {"${NUM_QUBITS}", numQubits},
         {"${MIN_QUBITS}", minQubits},
@@ -1072,7 +1075,7 @@ void assertMatrixFitsInCpuMem(int numQubits, bool isDense, int isDistrib, int nu
     bool matrFitsInMem = mem_canMatrixFitInMemory(numQubits, isDense, numMatrNodes, memPerNode);
 
     // specialise error message to whether matrix is distributed and dense or diag
-    std::string msg = (isDense)?
+    string msg = (isDense)?
         report::NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_CPU_MEM :
         ((numMatrNodes == 1)?
             report::NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_CPU_MEM :
@@ -1124,7 +1127,7 @@ void assertMatrixFitsInGpuMem(int numQubits, bool isDense, int isDistrib, int is
     bool matrFitsInMem = mem_canMatrixFitInMemory(numQubits, isDense, numMatrNodes, localCurrGpuMem);
 
     // specialise error message to whether matrix is distributed and dense or diag
-    std::string msg = (isDense)?
+    string msg = (isDense)?
         report::NEW_LOCAL_COMP_MATR_CANNOT_FIT_INTO_GPU_MEM :
         ((numMatrNodes == 1)?
             report::NEW_LOCAL_DIAG_MATR_CANNOT_FIT_INTO_GPU_MEM :
@@ -1229,7 +1232,7 @@ void validate_newMatrixAllocs(FullStateDiagMatr matr, qindex numBytes, const cha
 
 // T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr
 template <class T>
-void assertMatrixFieldsAreValid(T matr, int expectedNumQb, std::string errMsg, const char* caller) {
+void assertMatrixFieldsAreValid(T matr, int expectedNumQb, string errMsg, const char* caller) {
 
     qindex dim = util_getMatrixDim(matr);
     tokenSubs vars = {
@@ -1252,7 +1255,7 @@ void assertMatrixFieldsAreValid(T matr, int expectedNumQb, std::string errMsg, c
 
 // T can be CompMatr or DiagMatr (the only matrix structs with pointers)
 template <class T>
-void assertMatrixAllocsAreValid(T matr, std::string cpuErrMsg, std::string gpuErrMsg, const char* caller) {
+void assertMatrixAllocsAreValid(T matr, string cpuErrMsg, string gpuErrMsg, const char* caller) {
 
     // assert CPU memory is allocated
     assertThat(matr.cpuElems != NULL, cpuErrMsg, caller);
@@ -1296,7 +1299,7 @@ void validate_matrixFields(FullStateDiagMatr matr, const char* caller) {
     assertMatrixAllocsAreValid(matr, report::INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC, report::INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC, caller);
 }
 
-void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller) {
+void validate_matrixNumNewElems(int numQubits, vector<vector<qcomp>> elems, const char* caller) {
 
     // CompMatr accept 2D elems   
     qindex dim = powerOf2(numQubits);
@@ -1317,7 +1320,7 @@ void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> e
         assertThat(row.size() == dim, report::COMP_MATR_NEW_ELEMS_WRONG_ROW_DIM, vars, caller);
     }
 }
-void validate_matrixNumNewElems(int numQubits, std::vector<qcomp> elems, const char* caller) {
+void validate_matrixNumNewElems(int numQubits, vector<qcomp> elems, const char* caller) {
 
     // DiagMatr accept 1D elems
     qindex dim = powerOf2(numQubits);
@@ -1375,7 +1378,7 @@ void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* c
 
 // type T can be CompMatr or DiagMatr
 template <class T>
-void assertMatrixIsSynced(T matr, std::string errMsg, const char* caller) {
+void assertMatrixIsSynced(T matr, string errMsg, const char* caller) {
 
     // checks fields (including memory allocations)
     validate_matrixFields(matr, caller);
@@ -1543,7 +1546,7 @@ void assertRecognisedNewPaulis(const char* paulis, int numPaulis, const char* ca
         int ascii = (int) ch;
 
         assertThat(
-            parser_RECOGNISED_PAULI_CHARS.find(ch) != std::string::npos,
+            parser_RECOGNISED_PAULI_CHARS.find(ch) != string::npos,
             report::NEW_PAULI_STR_UNRECOGNISED_PAULI_CHAR,
             {{"${BAD_CHAR}", ascii}, {"${CHAR_IND}", i}}, caller);
     }
@@ -1629,7 +1632,7 @@ void validate_newPauliStrSumAllocs(PauliStrSum sum, qindex numBytesStrings, qind
  * PAULI STRING SUM PARSING
  */
 
-void validate_parsedPauliStrSumLineIsInterpretable(bool isInterpretable, std::string line, qindex lineIndex, const char* caller) {
+void validate_parsedPauliStrSumLineIsInterpretable(bool isInterpretable, string line, qindex lineIndex, const char* caller) {
 
     // TODO: we cannot yet report 'line' because tokenSubs so far only accepts integers :(
 
@@ -1637,7 +1640,7 @@ void validate_parsedPauliStrSumLineIsInterpretable(bool isInterpretable, std::st
     assertThat(isInterpretable, report::PARSED_PAULI_STR_SUM_UNINTERPRETABLE_LINE, vars, caller);
 }
 
-void validate_parsedPauliStrSumLineHasConsistentNumPaulis(int numPaulis, int numLinePaulis, std::string line, qindex lineIndex, const char* caller) {
+void validate_parsedPauliStrSumLineHasConsistentNumPaulis(int numPaulis, int numLinePaulis, string line, qindex lineIndex, const char* caller) {
 
     // TODO: we cannot yet report 'line' because tokenSubs so far only accepts integers :(
 
@@ -1648,7 +1651,7 @@ void validate_parsedPauliStrSumLineHasConsistentNumPaulis(int numPaulis, int num
     assertThat(numPaulis == numLinePaulis, report::PARSED_PAULI_STR_SUM_INCONSISTENT_NUM_PAULIS_IN_LINE, vars, caller);
 }
 
-void validate_parsedPauliStrSumCoeffIsValid(bool isCoeffValid, std::string line, qindex lineIndex, const char* caller) {
+void validate_parsedPauliStrSumCoeffIsValid(bool isCoeffValid, string line, qindex lineIndex, const char* caller) {
 
     // TODO: we cannot yet report 'line' because tokenSubs so far only accepts integers :(
 
@@ -1695,7 +1698,7 @@ void validate_target(Qureg qureg, int target, const char* caller) {
  * FILE IO
  */
 
-void validate_canReadFile(std::string fn, const char* caller) {
+void validate_canReadFile(string fn, const char* caller) {
 
     // TODO: embed filename into error message when tokenSubs is updated to permit strings
     assertThat(parser_canReadFile(fn), report::CANNOT_READ_FILE, caller);

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -13,6 +13,10 @@
 #include "quest/include/matrices.h"
 
 #include <vector>
+#include <string>
+
+using std::vector;
+using std::string;
 
 
 
@@ -112,8 +116,8 @@ void validate_matrixFields(DiagMatr2 matr, const char* caller);
 void validate_matrixFields(DiagMatr  matr, const char* caller);
 void validate_matrixFields(FullStateDiagMatr matr, const char* caller);
 
-void validate_matrixNumNewElems(int numQubits, std::vector<std::vector<qcomp>> elems, const char* caller);
-void validate_matrixNumNewElems(int numQubits, std::vector<qcomp> elems, const char* caller);
+void validate_matrixNumNewElems(int numQubits, vector<vector<qcomp>> elems, const char* caller);
+void validate_matrixNumNewElems(int numQubits, vector<qcomp> elems, const char* caller);
 
 void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller);
 
@@ -164,11 +168,11 @@ void validate_newPauliStrSumAllocs(PauliStrSum sum, qindex numBytesStrings, qind
  * PAULI STRING SUM PARSING
  */
 
-void validate_parsedPauliStrSumLineIsInterpretable(bool isInterpretable, std::string line, qindex lineIndex, const char* caller);
+void validate_parsedPauliStrSumLineIsInterpretable(bool isInterpretable, string line, qindex lineIndex, const char* caller);
 
-void validate_parsedPauliStrSumCoeffIsValid(bool isCoeffValid, std::string line, qindex lineIndex, const char* caller);
+void validate_parsedPauliStrSumCoeffIsValid(bool isCoeffValid, string line, qindex lineIndex, const char* caller);
 
-void validate_parsedPauliStrSumLineHasConsistentNumPaulis(int numPaulis, int numLinePaulis, std::string line, qindex lineIndex, const char* caller);
+void validate_parsedPauliStrSumLineHasConsistentNumPaulis(int numPaulis, int numLinePaulis, string line, qindex lineIndex, const char* caller);
 
 void validate_parsedStringIsNotEmpty(bool stringIsNotEmpty, const char* caller);
 
@@ -194,7 +198,7 @@ void validate_target(Qureg qureg, int target, const char* caller);
  * FILE IO
  */
 
-void validate_canReadFile(std::string fn, const char* caller);
+void validate_canReadFile(string fn, const char* caller);
 
 
 

--- a/quest/src/gpu/gpu_cuquantum.hpp
+++ b/quest/src/gpu/gpu_cuquantum.hpp
@@ -32,6 +32,9 @@
 #include "quest/src/gpu/gpu_types.hpp"
 
 #include <custatevec.h>
+#include <vector>
+
+using std::vector;
 
 
 
@@ -169,7 +172,7 @@ void applyMatrix(Qureg qureg, int* ctrls, int numCtrls, int* targs, int numTargs
         work, workSize) );
 }
 
-void applyMatrix(Qureg qureg, std::vector<int> ctrls, std::vector<int> targs, std::vector<cu_qcomp> matr) {
+void applyMatrix(Qureg qureg, vector<int> ctrls, vector<int> targs, vector<cu_qcomp> matr) {
 
     applyMatrix(qureg, ctrls.data(), ctrls.size(), targs.data(), targs.size(), matr.data());
 }

--- a/quest/src/gpu/gpu_types.hpp
+++ b/quest/src/gpu/gpu_types.hpp
@@ -21,6 +21,8 @@
 #include <cuComplex.h>
 #include <vector>
 
+using std::vector;
+
 
 
 /*
@@ -86,9 +88,9 @@ __host__ inline void unpackMatrixToCuQcomps(CompMatr1 in, cu_qcomp &m00, cu_qcom
     m11 = toCuQcomp(in.elems[1][1]);
 }
 
-__host__ inline std::vector<cu_qcomp> unpackMatrixToCuQcomps(CompMatr1 in) {
+__host__ inline vector<cu_qcomp> unpackMatrixToCuQcomps(CompMatr1 in) {
 
-    std::vector<cu_qcomp> vec(4);
+    vector<cu_qcomp> vec(4);
     vec[0] = toCuQcomp(in.elems[0][0]);
     vec[1] = toCuQcomp(in.elems[0][1]);
     vec[2] = toCuQcomp(in.elems[1][0]);


### PR DESCRIPTION
to remove std:: boilerplate everywhere, and to avoid recklessly including the entire std:: namespace in files parser.cpp and printer.cpp