### PR TITLE
patched clang multithreading

### DIFF
--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -15,10 +15,8 @@
 #include <algorithm>
 #include <complex>
 #include <vector>
-#include <array>
 
 using std::vector;
-using std::array;
 
 
 
@@ -336,7 +334,7 @@ qreal util_getTwoQubitDephasingTerm(qreal prob) {
     return - 4 * prob / 3;
 }
 
-array<qreal,3> util_getOneQubitDepolarisingFactors(qreal prob) {
+util_Scalars util_getOneQubitDepolarisingFactors(qreal prob) {
 
     // effected where braQubit == ketQubit
     qreal facAA = 1 - (2 * prob / 3);
@@ -345,25 +343,20 @@ array<qreal,3> util_getOneQubitDepolarisingFactors(qreal prob) {
     // effected where braQubit != ketQubit
     qreal facAB  = 1 - (4 * prob / 3);
 
-    return {facAA, facBB, facAB};
+    return {.c1=facAA, .c2=facBB, .c3=facAB, .c4=0}; // c4 ignored
 }
 
-array<qreal,3> util_getTwoQubitDepolarisingFactors(qreal prob) {
+util_Scalars util_getTwoQubitDepolarisingFactors(qreal prob) {
 
-    qreal fac1 = 1 - (4 * prob / 5);
-    qreal fac2 = 4 * prob / 15;
-    qreal fac3 = - (16 * prob / 15);
-
-    return {fac1, fac2, fac3};
+    return {
+        .c1 = 1 - (4 * prob / 5), 
+        .c2 = 4 * prob / 15, 
+        .c3 = - (16 * prob / 15), 
+        .c4 = 0 // ignored
+    };
 }
 
-array<qreal,2> util_getFirstTwoFactorsOfTwoQubitDepolarising(qreal prob) {
-
-    auto facs = util_getTwoQubitDepolarisingFactors(prob);
-    return {facs[0], facs[1]};
-}
-
-array<qreal,4> util_getOneQubitPauliChannelFactors(qreal pI, qreal pX, qreal pY, qreal pZ) {
+util_Scalars util_getOneQubitPauliChannelFactors(qreal pI, qreal pX, qreal pY, qreal pZ) {
 
     // effected where braQubit == ketQubit
     qreal facAA = pI + pZ;
@@ -373,14 +366,14 @@ array<qreal,4> util_getOneQubitPauliChannelFactors(qreal pI, qreal pX, qreal pY,
     qreal facAB = pI - pZ;
     qreal facBA = pX - pY;
 
-    return {facAA, facBB, facAB, facBA};
+    return {.c1=facAA, .c2=facBB, .c3=facAB, .c4=facBA};
 }
 
-array<qcomp,2> util_getOneQubitDampingFactors(qreal prob) {
+util_Scalars util_getOneQubitDampingFactors(qreal prob) {
 
-    // sqrt() can return complex for unnnormalised prob
-    qcomp c1 = sqrt(1 - qcomp(prob,0));
-    qcomp c2 = 1 - prob;
+    // we assume 0 < prob < 1 (true even of the inverse channel), so c1 is always real
+    qreal c1 = sqrt(1 - prob);
+    qreal c2 = 1 - prob;
 
-    return {c1, c2};
+    return {.c1=c1, .c2=c2, .c3=0, .c4=0}; //c3 and c4 ignored
 }

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -12,11 +12,9 @@
 #include <type_traits>
 #include <string>
 #include <vector>
-#include <array>
 
 using std::is_same_v;
 using std::vector;
-using std::array;
 
 
 
@@ -228,16 +226,26 @@ util_IndexRange util_getLocalIndRangeOfElemsWithinThisNode(int numElemsPerNode, 
  * OPERATOR PARAMETERS
  */
 
+typedef struct {
+
+    qreal c1;
+    qreal c2;
+    qreal c3;
+    qreal c4;
+
+} util_Scalars;
+
 qreal util_getOneQubitDephasingFactor(qreal prob);
+
 qreal util_getTwoQubitDephasingTerm(qreal prob);
 
-array<qreal,3> util_getOneQubitDepolarisingFactors(qreal prob);
-array<qreal,3> util_getTwoQubitDepolarisingFactors(qreal prob);
-array<qreal,2> util_getFirstTwoFactorsOfTwoQubitDepolarising(qreal prob);
+util_Scalars util_getOneQubitDepolarisingFactors(qreal prob);
 
-array<qreal,4> util_getOneQubitPauliChannelFactors(qreal pI, qreal pX, qreal pY, qreal pZ);
+util_Scalars util_getTwoQubitDepolarisingFactors(qreal prob);
 
-array<qcomp,2> util_getOneQubitDampingFactors(qreal prob);
+util_Scalars util_getOneQubitDampingFactors(qreal prob);
+
+util_Scalars util_getOneQubitPauliChannelFactors(qreal pI, qreal pX, qreal pY, qreal pZ);
 
 
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -667,7 +667,11 @@ void cpu_densmatr_oneQubitDepolarising_subA(Qureg qureg, int ketQubit, qreal pro
     qcomp* amps = qureg.cpuAmps;
 
     int braQubit = util_getBraQubit(ketQubit, qureg);
-    auto [facAA, facBB, facAB] = util_getOneQubitDepolarisingFactors(prob);
+    auto factors = util_getOneQubitDepolarisingFactors(prob);
+
+    auto facAA = factors.c1;
+    auto facBB = factors.c2;
+    auto facAB = factors.c3;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -680,10 +684,11 @@ void cpu_densmatr_oneQubitDepolarising_subA(Qureg qureg, int ketQubit, qreal pro
 
         // modify 4 amps, mixing a pair, and scaling the other
         qcomp amp00 = amps[i00];
-        amps[i00] = (facAA * amp00) + (facBB * amps[i11]);
+        qcomp amp11 = amps[i11];
+        amps[i00] = (facAA * amp00) + (facBB * amp11);
         amps[i01] *= facAB;
         amps[i10] *= facAB;
-        amps[i11] = (facAA * amps[i11]) + (facBB * amp00);
+        amps[i11] = (facAA * amp11) + (facBB * amp00);
     }
 }
 
@@ -697,7 +702,11 @@ void cpu_densmatr_oneQubitDepolarising_subB(Qureg qureg, int ketQubit, qreal pro
     qindex offset = getBufferRecvInd();
 
     int braBit = util_getRankBitOfBraQubit(ketQubit, qureg);
-    auto [facAA, facBB, facAB] = util_getOneQubitDepolarisingFactors(prob);
+    auto factors = util_getOneQubitDepolarisingFactors(prob);
+
+    auto facAA = factors.c1;
+    auto facBB = factors.c2;
+    auto facAB = factors.c3;
 
     // TODO:
     // each iteration below modifies 2 independent amps without mixing,
@@ -739,7 +748,7 @@ void cpu_densmatr_twoQubitDepolarising_subA(Qureg qureg, int ketQb1, int ketQb2,
     int braQb1 = util_getBraQubit(ketQb1, qureg);
     int braQb2 = util_getBraQubit(ketQb2, qureg);
 
-    qreal c3 = util_getTwoQubitDepolarisingFactors(prob)[2];
+    auto c3 = util_getTwoQubitDepolarisingFactors(prob).c3;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -764,7 +773,9 @@ void cpu_densmatr_twoQubitDepolarising_subB(Qureg qureg, int ketQb1, int ketQb2,
     int braQb1 = util_getBraQubit(ketQb1, qureg);
     int braQb2 = util_getBraQubit(ketQb2, qureg);
 
-    auto [c1, c2] = util_getFirstTwoFactorsOfTwoQubitDepolarising(prob);
+    auto factors = util_getTwoQubitDepolarisingFactors(prob);
+    auto c1 = factors.c1;
+    auto c2 = factors.c2;
 
     // for brevity
     qcomp* amps = qureg.cpuAmps;
@@ -797,7 +808,7 @@ void cpu_densmatr_twoQubitDepolarising_subC(Qureg qureg, int ketQb1, int ketQb2,
     int braQb1 = util_getBraQubit(ketQb1, qureg);
     int braBit2 = util_getRankBitOfBraQubit(ketQb2, qureg);
 
-    qreal c3 = util_getTwoQubitDepolarisingFactors(prob)[2];
+    auto c3 = util_getTwoQubitDepolarisingFactors(prob).c3;
 
     // TODO:
     // are we really inefficiently enumerating all amps and applying a non-unity
@@ -830,7 +841,9 @@ void cpu_densmatr_twoQubitDepolarising_subD(Qureg qureg, int ketQb1, int ketQb2,
     int braQb1 = util_getBraQubit(ketQb1, qureg);
     int braBit2 = util_getRankBitOfBraQubit(ketQb2, qureg);
 
-    auto [c1, c2] = util_getFirstTwoFactorsOfTwoQubitDepolarising(prob);
+    auto factors = util_getTwoQubitDepolarisingFactors(prob);
+    auto c1 = factors.c1;
+    auto c2 = factors.c2;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -861,7 +874,7 @@ void cpu_densmatr_twoQubitDepolarising_subE(Qureg qureg, int ketQb1, int ketQb2,
     int braBit1 = util_getRankBitOfBraQubit(ketQb1, qureg);
     int braBit2 = util_getRankBitOfBraQubit(ketQb2, qureg);
 
-    qreal c3 = util_getTwoQubitDepolarisingFactors(prob)[2];
+    qreal c3 = util_getTwoQubitDepolarisingFactors(prob).c3;
 
     // TODO:
     // are we really inefficiently enumerating all amps and applying a non-unity
@@ -894,7 +907,9 @@ void cpu_densmatr_twoQubitDepolarising_subF(Qureg qureg, int ketQb1, int ketQb2,
     int braBit1 = util_getRankBitOfBraQubit(ketQb1, qureg);
     int braBit2 = util_getRankBitOfBraQubit(ketQb2, qureg);
 
-    auto [c1, c2] = util_getFirstTwoFactorsOfTwoQubitDepolarising(prob);
+    auto factors = util_getTwoQubitDepolarisingFactors(prob);
+    auto c1 = factors.c1;
+    auto c2 = factors.c2;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -923,7 +938,9 @@ void cpu_densmatr_twoQubitDepolarising_subG(Qureg qureg, int ketQb1, int ketQb2,
     int braBit1 = util_getRankBitOfBraQubit(ketQb1, qureg);
     int braBit2 = util_getRankBitOfBraQubit(ketQb2, qureg);
 
-    auto [c1, c2] = util_getFirstTwoFactorsOfTwoQubitDepolarising(prob);
+    auto factors = util_getTwoQubitDepolarisingFactors(prob);
+    auto c1 = factors.c1;
+    auto c2 = factors.c2;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -952,7 +969,12 @@ void cpu_densmatr_oneQubitPauliChannel_subA(Qureg qureg, int ketQubit, qreal pI,
     qindex numIts = qureg.numAmpsPerNode / 4;
 
     int braQubit = util_getBraQubit(ketQubit, qureg);
-    auto [facAA, facBB, facAB, facBA] = util_getOneQubitPauliChannelFactors(pI, pX, pY, pZ);
+
+    auto factors = util_getOneQubitPauliChannelFactors(pI, pX, pY, pZ);
+    auto facAA = factors.c1;
+    auto facBB = factors.c2;
+    auto facAB = factors.c3;
+    auto facBA = factors.c4;
 
     // for brevity
     qcomp* amps = qureg.cpuAmps;
@@ -996,7 +1018,12 @@ void cpu_densmatr_oneQubitPauliChannel_subB(Qureg qureg, int ketQubit, qreal pI,
 
     int braInd = util_getPrefixBraInd(ketQubit, qureg);
     int braBit = getBit(qureg.rank, braInd);
-    auto [facAA, facBB, facAB, facBA] = util_getOneQubitPauliChannelFactors(pI, pX, pY, pZ);
+
+    auto factors = util_getOneQubitPauliChannelFactors(pI, pX, pY, pZ);
+    auto facAA = factors.c1;
+    auto facBB = factors.c2;
+    auto facAB = factors.c3;
+    auto facBA = factors.c4;
 
     // TODO:
     // each iteration below modifies 2 independent amps without mixing,
@@ -1037,7 +1064,10 @@ void cpu_densmatr_oneQubitDamping_subA(Qureg qureg, int ketQubit, qreal prob) {
     qindex numIts = qureg.numAmpsPerNode / 4;
 
     int braQubit = util_getBraQubit(ketQubit, qureg);
-    auto [c1, c2] = util_getOneQubitDampingFactors(prob);
+
+    auto factors = util_getOneQubitDampingFactors(prob);
+    auto c1 = factors.c1;
+    auto c2 = factors.c2;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -1064,7 +1094,7 @@ void cpu_densmatr_oneQubitDamping_subB(Qureg qureg, int qubit, qreal prob) {
     // half of all local amps are scaled
     qindex numIts = qureg.numAmpsPerNode / 2;
 
-    auto c2 = util_getOneQubitDampingFactors(prob)[1];
+    auto c2 = util_getOneQubitDampingFactors(prob).c2;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -1082,7 +1112,7 @@ void cpu_densmatr_oneQubitDamping_subC(Qureg qureg, int ketQubit, qreal prob) {
     qindex numIts = qureg.numAmpsPerNode / 2;
 
     int braBit = util_getRankBitOfBraQubit(ketQubit, qureg);
-    auto c1 = util_getOneQubitDampingFactors(prob)[0];
+    auto c1 = util_getOneQubitDampingFactors(prob).c1;
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {

--- a/quest/src/gpu/gpu_kernels.cuh
+++ b/quest/src/gpu/gpu_kernels.cuh
@@ -728,7 +728,7 @@ __global__ void kernel_densmatr_oneQubitPauliChannel_subB(
 
 __global__ void kernel_densmatr_oneQubitDamping_subA(
     cu_qcomp* amps, qindex numThreads,
-    int ketQubit, int braQubit, qreal prob, cu_qcomp c1, cu_qcomp c2
+    int ketQubit, int braQubit, qreal prob, qreal c1, qreal c2
 ) {
     GET_THREAD_IND(n, numThreads);
 
@@ -750,7 +750,7 @@ __global__ void kernel_densmatr_oneQubitDamping_subA(
 
 __global__ void kernel_densmatr_oneQubitDamping_subB(
     cu_qcomp* amps, qindex numThreads,
-    int qubit, cu_qcomp c2
+    int qubit, qreal c2
 ) {
     GET_THREAD_IND(n, numThreads);
 
@@ -767,7 +767,7 @@ __global__ void kernel_densmatr_oneQubitDamping_subB(
 
 __global__ void kernel_densmatr_oneQubitDamping_subC(
     cu_qcomp* amps, qindex numThreads,
-    int ketQubit, int braBit, cu_qcomp c1
+    int ketQubit, int braBit, qreal c1
 ) {
     GET_THREAD_IND(n, numThreads);
 


### PR DESCRIPTION
by avoiding use of variables in OpenMP parallel regions which are unpacked from C++17 structured bindings, as per bug https://github.com/llvm/llvm-project/issues/33025