### PR TITLE
changed communication buffer indexing

### DIFF
--- a/quest/src/comm/comm_indices.hpp
+++ b/quest/src/comm/comm_indices.hpp
@@ -1,0 +1,51 @@
+/** @file
+ * Functions which unambiguously identify the buffer indices
+ * at which communicated amplitudes are sent and received
+ */
+
+#ifndef COMM_INDICES_HPP
+#define COMM_INDICES_HPP
+
+#include "quest/include/types.h"
+#include "quest/include/qureg.h"
+
+#include "quest/src/core/inliner.hpp"
+
+#include <utility>
+
+
+
+/*
+ * BUFFER INDICES
+ *
+ * which are inlined mainly to avoid symbol duplication,
+ * but also so that callers of getBufferRecvInd() which
+ * use the result as an index-offset in hot loops can
+ * exploit the compile-time known constant.
+ */
+
+
+INLINE qindex getSubBufferSendInd(Qureg qureg) {
+
+    // the maximum size of a swapped sub-buffer is half its capacity, so we
+    // will always pack sub-buffers starting from half capacity
+    return qureg.numAmpsPerNode / 2;
+}
+
+
+INLINE qindex getBufferRecvInd() {
+
+    // we always receive amplitudes to the start of the buffer, regardless
+    // of whether we are receiving a full or sub-buffer
+    return 0;
+}
+
+
+INLINE std::pair<qindex,qindex> getSubBufferSendRecvInds(Qureg qureg) {
+
+    return {getSubBufferSendInd(qureg), getBufferRecvInd()};
+}
+
+
+
+#endif // COMM_INDICES_HPP

--- a/quest/src/comm/comm_indices.hpp
+++ b/quest/src/comm/comm_indices.hpp
@@ -9,8 +9,6 @@
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
 
-#include "quest/src/core/inliner.hpp"
-
 #include <utility>
 
 
@@ -25,7 +23,7 @@
  */
 
 
-INLINE qindex getSubBufferSendInd(Qureg qureg) {
+static inline qindex getSubBufferSendInd(Qureg qureg) {
 
     // the maximum size of a swapped sub-buffer is half its capacity, so we
     // will always pack sub-buffers starting from half capacity
@@ -33,7 +31,7 @@ INLINE qindex getSubBufferSendInd(Qureg qureg) {
 }
 
 
-INLINE qindex getBufferRecvInd() {
+constexpr static inline qindex getBufferRecvInd() {
 
     // we always receive amplitudes to the start of the buffer, regardless
     // of whether we are receiving a full or sub-buffer
@@ -41,7 +39,7 @@ INLINE qindex getBufferRecvInd() {
 }
 
 
-INLINE std::pair<qindex,qindex> getSubBufferSendRecvInds(Qureg qureg) {
+static inline std::pair<qindex,qindex> getSubBufferSendRecvInds(Qureg qureg) {
 
     return {getSubBufferSendInd(qureg), getBufferRecvInd()};
 }

--- a/quest/src/comm/comm_routines.hpp
+++ b/quest/src/comm/comm_routines.hpp
@@ -12,6 +12,16 @@
 
 
 /*
+ * MESSAGE INDICES
+ */
+
+qindex getSubBufferSendInd(Qureg qureg);
+
+qindex getSubBufferRecvInd();
+
+
+
+/*
  * STATE EXCHANGE METHODS
  */
 
@@ -19,9 +29,9 @@ void comm_exchangeAmpsToBuffers(Qureg qureg, qindex sendInd, qindex recvInd, qin
 
 void comm_exchangeAmpsToBuffers(Qureg qureg, int pairRank);
 
-void comm_exchangeBuffers(Qureg qureg, qindex numAmpsAndRecvInd, int pairRank);
+void comm_exchangeSubBuffers(Qureg qureg, qindex numAmpsAndRecvInd, int pairRank);
 
-void comm_asynchSendBuffer(Qureg qureg, qindex numElems, int pairRank);
+void comm_asynchSendSubBuffer(Qureg qureg, qindex numElems, int pairRank);
 
 void comm_receiveArrayToBuffer(Qureg qureg, qindex numElems, int pairRank);
 

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -151,6 +151,12 @@ void assert_pairRankIsDistinct(Qureg qureg, int pairRank) {
         error_commWithSameRank();
 }
 
+void assert_bufferSendRecvDoesNotOverlap(qindex sendInd, qindex recvInd, qindex numAmps) {
+
+    if (sendInd + numAmps > recvInd)
+        raiseInternalError("A distributed function attempted to send and receive portions of the buffer which overlapped.");
+}
+
 
 
 /*

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -71,6 +71,8 @@ void assert_quregIsDistributed(Qureg qureg);
 
 void assert_pairRankIsDistinct(Qureg qureg, int pairRank);
 
+void assert_bufferSendRecvDoesNotOverlap(qindex sendInd, qindex recvInd, qindex numAmps);
+
 
 
 /*

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -154,7 +154,7 @@ void localiser_statevec_anyCtrlOneTargDenseMatr(Qureg qureg, vector<int> ctrls, 
     else {
         qindex numExch = qureg.numAmpsPerNode / powerOf2(ctrls.size());
         accel_statevec_packAmpsIntoBuffer(qureg, ctrls, ctrlStates);
-        comm_exchangeBuffers(qureg, numExch, pairRank);
+        comm_exchangeSubBuffers(qureg, numExch, pairRank);
     }
 
     // extract relevant gate elements

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -16,7 +16,7 @@
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/accelerator.hpp"
-#include "quest/src/comm/comm_routines.hpp"
+#include "quest/src/comm/comm_indices.hpp"
 
 #include <vector>
 
@@ -107,7 +107,8 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
     // each control qubit halves the needed iterations
     qindex numIts = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     
-    qindex offset = getSubBufferRecvInd();
+    // received amplitudes may begin at an arbitrary offset in the buffer
+    qindex offset = getBufferRecvInd();
 
     auto sortedCtrls   = util_getSorted(ctrls);
     auto ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
@@ -121,7 +122,10 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
         // i = nth local index where ctrl bits are in specified states
         qindex i = insertBitsWithMaskedValues(n, sortedCtrls.data(), numCtrlBits, ctrlStateMask);
 
-        qureg.cpuAmps[i] = fac0*qureg.cpuAmps[i] + fac1*qureg.cpuCommBuffer[offset+n];
+        // j = nth received amplitude from pair rank
+        qindex j = n + offset;
+
+        qureg.cpuAmps[i] = fac0*qureg.cpuAmps[i] + fac1*qureg.cpuCommBuffer[j];
     }
 }
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -16,6 +16,7 @@
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/accelerator.hpp"
+#include "quest/src/comm/comm_routines.hpp"
 
 #include <vector>
 
@@ -36,6 +37,9 @@ void cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> ctrls, vector<int>
     // each control qubit halves the needed iterations
     qindex numIts = qureg.numAmpsPerNode / powerOf2(ctrls.size());
 
+    // amplitudes are packed at an offset into the buffer
+    qindex offset = getSubBufferSendInd(qureg);
+
     auto sortedCtrls   = util_getSorted(ctrls);
     auto ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
     
@@ -48,7 +52,7 @@ void cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> ctrls, vector<int>
         // i = nth local index where ctrl bits are in specified states
         qindex i = insertBitsWithMaskedValues(n, sortedCtrls.data(), numCtrlBits, ctrlStateMask);
 
-        qureg.cpuCommBuffer[n] = qureg.cpuAmps[i];
+        qureg.cpuCommBuffer[offset + n] = qureg.cpuAmps[i];
     }
 }
 
@@ -102,6 +106,8 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
 
     // each control qubit halves the needed iterations
     qindex numIts = qureg.numAmpsPerNode / powerOf2(ctrls.size());
+    
+    qindex offset = getSubBufferRecvInd();
 
     auto sortedCtrls   = util_getSorted(ctrls);
     auto ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
@@ -115,11 +121,7 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
         // i = nth local index where ctrl bits are in specified states
         qindex i = insertBitsWithMaskedValues(n, sortedCtrls.data(), numCtrlBits, ctrlStateMask);
 
-        // l = index of nth received buffer amp
-        qindex l = n + numIts;
-        qcomp amp = qureg.cpuCommBuffer[l];
-
-        qureg.cpuAmps[i] = fac0*qureg.cpuAmps[i] + fac1*amp;
+        qureg.cpuAmps[i] = fac0*qureg.cpuAmps[i] + fac1*qureg.cpuCommBuffer[offset+n];
     }
 }
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -19,8 +19,7 @@ using std::vector;
  * COMMUNICATION BUFFER PACKING
  */
 
-template <int NumCtrls> 
-    void cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates);
+template <int NumCtrls> void cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates);
 
 
 /*

--- a/quest/src/gpu/gpu_kernels.hpp
+++ b/quest/src/gpu/gpu_kernels.hpp
@@ -68,6 +68,7 @@ __global__ void kernel_statevec_packAmpsIntoBuffer(
     // i = nth local index where ctrls are active
     qindex i = insertBitsWithMaskedValues(n, ctrls, numCtrlBits, mask);
 
+    // caller offsets buffer by sub-buffer send-index
     buffer[n] = amps[i];
 }
 
@@ -120,10 +121,8 @@ __global__ void kernel_statevec_anyCtrlOneTargDenseMatr_subB(
     // i = nth local index where ctrl bits are active
     qindex i = insertBitsWithMaskedValues(n, ctrls, numCtrlBits, mask);
 
-    // k = index of nth received buffer amp
-    qindex k = n + numThreads;
-
-    amps[i] = fac0*amps[i] + fac1*buffer[k];
+    // caller offsets buffer by receive-index
+    amps[i] = fac0*amps[i] + fac1*buffer[n];
 }
 
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -139,7 +139,7 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
 
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
-    qindex recvInd = getBufferRecvInd(qureg);
+    qindex recvInd = getBufferRecvInd();
 
     devicevec sortedCtrls = util_getSorted(ctrls);
     qindex ctrlStateMask  = util_getBitMask(ctrls, ctrlStates);

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -39,7 +39,7 @@
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/accelerator.hpp"
-#include "quest/src/comm/comm_routines.hpp"
+#include "quest/src/comm/comm_indices.hpp"
 
 #if COMPILE_CUDA
     #include "quest/src/gpu/gpu_types.hpp"
@@ -139,7 +139,7 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
 
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
-    qindex recvInd = getSubBufferRecvInd(qureg);
+    qindex recvInd = getBufferRecvInd(qureg);
 
     devicevec sortedCtrls = util_getSorted(ctrls);
     qindex ctrlStateMask  = util_getBitMask(ctrls, ctrlStates);


### PR DESCRIPTION
so that the sent sub-buffers always begin in the middle of the full-buffer. This enables the communicated amplitudes to be received to the first index (zero), to be consistent with the scenario when sub-buffers are not packed (the buffer is filled straight from the Qureg amplitudes). As a result, post-communication subroutines always know where the received amplitudes begin in the buffer; from zero.

This is crucial; many post-communication routines are agnostic to the number of control qubits, and as a result, they do not know whether all amplitudes were exchanged (the buffer was filled entirely) or a sub-buffer was packed and exchanged. Before this change, the receiving index was inconsistent between these two situations, requiring the post-comm subroutine to condition on the number of suffix controls, and was liable to a bug