### PR TITLE
added persistent GPU cache

### DIFF
--- a/quest/include/debug.h
+++ b/quest/include/debug.h
@@ -24,6 +24,9 @@ void setValidationOff();
 
 void setNumReportedItems(qindex num);
 
+qindex getGpuCacheSize();
+void clearGpuCache();
+
 
 
 // end de-mangler

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -5,10 +5,16 @@
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/printer.hpp"
-
+#include "quest/src/gpu/gpu_config.hpp"
 
 // enable invocation by both C and C++ binaries
 extern "C" {
+
+
+
+/*
+ * VALIDATION
+ */
 
 
 void setValidationOn() {
@@ -19,11 +25,43 @@ void setValidationOff() {
     validate_disable();
 }
 
+
+
+/*
+ * REPORTERS
+ */
+
+
 void setNumReportedItems(qindex num) {
     validate_numReportedItems(num, __func__);
 
     printer_setMaxNumPrintedItems(num);
 }
+
+
+
+/*
+ * GPU CACHE
+ */
+
+
+qindex getGpuCacheSize() {
+
+    if (getQuESTEnv().isGpuAccelerated)
+        return gpu_getCacheMemoryInBytes();
+
+    // safely returns 0 if not GPU accelerated
+    return 0;
+}
+
+
+void clearGpuCache() {
+
+    // safely do nothing if not GPU accelerated
+    if (getQuESTEnv().isGpuAccelerated)
+        gpu_clearCache();
+}
+
 
 
 } // end de-name mangler

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -216,7 +216,8 @@ void printGpuInfo() {
         {"gpuDirect",     (gpu_isGpuCompiled())? printer_toStr(gpu_isDirectGpuCommPossible()) : na},
         {"gpuMemPools",   (gpu_isGpuCompiled())? printer_toStr(gpu_doesGpuSupportMemPools()) : na},
         {"gpuMemory",     (gpu_isGpuCompiled())? printer_toStr(gpu_getTotalMemoryInBytes()) + by + pg : na},
-        {"gpuMemoryFree", (gpu_isGpuCompiled())? printer_toStr(gpu_getTotalMemoryInBytes()) + by + pg : na},
+        {"gpuMemoryFree", (gpu_isGpuCompiled())? printer_toStr(gpu_getCurrentAvailableMemoryInBytes()) + by + pg : na},
+        {"gpuCache",      (gpu_isGpuCompiled())? printer_toStr(gpu_getCacheMemoryInBytes()) + by + pg : na},
     });
 }
 

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -260,6 +260,11 @@ void error_gpuSimButGpuNotCompiled() {
     raiseInternalError("A function attempted to dispatch a simulation to the GPU but QuEST was not compiled with GPU acceleration enabled.");
 }
 
+void error_gpuCacheModifiedButGpuNotCompiled() {
+
+    raiseInternalError("A function attempted to allocate or clear the GPU cache memory but QuEST was not compiled with GPU acceleration enabled.");
+}
+
 void error_gpuCopyButQuregNotGpuAccelerated() {
 
     raiseInternalError("A function attempted to access GPU memory of a Qureg which is not GPU accelerated.");

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -127,6 +127,8 @@ void error_gpuCopyButGpuNotCompiled();
 
 void error_gpuSimButGpuNotCompiled();
 
+void error_gpuCacheModifiedButGpuNotCompiled();
+
 void error_gpuCopyButQuregNotGpuAccelerated();
 
 void error_gpuCopyButMatrixNotGpuAccelerated();

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -454,8 +454,10 @@ qcomp* gpu_getCacheOfSize(qindex numElemsPerThread, qindex numThreads) {
         return gpuCache;
 
     // otherwise, resize the cache
+    gpuCacheLen = numNewElems;
     CUDA_CHECK( cudaFree(gpuCache) );
-    CUDA_CHECK( cudaMalloc(&gpuCache, numNewElems * sizeof *gpuCache) );
+    CUDA_CHECK( cudaMalloc(&gpuCache, gpuCacheLen * sizeof *gpuCache) );
+
     return gpuCache;
 
 #else

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -89,4 +89,16 @@ bool gpu_haveGpuAmpsBeenSynced(qcomp* gpuArr);
 
 
 
+/*
+ * CACHE MANAGEMENT
+ */
+
+qcomp* gpu_getCacheOfSize(qindex numElemsPerThread, qindex numThreads);
+
+void gpu_clearCache();
+
+size_t gpu_getCacheMemoryInBytes();
+
+
+
 #endif // GPU_CONFIG_HPP

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -275,7 +275,7 @@ void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
     qcomp* cache = gpu_getCacheOfSize(powerOf2(targs.size()), numThreads);
 
     kernel_statevec_anyCtrlAnyTargDenseMatr_sub <NumCtrls, NumTargs> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
-        toCuQcomps(qureg.gpuAmps), getPtr(cache), numThreads,
+        toCuQcomps(qureg.gpuAmps), toCuQcomps(cache), numThreads,
         getPtr(deviceQubits), ctrls.size(), qubitStateMask, getPtr(deviceTargs), targs.size(),
         toCuQcomps(matr.gpuElems));
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -40,6 +40,7 @@
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/accelerator.hpp"
 #include "quest/src/comm/comm_indices.hpp"
+#include "quest/src/gpu/gpu_config.hpp"
 
 #if COMPILE_CUDA
     #include "quest/src/gpu/gpu_types.hpp"

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -271,23 +271,13 @@ void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
     devicevec deviceTargs  = targs;
     devicevec deviceQubits = util_getSorted(ctrls, targs);
     qindex qubitStateMask  = util_getBitMask(ctrls, ctrlStates, targs, vector<int>(targs.size(),0));
-
-    // TODO: allocating per-thread private memory here is ridiculously slow and pointless, and makes redundant
-    // the persistent GPU memory in the CompMatr. Revise this to use persistent env-attached memory, as per 
-    // discussions with Richard Meister.
-
-    cu_qcomp *cache;
-    qindex numTargAmps = powerOf2(targs.size());
-    qindex gridSize = numBlocks * NUM_THREADS_PER_BLOCK;
-    qindex cacheSize = numTargAmps * gridSize;
-    cudaMalloc(&cache, cacheSize * sizeof *cache);
+    
+    qcomp* cache = gpu_getCacheOfSize(powerOf2(targs.size()), numThreads);
 
     kernel_statevec_anyCtrlAnyTargDenseMatr_sub <NumCtrls, NumTargs> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
-        toCuQcomps(qureg.gpuAmps), cache, numThreads,
+        toCuQcomps(qureg.gpuAmps), getPtr(cache), numThreads,
         getPtr(deviceQubits), ctrls.size(), qubitStateMask, getPtr(deviceTargs), targs.size(),
         toCuQcomps(matr.gpuElems));
-
-    cudaFree(cache);
 
 #else
     error_gpuSimButGpuNotCompiled();


### PR DESCRIPTION
so that many-target CompMatr can be simulated without wastefully re-allocating thread-private global memory. This elevates commit https://github.com/QuEST-Kit/QuEST/commit/dd2b54993166390244fe3b45103edf41df8847a0 to be actually worthwhile.

In addition, we
- optimised CPU any-targ dense matrix by avoiding unnecessary vector re-initialisation during loop
- added user-facing clearGpuCache()
- added user-facing getGpuCacheSize()
- updated reportQuESTEnv() to report the current cache size

Co-Authored-By: Richard Meister <richardm.tug@gmail.com>