### PR TITLE
tidied boilerplate

### DIFF
--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -112,24 +112,16 @@ void freeAllMemoryIfAnyAllocsFailed(T matr) {
     if (!didAnyAllocsFailOnAnyNode(matr))
         return;
 
-    // otherwise, free the single-integer isUnitary flag malloc (hehe)
-    if (matr.isUnitary != NULL)
-        free(matr.isUnitary);
-
-    // and all successfully allocated rows of 2D structures (if outer list allocated)
+    // otherwise free all successfully allocated rows of 2D structures (if outer list allocated)
     if constexpr (util_isDenseMatrixType<T>())
         if (matr.cpuElems != NULL)
             for (qindex r=0; r<matr.numRows; r++)
-                if (matr.cpuElems[r] != NULL)
-                    free(matr.cpuElems[r]);
+                free(matr.cpuElems[r]);
 
-    // free the outer CPU array itself
-    if (matr.cpuElems != NULL)
-        free(matr.cpuElems);
-    
-    // and the GPU memory (gauranteed NULL in non-GPU mode)
-    if (matr.gpuElems != NULL)
-        gpu_deallocAmps(matr.gpuElems);
+    // freeing NULL is legal
+    free(matr.cpuElems);
+    free(matr.isUnitary);
+    gpu_deallocAmps(matr.gpuElems);
 }
 
 

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -59,12 +59,9 @@ void freeAllMemoryIfAnyAllocsFailed(PauliStrSum sum) {
     if (!didAnyAllocsFailOnAnyNode(sum))
         return;
 
-    // otherwise free every successful allocation
-    if (sum.strings != NULL)
-        free(sum.strings);
-    
-    if (sum.coeffs != NULL)
-        free(sum.coeffs);
+    // otherwise free every successful allocation (freeing NULL is legal)
+    free(sum.strings);
+    free(sum.coeffs);
 }
 
 

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -70,18 +70,11 @@ void freeAllMemoryIfAnyAllocsFailed(Qureg qureg) {
     if (!didAnyAllocsFailOnAnyNode(qureg))
         return;
 
-    // otherwise, free everything that was successfully allocated
-    if (qureg.cpuAmps != NULL)
-        cpu_deallocAmps(qureg.cpuAmps);
-
-    if (qureg.cpuCommBuffer != NULL)
-        cpu_deallocAmps(qureg.cpuCommBuffer);
-
-    if (qureg.gpuAmps != NULL)
-        gpu_deallocAmps(qureg.gpuAmps);
-
-    if (qureg.gpuCommBuffer != NULL)
-        gpu_deallocAmps(qureg.gpuCommBuffer);
+    // otherwise, free everything that was successfully allocated (freeing NULL is legal)
+    cpu_deallocAmps(qureg.cpuAmps);
+    cpu_deallocAmps(qureg.cpuCommBuffer);
+    gpu_deallocAmps(qureg.gpuAmps);
+    gpu_deallocAmps(qureg.gpuCommBuffer);
 }
 
 

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -70,6 +70,18 @@ using std::vector;
 #define ARR(f) vector<decltype(&f<0,0>)>
 
 
+#define GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS(funcsuffix, qureg, numctrls) \
+    ((qureg).isGpuAccelerated)? \
+        GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_##funcsuffix, numctrls ) : \
+        GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_##funcsuffix, numctrls )
+
+
+#define GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS(funcsuffix, qureg, numctrls, numtargs) \
+    ((qureg).isGpuAccelerated)? \
+        GET_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( cpu_##funcsuffix, numctrls, numtargs ) : \
+        GET_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( gpu_##funcsuffix, numctrls, numtargs )
+
+
 
 /*
  * COMMUNICATION BUFFER PACKING
@@ -84,12 +96,9 @@ qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubits, vector
     if (qubitStates.empty())
         error_noCtrlsGivenToBufferPacker();
 
-    // packing treats qubits as if they were ctrl qubits
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_statevec_packAmpsIntoBuffer, qubits.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_statevec_packAmpsIntoBuffer, qubits.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, qubits, qubitStates);
+    // packing treats all qubits as if they were ctrl qubits
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_packAmpsIntoBuffer, qureg, qubits.size() );
+    func(qureg, qubits, qubitStates);
 
     // return the number of packed amps, for caller convenience
     return qureg.numAmpsPerNode / powerOf2(qubits.size());
@@ -104,78 +113,57 @@ qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubits, vector
 
 void accel_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
 
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_statevec_anyCtrlSwap_subA, ctrls.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_statevec_anyCtrlSwap_subA, ctrls.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates, targ1, targ2);
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlSwap_subA, qureg, ctrls.size() );
+    func(qureg, ctrls, ctrlStates, targ1, targ2);
 }
 
 void accel_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) {
 
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_statevec_anyCtrlSwap_subB, ctrls.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_statevec_anyCtrlSwap_subB, ctrls.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates);
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlSwap_subB, qureg, ctrls.size() );
+    func(qureg, ctrls, ctrlStates);
 }
 
 void accel_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) {
 
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_statevec_anyCtrlSwap_subC, ctrls.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_statevec_anyCtrlSwap_subC, ctrls.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates, targ, targState);
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlSwap_subC, qureg, ctrls.size() );
+    func(qureg, ctrls, ctrlStates, targ, targState);
 }
 
 
 
 /*
- * DENSE MATRIX
+ * ONE-TARGET MATRIX
  */
 
 
 void accel_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr) {
 
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_statevec_anyCtrlOneTargDenseMatr_subA, ctrls.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_statevec_anyCtrlOneTargDenseMatr_subA, ctrls.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates, targ, matr);
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlOneTargDenseMatr_subA, qureg, ctrls.size() );
+    func(qureg, ctrls, ctrlStates, targ, matr);
 }
 
 void accel_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1) {
 
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( cpu_statevec_anyCtrlOneTargDenseMatr_subB, ctrls.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS( gpu_statevec_anyCtrlOneTargDenseMatr_subB, ctrls.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates, fac0, fac1);
-}
-
-void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr) {
-
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( cpu_statevec_anyCtrlAnyTargDenseMatr_sub, ctrls.size(), targs.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( gpu_statevec_anyCtrlAnyTargDenseMatr_sub, ctrls.size(), targs.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates, targs, matr);
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlOneTargDenseMatr_subB, qureg, ctrls.size() );
+    func(qureg, ctrls, ctrlStates, fac0, fac1);
 }
 
 
 
 /*
- * DIAGONAL MATRIX
+ * ANY-TARGET MATRIX
  */
+
+
+void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr) {
+
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( statevec_anyCtrlAnyTargDenseMatr_sub, qureg, ctrls.size(), targs.size() );
+    func(qureg, ctrls, ctrlStates, targs, matr);
+}
 
 
 void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr) {
 
-    auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( cpu_statevec_anyCtrlAnyTargDiagMatr_sub, ctrls.size(), targs.size() );
-    auto gpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( gpu_statevec_anyCtrlAnyTargDiagMatr_sub, ctrls.size(), targs.size() );
-    auto useFunc = (qureg.isGpuAccelerated)? gpuFunc : cpuFunc;
-
-    useFunc(qureg, ctrls, ctrlStates, targs, matr);
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( statevec_anyCtrlAnyTargDiagMatr_sub, qureg, ctrls.size(), targs.size() );
+    func(qureg, ctrls, ctrlStates, targs, matr);
 }
-

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -96,18 +96,18 @@ void accel_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int>
 
 
 /*
- * DENSE MATRIX
+ * ONE-TARGET MATRIX
  */
 
 void accel_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr);
 void accel_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1);
 
-void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr);
-
 
 /*
- * DIAGONAL MATRIX
+ * ANY-TARGET MATRIX
  */
+
+void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr);
 
 void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr);
 

--- a/quest/src/cpu/cpu_config.cpp
+++ b/quest/src/cpu/cpu_config.cpp
@@ -80,5 +80,6 @@ qcomp* cpu_allocAmps(qindex numLocalAmps) {
 
 void cpu_deallocAmps(qcomp* amps) {
 
+    // amps can safely be NULL
     free(amps);
 }

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -58,6 +58,7 @@ void cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubitInds, vector<
     }
 }
 
+
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_packAmpsIntoBuffer, (Qureg, vector<int>, vector<int>) )
 
 
@@ -92,8 +93,6 @@ template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<i
     }
 }
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subA, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) )
-
 
 template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) {
 
@@ -124,8 +123,6 @@ template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<i
         qureg.cpuAmps[i] = qureg.cpuCommBuffer[j];
     }
 }
-
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subB, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) )
 
 
 template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) {
@@ -159,6 +156,9 @@ template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<i
     }
 }
 
+
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subA, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subB, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) )
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subC, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) )
 
 
@@ -199,8 +199,6 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, v
     }
 }
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, vector<int>, vector<int>, int, CompMatr1) )
-
 
 template <int NumCtrls>
 void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1) {
@@ -232,6 +230,8 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
     }
 }
 
+
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, vector<int>, vector<int>, int, CompMatr1) )
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subB, (Qureg, vector<int>, vector<int>, qcomp, qcomp) )
 
 
@@ -298,6 +298,7 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
     }
 }
 
+
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_anyCtrlAnyTargDenseMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, CompMatr) )
 
 
@@ -338,5 +339,6 @@ void cpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
         qureg.cpuAmps[i] *= matr.cpuElems[t];
     }
 }
+
 
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_anyCtrlAnyTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, DiagMatr) )

--- a/quest/src/gpu/gpu_kernels.hpp
+++ b/quest/src/gpu/gpu_kernels.hpp
@@ -196,7 +196,7 @@ __global__ void kernel_statevec_anyCtrlOneTargDenseMatr_subB(
 
 
 __forceinline__ __device__ qindex getStrideOfGlobalThreadArr() {
-    return gridDim.x * blockDim.x
+    return gridDim.x * blockDim.x;
 }
 
 
@@ -248,7 +248,7 @@ __global__ void kernel_statevec_anyCtrlAnyTargDenseMatr_sub(
         for (qindex l=0; l<numTargAmps; l++) {
 
             qindex j = getThreadsNthGlobalArrInd(l, n, stride);
-            qindex h = getFlattenedMatrInd(k, l, numTargAmps)
+            qindex h = getFlattenedMatrInd(k, l, numTargAmps);
             amps[i] += flatMatrElems[h] * cache[j];
         }
     }

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -123,8 +123,6 @@ void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> c
 #endif
 }
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subA, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) )
-
 
 template <int NumCtrls> 
 void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) {
@@ -149,8 +147,6 @@ void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> c
     error_gpuSimButGpuNotCompiled();
 #endif
 }
-
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subB, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) )
 
 
 template <int NumCtrls> 
@@ -178,6 +174,8 @@ void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> c
 }
 
 
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subA, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subB, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) )
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subC, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) )
 
 
@@ -218,8 +216,6 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, v
 #endif
 }
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, vector<int>, vector<int>, int, CompMatr1) )
-
 
 template <int NumCtrls>
 void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1) {
@@ -246,6 +242,8 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
 #endif
 }
 
+
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, vector<int>, vector<int>, int, CompMatr1) )
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subB, (Qureg, vector<int>, vector<int>, qcomp, qcomp) )
 
 
@@ -296,6 +294,7 @@ void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 #endif
 }
 
+
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_anyCtrlAnyTargDenseMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, CompMatr) )
 
 
@@ -334,5 +333,6 @@ void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
     error_gpuSimButGpuNotCompiled();
 #endif
 }
+
 
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_anyCtrlAnyTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, DiagMatr) )


### PR DESCRIPTION
- moved the final subroutine of `localiser_statevec_anyCtrlSwap()` into its own function so it can be directly called by `localiser_statevec_anyCtrlAnyTargDenseMatr()`, avoiding repeated, superfluous processing
- removed unnecessary non-`NULL` checks before `free()` (thanks @rrmeister !)
- reduced function-dispatch code duplication in `accelerator.cpp` using mOaR mACroS
- reduced thread-indexing code duplication in `gpu_kernels.hpp` using mOAr MacROs
- clarified `kernel_statevec_anyCtrlAnyTargDenseMatr_sub()` using some pretty inline functions
- moved instantiation macros of templated functions to the bottom of their sections for visual clarity