### PR TITLE
refactored allocation and gpu-sync checks

### DIFF
--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -72,6 +72,13 @@ typedef struct {
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
     int* const isUnitary;
 
+    // whether the user has ever synchronised memory to the GPU, which is performed automatically
+    // when calling functions like setCompMatr(), but which requires manual invocation with
+    // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
+    // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
+    // made after an initial sync have been re-synched. This is a heap pointer, as above.
+    int* const wasGpuSynced;
+
     // 2D CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
     qcomp** cpuElems;
 
@@ -127,6 +134,13 @@ typedef struct {
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
     int* const isUnitary;
 
+    // whether the user has ever synchronised memory to the GPU, which is performed automatically
+    // when calling functions like setCompMatr(), but which requires manual invocation with
+    // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
+    // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
+    // made after an initial sync have been re-synched. This is a heap pointer, as above.
+    int* const wasGpuSynced;
+
     // CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
     qcomp* cpuElems;
 
@@ -160,6 +174,13 @@ typedef struct {
     // flag is stored in heap so even copies of structs are mutable, but pointer is immutable.
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
     int* const isUnitary;
+
+    // whether the user has ever synchronised memory to the GPU, which is performed automatically
+    // when calling functions like setCompMatr(), but which requires manual invocation with
+    // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
+    // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
+    // made after an initial sync have been re-synched. This is a heap pointer, as above.
+    int* const wasGpuSynced;
 
     // CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
     qcomp* cpuElems;

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -9,6 +9,7 @@
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/printer.hpp"
 #include "quest/src/core/parser.hpp"
+#include "quest/src/core/memory.hpp"
 #include "quest/src/cpu/cpu_config.hpp"
 #include "quest/src/comm/comm_config.hpp"
 #include "quest/src/comm/comm_routines.hpp"
@@ -46,7 +47,8 @@ int getPauliFromMaskAt(PAULI_MASK_TYPE mask, int ind) {
 
 bool didAnyAllocsFailOnAnyNode(PauliStrSum sum) {
 
-    bool anyFail = (sum.strings == nullptr) || (sum.coeffs == nullptr);
+    bool anyFail = ! mem_isAllocated(sum.strings) || ! mem_isAllocated(sum.coeffs);
+    
     if (comm_isInit())
         anyFail = comm_isTrueOnAllNodes(anyFail);
 

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -34,19 +34,19 @@ using std::string;
 bool didAnyLocalAllocsFail(Qureg qureg) {
 
     // CPU memory should always be allocated
-    if (qureg.cpuAmps == nullptr)
+    if (! mem_isAllocated(qureg.cpuAmps))
         return true;
 
     // when distributed, the CPU communication buffer must be allocated
-    if (qureg.isDistributed && qureg.cpuCommBuffer == nullptr)
+    if (qureg.isDistributed && ! mem_isAllocated(qureg.cpuCommBuffer))
         return true;
 
     // when GPU-accelerated, the GPU memory should be allocated
-    if (qureg.isGpuAccelerated && qureg.gpuAmps == nullptr)
+    if (qureg.isGpuAccelerated && ! mem_isAllocated(qureg.gpuAmps))
         return true;
 
     // when both distributed and GPU-accelerated, the GPU communication buffer must be allocated
-    if (qureg.isDistributed && qureg.isGpuAccelerated && qureg.gpuCommBuffer == nullptr)
+    if (qureg.isDistributed && qureg.isGpuAccelerated && ! mem_isAllocated(qureg.gpuCommBuffer))
         return true;
 
     // otherwise all pointers were non-NULL so no allocations failed
@@ -216,10 +216,10 @@ void printMemoryInfo(Qureg qureg) {
 
     print_table(
         "memory", {
-        {"cpuAmps",       (qureg.cpuAmps       == nullptr)? na : localMemStr},
-        {"gpuAmps",       (qureg.gpuAmps       == nullptr)? na : localMemStr},
-        {"cpuCommBuffer", (qureg.cpuCommBuffer == nullptr)? na : localMemStr},
-        {"gpuCommBuffer", (qureg.gpuCommBuffer == nullptr)? na : localMemStr},
+        {"cpuAmps",       mem_isAllocated(qureg.cpuAmps)?       localMemStr : na},
+        {"gpuAmps",       mem_isAllocated(qureg.gpuAmps)?       localMemStr : na},
+        {"cpuCommBuffer", mem_isAllocated(qureg.cpuCommBuffer)? localMemStr : na},
+        {"gpuCommBuffer", mem_isAllocated(qureg.gpuCommBuffer)? localMemStr : na},
         {"globalTotal",   globalMemStr},
     });
 }

--- a/quest/src/core/memory.hpp
+++ b/quest/src/core/memory.hpp
@@ -13,6 +13,7 @@
 
 #include "quest/include/types.h"
 #include "quest/include/qureg.h"
+#include "quest/include/paulis.h"
 
 
 
@@ -81,6 +82,21 @@ int mem_getMaxNumMatrixQubitsBeforeLocalMemSizeofOverflow(bool isDenseMatrix, in
 bool mem_canQuregFitInMemory(int numQubits, bool isDensMatr, int numNodes, qindex memBytesPerNode);
 
 bool mem_canMatrixFitInMemory(int numQubits, bool isDense, int numNodes, qindex memBytesPerNode);
+
+
+
+/*
+ * MEMORY ALLOCATION SUCCESS
+ */
+
+
+bool mem_isAllocated(int* heapflag);
+bool mem_isAllocated(PauliStr* array);
+bool mem_isAllocated(qcomp* array);
+bool mem_isAllocated(qcomp** matrix, qindex numRows);
+
+bool mem_isOuterAllocated(qcomp*   ptr);
+bool mem_isOuterAllocated(qcomp**  ptr);
 
 
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -98,6 +98,13 @@ constexpr bool util_isFixedSizeMatrixType() {
 }
 
 template<class T>
+constexpr bool util_isHeapMatrixType() {
+
+    // all non-fixed size matrices are stored in the heap (never the stack)
+    return ! util_isFixedSizeMatrixType<T>();
+}
+
+template<class T>
 constexpr bool util_isDistributableMatrixType() {
 
     return (is_same_v<T, FullStateDiagMatr>);
@@ -110,16 +117,6 @@ bool util_isDistributedMatrix(T matr) {
         return matr.isDistributed;
 
     return false;
-}
-
-template<class T>
-constexpr bool util_doesMatrixHaveIsUnitaryFlag() {
-
-    return (
-        is_same_v<T, CompMatr> ||
-        is_same_v<T, DiagMatr> ||
-        is_same_v<T, FullStateDiagMatr>
-    );
 }
 
 template<class T>

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -196,6 +196,20 @@ namespace report {
 
 
     /*
+     * MUTABLE OBJECT FLAGS
+     */
+
+    string NEW_HEAP_FLAG_ALLOC_FAILED =
+        "Attempted allocation of a heap flag (such as 'isUnitary', 'isCPTP', 'wasGpuSynced') miraculously failed, despite being a mere ${NUM_BYTES} bytes. This is unfathomably unlikely - go and have your fortune read at once!";
+
+    string INVALID_HEAP_FLAG_PTR =
+        "A flag (e.g. 'isUnitary', 'isCPTP', 'wasGpuSynced') bound to the given operator data structure (e.g. matrix, superoperator, Kraus map) was a NULL pointer, instead of an expected pointer to persistent heap memory. This may imply the structure has already been destroyed and its fields manually overwritten by the user.";
+
+    string INVALID_HEAP_FLAG_VALUE = 
+        "A flag (e.g. 'isUnitary', 'isCPTP', 'wasGpuSynced') bound to the given operator data structure (e.g. matrix, superoperator, Kraus map) had an invalid value of ${BAD_FLAG}. Allowed values are '0' and '1', and the 'isUnitary' and 'isCPTP' fields can additionally be set to the \"unknown\" value of '${UNKNOWN_FLAG} to defer their evaluation. However, these flags should never be modified directly by the user.";
+
+
+    /*
      * MATRIX CREATION
      */
 
@@ -245,13 +259,10 @@ namespace report {
 
 
     string NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED = 
-        "Attempted allocation of memory (${NUM_BYTES} bytes in RAM) failed.";
+        "Attempted allocation of memory for one or more rows of the matrix (a total of ${NUM_BYTES} bytes in RAM) failed.";
 
     string NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED = 
-        "Attempted allocation of GPU memory (${NUM_BYTES} bytes in VRAM) failed.";
-
-    string NEW_MATRIX_IS_UNITARY_FLAG_ALLOC_FAILED = 
-        "Attempted allocation of the 'isUnitary' heap field (a mere ${NUM_BYTES} bytes) failed! This is unprecedentedly unlikely - go and have your fortune read at once.";
+        "Attempted allocation of the matrix's GPU memory (${NUM_BYTES} bytes in VRAM) failed.";
 
 
     string NEW_DISTRIB_MATRIX_IN_NON_DISTRIB_ENV = 
@@ -306,12 +317,6 @@ namespace report {
     string INVALID_COMP_MATR_FIELDS =
         "Invalid CompMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createCompMatr().";
 
-    string INVALID_COMP_MATR_CPU_MEM_ALLOC =
-        "Invalid CompMatr. One or more rows of the 2D CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createCompMatr().";
-
-    string INVALID_COMP_MATR_GPU_MEM_ALLOC =
-        "Invalid CompMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createCompMatr().";
-
 
     string INVALID_DIAG_MATR_1_FIELDS =
         "Invalid DiagMatr1. Targeted ${NUM_QUBITS} qubits (instead of 1) and had a dimension of ${NUM_ROWS}x${NUM_ROWS} (instead of 2x2). It is likely this matrix was not initialised with getDiagMatr1().";
@@ -322,21 +327,9 @@ namespace report {
     string INVALID_DIAG_MATR_FIELDS =
         "Invalid DiagMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createDiagMatr().";
 
-    string INVALID_DIAG_MATR_CPU_MEM_ALLOC =
-        "Invalid DiagMatr. The CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
-
-    string INVALID_DIAG_MATR_GPU_MEM_ALLOC =
-        "Invalid DiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createDiagMatr().";
-
 
     string INVALID_FULL_STATE_DIAG_MATR_FIELDS = 
         "Invalid FullStateDiagMatr. Targeted ${NUM_QUBITS} qubits and had a dimension of ${NUM_ROWS}x${NUM_ROWS}. It is likely this matrix was not created with createFullStateDiagMatr().";
-
-    string INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC =
-        "Invalid FullStateDiagMatr. The CPU memory (RAM) was seemingly unallocated. It is likely this matrix was not initialised with createFullStateDiagMatr().";
-
-    string INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC =
-        "Invalid FullStateDiagMatr. The GPU memory (VRAM) was seemingly unallocated. It is likely this matrix was not initialised with createFullStateDiagMatr().";
 
 
     string COMP_MATR_NOT_SYNCED_TO_GPU = 
@@ -349,11 +342,16 @@ namespace report {
         "The FullStateDiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncFullStateDiagMatr() after manually modifying elements, or overwrite elements in batch with setFullStateDiagMatr().";
 
 
-    string INVALID_MATRIX_IS_UNITARY_FLAG = 
-        "The 'isUnitary' field of the given matrix had invalid value ${BAD_FLAG}, suggesting it was manually modified. Valid values are 0, 1 and ${UNKNOWN_FLAG} (to indicate that unitarity is not yet known, deferring evaluation) although this need never be modified by the user.";
 
     string MATRIX_NOT_UNITARY = 
         "The given matrix was not (approximately) unitary.";
+
+
+    string INVALID_MATRIX_CPU_ELEMS_PTR =
+        "The given matrix's outer CPU heap-memory pointer was NULL. This implies the matrix was prior destroyed and its pointers were manually cleared.";
+
+    string INVALID_MATRIX_GPU_ELEMS_PTR =
+        "The given matrix's GPU memory pointer was NULL. This implies the matrix was prior destroyed and its pointer was manually cleared.";
 
 
     string FULL_STATE_DIAG_MATR_MISMATCHES_QUREG_DIM =
@@ -431,7 +429,10 @@ namespace report {
     string INVALID_PAULI_STR_SUM_FIELDS =
         "The given PauliStrSum had invalid fields (.numTerms=${NUM_TERMS}), which is likely a result from not being correctly initialised by createPauliStrSum().";
 
-    
+    string INVALID_PAULI_STR_HEAP_PTR =
+        "One or more of the PauliStrumSum's heap pointers was unexpectedly NULL. This might imply the PauliStrSum was already destroyed and had its pointers manually overwritten by the user.";
+
+
     /*
      * OPERATOR PARAMETERS
      */
@@ -752,6 +753,7 @@ void assertQuregTotalNumAmpsDontExceedMaxIndex(int numQubits, int isDensMatr, co
     string msg = (isDensMatr)? 
         report::NEW_DENSMATR_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX : 
         report::NEW_STATEVEC_QUREG_NUM_AMPS_WOULD_EXCEED_QINDEX ;
+
     tokenSubs vars = {
         {"${NUM_QUBITS}", numQubits}, 
         {"${MAX_QUBITS}", maxNumQubits}};
@@ -907,16 +909,16 @@ void validate_newQuregAllocs(Qureg qureg, const char* caller) {
 
     // we get node consensus in case mallocs fail on some nodes but not others, as may occur
     // in heterogeneous settings, or where nodes may have other processes and loads hogging RAM. 
-    assertAllNodesAgreeThat(qureg.cpuAmps != nullptr, report::NEW_QUREG_CPU_AMPS_ALLOC_FAILED, caller);
+    assertAllNodesAgreeThat(mem_isAllocated(qureg.cpuAmps), report::NEW_QUREG_CPU_AMPS_ALLOC_FAILED, caller);
 
     if (qureg.isGpuAccelerated)
-        assertAllNodesAgreeThat(qureg.gpuAmps != nullptr, report::NEW_QUREG_GPU_AMPS_ALLOC_FAILED, caller);
+        assertAllNodesAgreeThat(mem_isAllocated(qureg.gpuAmps), report::NEW_QUREG_GPU_AMPS_ALLOC_FAILED, caller);
 
     if (qureg.isDistributed)
-        assertAllNodesAgreeThat(qureg.cpuCommBuffer != nullptr, report::NEW_QUREG_CPU_COMM_BUFFER_ALLOC_FAILED, caller);
+        assertAllNodesAgreeThat(mem_isAllocated(qureg.cpuCommBuffer), report::NEW_QUREG_CPU_COMM_BUFFER_ALLOC_FAILED, caller);
 
     if (qureg.isDistributed && qureg.isGpuAccelerated)
-        assertAllNodesAgreeThat(qureg.gpuCommBuffer != nullptr, report::NEW_QUREG_GPU_COMM_BUFFER_ALLOC_FAILED, caller);
+        assertAllNodesAgreeThat(mem_isAllocated(qureg.gpuCommBuffer), report::NEW_QUREG_GPU_COMM_BUFFER_ALLOC_FAILED, caller);
 }
 
 
@@ -1210,31 +1212,45 @@ void assertNewMatrixAllocsSucceeded(T matr, qindex numBytes, const char* caller)
     if (!isValidationEnabled)
         return;
 
-    // assert CPU array of rows was malloc'd successfully
     tokenSubs vars = {{"${NUM_BYTES}", numBytes}};
-    assertAllNodesAgreeThat(matr.cpuElems != nullptr, report::NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED, vars, caller);
 
-    // assert each CPU row was calloc'd successfully (if matrix is dense)
+    // assert CPU array (which may be nested arrays) all allocated successfully
+    bool isAlloc;
     if constexpr (util_isDenseMatrixType<T>())
-        for (qindex r=0; r<matr.numRows; r++)
-            assertAllNodesAgreeThat(matr.cpuElems[r] != nullptr, report::NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED, vars, caller);
-    
+        isAlloc = mem_isAllocated(matr.cpuElems, matr.numRows);
+    else
+        isAlloc = mem_isAllocated(matr.cpuElems);
+    assertAllNodesAgreeThat(isAlloc, report::NEW_MATRIX_CPU_ELEMS_ALLOC_FAILED, vars, caller);
+
     // optionally assert GPU memory was malloc'd successfully
     if (getQuESTEnv().isGpuAccelerated)
-        assertAllNodesAgreeThat(util_getGpuMemPtr(matr) != nullptr, report::NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED, vars, caller);
+        assertAllNodesAgreeThat(mem_isAllocated(util_getGpuMemPtr(matr)), report::NEW_MATRIX_GPU_ELEMS_ALLOC_FAILED, vars, caller);
 
-    // assert the teeny-tiny isUnitary flag was alloc'd
+    // assert the teeny-tiny heap flags are alloc'd
     vars["${NUM_BYTES}"] = sizeof(*(matr.isUnitary));
-    assertAllNodesAgreeThat(matr.isUnitary != nullptr, report::NEW_MATRIX_IS_UNITARY_FLAG_ALLOC_FAILED, vars, caller);
+    assertAllNodesAgreeThat(mem_isAllocated(matr.isUnitary),    report::NEW_HEAP_FLAG_ALLOC_FAILED, vars, caller);
+    assertAllNodesAgreeThat(mem_isAllocated(matr.wasGpuSynced), report::NEW_HEAP_FLAG_ALLOC_FAILED, vars, caller);
 }
 
-void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller) {
+void validate_newMatrixAllocs(CompMatr matr, const char* caller) {
+
+    bool isDenseMatrix = true;
+    int numNodes = 1;
+    qindex numBytes = mem_getLocalMatrixMemoryRequired(matr.numQubits, isDenseMatrix, numNodes);
     assertNewMatrixAllocsSucceeded(matr, numBytes, caller);
 }
-void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller) {
+void validate_newMatrixAllocs(DiagMatr matr, const char* caller) {
+
+    bool isDenseMatrix = false;
+    int numNodes = 1;
+    qindex numBytes = mem_getLocalMatrixMemoryRequired(matr.numQubits, isDenseMatrix, numNodes);
     assertNewMatrixAllocsSucceeded(matr, numBytes, caller);
 }
-void validate_newMatrixAllocs(FullStateDiagMatr matr, qindex numBytes, const char* caller) {
+void validate_newMatrixAllocs(FullStateDiagMatr matr, const char* caller) {
+
+    bool isDenseMatrix = false;
+    int numNodes = (matr.isDistributed)? getQuESTEnv().numNodes : 1;
+    qindex numBytes = mem_getLocalMatrixMemoryRequired(matr.numQubits, isDenseMatrix, numNodes);
     assertNewMatrixAllocsSucceeded(matr, numBytes, caller);
 }
 
@@ -1308,32 +1324,41 @@ void validate_fullStateDiagMatrNewElems(FullStateDiagMatr matr, qindex startInd,
         vars, caller);
 }
 
-void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller) {
-
-    // avoid potentially expensive node-consensus if validation anyway disabled
-    if (!isValidationEnabled)
-        return;
-
-    // we permit the matrix to contain the GPU-mem-unsync flag in CPU-only mode,
-    // to avoid astonishing a CPU-only user with a GPU-related error message
-    if (!getQuESTEnv().isGpuAccelerated)
-        return;
-
-    // to work with distributed FullStateDiagMatr, whereby we wish to check that
-    // every node's GPU elems have been overwritten (not just e.g. the root node's),
-    // we need to gather expensive consensus on the validity. 
-    assertAllNodesAgreeThat(!gpu_doCpuAmpsHaveUnsyncMemFlag(firstElem), report::MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG, caller);
-}
-
 
 
 /*
  * EXISTING MATRICES
  */
 
+// T can be CompMatr, DiagMatr, FullStateDiagMatr
+template <class T>
+void assertAdditionalHeapMatrixFieldsAreValid(T matr, const char* caller) {
+
+    // assert heap pointers are not NULL
+    assertThat(mem_isAllocated(matr.isUnitary),    report::INVALID_HEAP_FLAG_PTR, caller);
+    assertThat(mem_isAllocated(matr.wasGpuSynced), report::INVALID_HEAP_FLAG_PTR, caller);
+
+    tokenSubs vars = {{"${BAD_FLAG}", 0}, {"${UNKNOWN_FLAG}", validate_STRUCT_PROPERTY_UNKNOWN_FLAG}};
+
+    // assert isUnitary has valid value
+    int flag = *matr.isUnitary;
+    vars["${BAD_FLAG}"] = flag;
+    assertThat(flag == 0 || flag == 1 || flag == validate_STRUCT_PROPERTY_UNKNOWN_FLAG, report::INVALID_HEAP_FLAG_VALUE, vars, caller);
+
+    // checks whether users have, after destroying their struct, manually set the outer
+    // heap-memory pointers to NULL. We do not check inner pointers of 2D structures (which may
+    // be too expensive to enumerate), and we cannot determine whether the struct was not validly
+    // created because un-initialised structs will have random non-NULL pointers.
+    assertThat(mem_isOuterAllocated(matr.cpuElems), report::INVALID_MATRIX_CPU_ELEMS_PTR, caller);
+
+    validate_envIsInit(caller);
+    if (getQuESTEnv().isGpuAccelerated)
+        assertThat(mem_isOuterAllocated(util_getGpuMemPtr(matr)), report::INVALID_MATRIX_GPU_ELEMS_PTR, caller);
+}
+
 // T can be CompMatr1, CompMatr2, CompMatr, DiagMatr1, DiagMatr2, DiagMatr, FullStateDiagMatr
 template <class T>
-void assertMatrixFieldsAreValid(T matr, int expectedNumQb, string errMsg, const char* caller) {
+void assertMatrixFieldsAreValid(T matr, int expectedNumQb, string badFieldMsg, const char* caller) {
 
     qindex dim = util_getMatrixDim(matr);
     tokenSubs vars = {
@@ -1342,88 +1367,39 @@ void assertMatrixFieldsAreValid(T matr, int expectedNumQb, string errMsg, const 
 
     // assert correct fixed-size numQubits (caller gaurantees this passes for dynamic-size),
     // where the error message string already contains the expected numQb
-    assertThat(matr.numQubits == expectedNumQb, errMsg, vars, caller);
+    assertThat(matr.numQubits == expectedNumQb, badFieldMsg, vars, caller);
 
     // validate .numQubits and .numRows or .numElems
     qindex expectedDim = powerOf2(matr.numQubits);
-    assertThat(matr.numQubits >= 1, errMsg, vars, caller);
-    assertThat(dim == expectedDim,  errMsg, vars, caller);
+    assertThat(matr.numQubits >= 1, badFieldMsg, vars, caller);
+    assertThat(dim == expectedDim,  badFieldMsg, vars, caller);
 
-    // assert isUnitary flag is valid; it is user-modifiable (if they are naughty)!
-    if constexpr (util_doesMatrixHaveIsUnitaryFlag<T>()) {
-        int flag = (matr.isUnitary == nullptr)? 0 : *matr.isUnitary; // lazy segfault if failed allocation (caught below)
-        assertThat(
-            flag == 0 || flag == 1 || flag == validate_STRUCT_PROPERTY_UNKNOWN_FLAG, report::INVALID_MATRIX_IS_UNITARY_FLAG,
-            {{"${BAD_FLAG}", flag}, {"${UNKNOWN_FLAG}", validate_STRUCT_PROPERTY_UNKNOWN_FLAG}}, caller);
-    }
+    if constexpr (util_isHeapMatrixType<T>())
+        assertAdditionalHeapMatrixFieldsAreValid(matr, caller);
 
     // we do not bother checking slightly more involved fields like numAmpsPerNode - there's
-    // no risk that they're wrong (because they're constant) unless the struct was unitialised,
-    // which we have already validated against
+    // no risk that they're wrong (because they're const so users cannot modify them) unless 
+    // the struct was unitialised, which we have already validated against
 }
 
-// T can be CompMatr, DiagMatr, FullStateDiagMatr (i.e. matrix structs with heap pointers)
-template <class T>
-void assertMatrixAllocsAreValid(T matr, string cpuErrMsg, string gpuErrMsg, const char* caller) {
+void validate_matrixFields(CompMatr1 matr, const char* caller) { assertMatrixFieldsAreValid(matr, 1,              report::INVALID_COMP_MATR_1_FIELDS, caller); }
+void validate_matrixFields(CompMatr2 matr, const char* caller) { assertMatrixFieldsAreValid(matr, 2,              report::INVALID_COMP_MATR_2_FIELDS, caller); }
+void validate_matrixFields(CompMatr  matr, const char* caller) { assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_COMP_MATR_FIELDS,   caller); }
+void validate_matrixFields(DiagMatr1 matr, const char* caller) { assertMatrixFieldsAreValid(matr, 1,              report::INVALID_DIAG_MATR_1_FIELDS, caller); }
+void validate_matrixFields(DiagMatr2 matr, const char* caller) { assertMatrixFieldsAreValid(matr, 2,              report::INVALID_DIAG_MATR_2_FIELDS, caller); }
+void validate_matrixFields(DiagMatr  matr, const char* caller) { assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_DIAG_MATR_FIELDS,   caller); }
+void validate_matrixFields(FullStateDiagMatr matr, const char* caller) { assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_FULL_STATE_DIAG_MATR_FIELDS, caller); }
 
-    // TODO:
-    // I'm fairly sure this validation is completely pointless - the memory being unallocated
-    // being the struct was manually initialised cannot be determined reliably by a NULL check,
-    // because the pointer fields will be un-initialised i.e. random. Only malloc will sensibly
-    // set the fields to NULL, which immediately post-allocation validation would capture. Eh!
-
-    // assert CPU memory is allocated
-    assertThat(matr.cpuElems != nullptr, cpuErrMsg, caller);
-
-    // we do not check that each CPU memory row (of CompMatr; irrelevant to DiagMatr)
-    // is not-NULL because it's really unlikely that inner memory wasn't allocaed but
-    // outer was and this wasn't somehow caught by post-creation validation (i.e. the 
-    // user manually malloc'd memory after somehow getting around const fields). Further,
-    // since this function is called many times (i.e. each time the user passes a matrix
-    // to a simulation function like multiQubitUnitary()), it may be inefficient to 
-    // serially process each row pointer.
-
-    // optionally assert GPU memory is allocated
-    validate_envIsInit(caller);
-    if (getQuESTEnv().isGpuAccelerated)
-        assertThat(util_getGpuMemPtr(matr) != nullptr, gpuErrMsg, caller);
-}
-
-void validate_matrixFields(CompMatr1 matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, 1, report::INVALID_COMP_MATR_1_FIELDS, caller);
-}
-void validate_matrixFields(CompMatr2 matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, 2, report::INVALID_COMP_MATR_2_FIELDS, caller);
-}
-void validate_matrixFields(CompMatr matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_COMP_MATR_FIELDS, caller);
-    assertMatrixAllocsAreValid(matr, report::INVALID_COMP_MATR_CPU_MEM_ALLOC, report::INVALID_COMP_MATR_GPU_MEM_ALLOC, caller);
-}
-void validate_matrixFields(DiagMatr1 matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, 1, report::INVALID_DIAG_MATR_1_FIELDS, caller);
-}
-void validate_matrixFields(DiagMatr2 matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, 2, report::INVALID_DIAG_MATR_2_FIELDS, caller);
-}
-void validate_matrixFields(DiagMatr matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_DIAG_MATR_FIELDS, caller);
-    assertMatrixAllocsAreValid(matr, report::INVALID_DIAG_MATR_CPU_MEM_ALLOC, report::INVALID_DIAG_MATR_GPU_MEM_ALLOC, caller);
-}
-void validate_matrixFields(FullStateDiagMatr matr, const char* caller) {
-    assertMatrixFieldsAreValid(matr, matr.numQubits, report::INVALID_FULL_STATE_DIAG_MATR_FIELDS, caller);
-    assertMatrixAllocsAreValid(matr, report::INVALID_FULL_STATE_DIAG_MATR_CPU_MEM_ALLOC, report::INVALID_FULL_STATE_DIAG_MATR_GPU_MEM_ALLOC, caller);
-}
-
-// type T can be CompMatr or DiagMatr
+// type T can be CompMatr, DiagMatr or FullStateDiagMatr
 template <class T>
 void assertMatrixIsSynced(T matr, string errMsg, const char* caller) {
 
     // we don't need to perform any sync check in CPU-only mode
-    if (util_getGpuMemPtr(matr) == nullptr)
+    if (!mem_isAllocated(util_getGpuMemPtr(matr)))
         return;
 
     // check if GPU amps have EVER been overwritten; we sadly cannot check the LATEST changes were pushed though
-    assertThat(gpu_haveGpuAmpsBeenSynced(util_getGpuMemPtr(matr)), errMsg, caller);
+    assertThat(*(matr.wasGpuSynced) == 1, errMsg, caller);
 }
 
 // type T can be CompMatr, DiagMatr, FullStateDiagMatr
@@ -1653,11 +1629,11 @@ void validate_newPauliStrSumMatchingListLens(qindex numStrs, qindex numCoeffs, c
 void validate_newPauliStrSumAllocs(PauliStrSum sum, qindex numBytesStrings, qindex numBytesCoeffs, const char* caller) {
 
     assertThat(
-        sum.strings != nullptr, report::NEW_PAULI_STR_SUM_STRINGS_ALLOC_FAILED, 
+        mem_isAllocated(sum.strings), report::NEW_PAULI_STR_SUM_STRINGS_ALLOC_FAILED, 
         {{"${NUM_TERMS}", sum.numTerms}, {"${NUM_BYTES}", numBytesStrings}}, caller);
 
     assertThat(
-        sum.coeffs != nullptr, report::NEW_PAULI_STR_SUM_COEFFS_ALLOC_FAILED, 
+        mem_isAllocated(sum.coeffs), report::NEW_PAULI_STR_SUM_COEFFS_ALLOC_FAILED, 
         {{"${NUM_TERMS}", sum.numTerms}, {"${NUM_BYTES}", numBytesCoeffs}}, caller);
 }
 
@@ -1709,7 +1685,8 @@ void validate_pauliStrSumFields(PauliStrSum sum, const char* caller) {
 
     assertThat(sum.numTerms > 0, report::INVALID_PAULI_STR_SUM_FIELDS, {{"${NUM_TERMS}", sum.numTerms}}, caller);
 
-    // no point checking sum's pointers are not nullptr; see the explanation in validate_quregFields()
+    assertThat(mem_isAllocated(sum.coeffs),  report::INVALID_PAULI_STR_HEAP_PTR, caller);
+    assertThat(mem_isAllocated(sum.strings), report::INVALID_PAULI_STR_HEAP_PTR, caller);
 }
 
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -277,10 +277,6 @@ namespace report {
      * MATRIX INITIALISATION
      */
 
-    string MATRIX_NEW_ELEMS_CONTAINED_GPU_SYNC_FLAG = 
-        "The new matrix elements contained a reserved, forbidden value as the first element, used internally to detect that whether GPU memory has not synchronised. The value was intended to be extremely unlikely to be used by users - go buy a lottery ticket! If you insist on using this value in the first element, add a numerically insignificant perturbation.";
-
-
     string COMP_MATR_NEW_ELEMS_WRONG_NUM_ROWS =
         "Incompatible number of rows (${NUM_GIVEN_ROWS}) of elements given to overwrite a ${NUM_QUBITS}-qubit CompMatr, which expects ${NUM_EXPECTED_ROWS} rows.";
 
@@ -336,11 +332,10 @@ namespace report {
         "The CompMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please call syncCompMatr() after manually modifying elements, or overwrite all elements with setCompMatr() which automatically synchronises.";
 
     string DIAG_MATR_NOT_SYNCED_TO_GPU = 
-        "The DiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncDiagMatr() after manually modifying elements, or overwrite all elements with setDiagMatr().";
+        "The DiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please call syncDiagMatr() after manually modifying elements, or overwrite all elements with setDiagMatr() which automatically synchronises.";
 
     string FULL_STATE_DIAG_MATR_NOT_SYNCED_TO_GPU = 
-        "The FullStateDiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please first call syncFullStateDiagMatr() after manually modifying elements, or overwrite elements in batch with setFullStateDiagMatr().";
-
+        "The FullStateDiagMatr has yet not been synchronised with its persistent GPU memory, so potential changes to its elements are being ignored. Please call syncFullStateDiagMatr() after manually modifying elements, or overwrite elements in batch with setFullStateDiagMatr() which automatically synchronises.";
 
 
     string MATRIX_NOT_UNITARY = 
@@ -1344,6 +1339,11 @@ void assertAdditionalHeapMatrixFieldsAreValid(T matr, const char* caller) {
     int flag = *matr.isUnitary;
     vars["${BAD_FLAG}"] = flag;
     assertThat(flag == 0 || flag == 1 || flag == validate_STRUCT_PROPERTY_UNKNOWN_FLAG, report::INVALID_HEAP_FLAG_VALUE, vars, caller);
+
+    // assert wasGpuSynced has a valid value
+    flag = *matr.wasGpuSynced;
+    vars["${BAD_FLAG}"] = flag;
+    assertThat(flag == 0 || flag == 1, report::INVALID_HEAP_FLAG_VALUE, vars, caller);
 
     // checks whether users have, after destroying their struct, manually set the outer
     // heap-memory pointers to NULL. We do not check inner pointers of 2D structures (which may

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -98,9 +98,9 @@ void validate_newCompMatrParams(int numQubits, const char* caller);
 void validate_newDiagMatrParams(int numQubits, const char* caller);
 void validate_newFullStateDiagMatrParams(int numQubits, int useDistrib, const char* caller);
 
-void validate_newMatrixAllocs(CompMatr matr, qindex numBytes, const char* caller);
-void validate_newMatrixAllocs(DiagMatr matr, qindex numBytes, const char* caller);
-void validate_newMatrixAllocs(FullStateDiagMatr matr, qindex numBytes, const char* caller);
+void validate_newMatrixAllocs(CompMatr matr, const char* caller);
+void validate_newMatrixAllocs(DiagMatr matr, const char* caller);
+void validate_newMatrixAllocs(FullStateDiagMatr matr, const char* caller);
 
 
 
@@ -110,8 +110,6 @@ void validate_newMatrixAllocs(FullStateDiagMatr matr, qindex numBytes, const cha
 
 void validate_matrixNumNewElems(int numQubits, vector<vector<qcomp>> elems, const char* caller);
 void validate_matrixNumNewElems(int numQubits, vector<qcomp> elems, const char* caller);
-
-void validate_matrixNewElemsDontContainUnsyncFlag(qcomp firstElem, const char* caller);
 
 void validate_fullStateDiagMatrNewElems(FullStateDiagMatr matr, qindex startInd, qindex numElems, const char* caller);
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -258,15 +258,6 @@ void gpu_sync() {
  */
 
 
-// initial value of first element of freshly GPU-allocated memory which
-// indicates memory has not yet been synced/overwritten since creation.
-// This is used by validation to detect users forgetting to sync memory
-// of API structures, so should be an arbitrary value users are unlikely 
-// to set as the first element (which we will validate anyway). We don't
-// do this for Quregs which are always overwritten at creation.
-const qcomp UNSYNCED_GPU_MEM_FLAG = qcomp(3.141592653, 12345.67890);
-
-
 qcomp* gpu_allocArray(qindex length) {
 #if COMPILE_CUDA
 
@@ -409,55 +400,16 @@ void gpu_copyCpuToGpu(DiagMatr matr) {
 
 
 void gpu_copyCpuToGpu(FullStateDiagMatr matr) {
-    assertHeapObjectHasGpuMem(matr);
+    assertHeapObjectGpuMemIsAllocated(matr);
+
     copyArrayIfGpuCompiled(matr.cpuElems, util_getGpuMemPtr(matr), matr.numElemsPerNode, TO_DEVICE);
 }
 
 
-void gpu_copyCpuToGpu(KrausMap map) {
-    assertHeapObjectHasGpuMem(map);
-    copyMatrixIfGpuCompiled(map.cpuSuperopElems, util_getGpuMemPtr(map), map.numSuperopRows, TO_DEVICE);
-}
+void gpu_copyCpuToGpu(SuperOp op) {
+    assertHeapObjectGpuMemIsAllocated(op);
 
-
-
-/*
- * MEMORY MANAGEMENT
- */
-
-
-bool gpu_haveGpuAmpsBeenSynced(qcomp* gpuArr) {
-#if COMPILE_CUDA
-
-    if (gpuArr == nullptr || ! getQuESTEnv().isGpuAccelerated)
-        error_gpuCopyButMatrixNotGpuAccelerated();
-
-    // obtain first element from device memory
-    qcomp firstElem;
-    CUDA_CHECK( cudaMemcpy(&firstElem, gpuArr, sizeof(qcomp), cudaMemcpyDeviceToHost) );
-
-    // check whether it is still the unsync'd flag
-    return firstElem != UNSYNCED_GPU_MEM_FLAG;
-
-#else
-    error_gpuCopyButGpuNotCompiled();
-    return false;
-#endif
-}
-
-
-bool gpu_doCpuAmpsHaveUnsyncMemFlag(qcomp firstCpuAmp) {
-
-    // we permit the unsync flag to appear in CPU-only matrices, so we
-    // should never be asking this question unless env is GPU-accelerated. 
-    // Indeed permitting the flag when CPU-only could astonish users
-    // if they later enabled GPU-accel and encounter a validation error
-    // (not actually this internal error), but that's less astonishing then 
-    // getting a GPU-related error message when running in CPU-mode!
-    if (!getQuESTEnv().isGpuAccelerated)
-        error_gpuMemSyncQueriedButEnvNotGpuAccelerated();
-
-    return firstCpuAmp == UNSYNCED_GPU_MEM_FLAG;
+    copyMatrixIfGpuCompiled(op.cpuElems, util_getGpuMemPtr(op), op.numRows, TO_DEVICE);
 }
 
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -367,9 +367,9 @@ void copyMatrixIfGpuCompiled(qcomp** cpuMatr, qcomp* gpuArr, qindex matrDim, enu
 
 
 template <typename T>
-void assertHeapObjectHasGpuMem(T obj) {
+void assertHeapObjectGpuMemIsAllocated(T obj) {
 
-    if (util_getGpuMemPtr(obj) == nullptr || ! getQuESTEnv().isGpuAccelerated)
+    if (! mem_isAllocated(util_getGpuMemPtr(obj)) || ! getQuESTEnv().isGpuAccelerated)
         error_gpuCopyButMatrixNotGpuAccelerated();
 }
 
@@ -379,6 +379,7 @@ void gpu_copyCpuToGpu(Qureg qureg, qcomp* cpuArr, qcomp* gpuArr, qindex numElems
     // these functions unusually accept a Qureg just to run internal error validation,
     // to ensure that the given gpuArr can be read/write without segmentation fault
     assert_quregIsGpuAccelerated(qureg);
+
     copyArrayIfGpuCompiled(cpuArr, gpuArr, numElems, TO_DEVICE);
 }
 void gpu_copyCpuToGpu(Qureg qureg) {
@@ -394,13 +395,15 @@ void gpu_copyGpuToCpu(Qureg qureg) {
 
 
 void gpu_copyCpuToGpu(CompMatr matr) {
-    assertHeapObjectHasGpuMem(matr);
+    assertHeapObjectGpuMemIsAllocated(matr);
+
     copyMatrixIfGpuCompiled(matr.cpuElems, util_getGpuMemPtr(matr), matr.numRows, TO_DEVICE);
 }
 
 
 void gpu_copyCpuToGpu(DiagMatr matr) {
-    assertHeapObjectHasGpuMem(matr);
+    assertHeapObjectGpuMemIsAllocated(matr);
+
     copyArrayIfGpuCompiled(matr.cpuElems, util_getGpuMemPtr(matr), matr.numElems, TO_DEVICE);
 }
 


### PR DESCRIPTION
All allocation checks have been moved to `memory.cpp` so that nullptr comparisons aren't littering the code, and to make explicit when nested data-structures are being thoroughly checked (i.e. that all nested pointers are non-NULL, vs just the outer). Also tidied/combined validation related to memory allocation.

Structures with persistent GPU memory now have a `wasGpuSynced` field to indicate whether their memory has ever been copied to the GPU since creation. This replaces the previously hacky design which kept the first GPU element as a special default value until being overwritten. That design necessitated wastefully copying (a single amplitude) from device to host at every invocation of "has synched" validation, which forces kernel synchronisation and precludes efficient streaming. Further, it persuaded lots of validation boilerplate to check a user wasn't unknowingly passing in that special default value (a rare but technically possible scenario).