### PR TITLE
removed const struct fields

### DIFF
--- a/quest/include/channels.h
+++ b/quest/include/channels.h
@@ -30,9 +30,8 @@
 
 typedef struct {
 
-    // fields are const to prevent user modification
-    const int numQubits;
-    const qindex numRows;
+    int numQubits;
+    qindex numRows;
     
     qcomp** cpuElems;
     qcomp* gpuElemsFlat;
@@ -42,20 +41,19 @@ typedef struct {
     // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
     // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
     // made after an initial sync have been re-synched. This is a heap pointer to remain mutable.
-    int* const wasGpuSynced;
+    int* wasGpuSynced;
 
 } SuperOp;
 
 
 typedef struct {
 
-    // fields are const to prevent user modification
-    const int numQubits;
+    int numQubits;
 
     // representation of the map as a collection of Kraus operators, kept exclusively 
     // in CPU memory, and used only for CPTP validation and reporting the map
-    const qindex numMatrices;
-    const qindex numRows;
+    qindex numMatrices;
+    qindex numRows;
     qcomp*** matrices;
 
     // representation of the map as a single superoperator, used for simulation
@@ -63,7 +61,7 @@ typedef struct {
 
     // CPTP-ness is determined at validation; 0 or 1, or -1 to indicate unknown. The flag is 
     // stored in heap so even copies of structs are mutable, but pointer itself is immutable.
-    int* const isCPTP;
+    int* isCPTP;
 
 } KrausMap;
 

--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -11,33 +11,25 @@ extern "C" {
 #endif
 
 
+
 /*
  * QuESTEnv is a struct of which there will be a single, immutable
  * main instance, statically instantiated inside environment.cpp,
  * accessible anywhere via a getter, and which is consulted for
  * determining the deployment configuration. Users can obtain a
  * local copy of this struct with getQuESTEnv().
- * 
- * QuESTEnv is not declared const, because it is impossible to 
- * runtime initialise a const global variable like a singleton.
- * A shame, but this poses no risk; the internal singleton is not 
- * obtainable nor modifiable outside of environment.cpp since its 
- * getter returns a copy. 
  */
-
 
 typedef struct {
 
     // deployment mode
-    const int isMultithreaded;
-    const int isGpuAccelerated;
-    const int isDistributed;
+    int isMultithreaded;
+    int isGpuAccelerated;
+    int isDistributed;
 
     // distributed configuration
-    const int rank;
-    const int numNodes;
-
-    // TODO: RNG seeds
+    int rank;
+    int numNodes;
 
 } QuESTEnv;
 

--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -28,8 +28,7 @@
  *
  * which are visible to both C and C++, where qcomp resolves
  * to the native complex type. These are not de-mangled because
- * C++ structs are already C compatible. We define their fields
- * as const to prevent users mangling them.
+ * C++ structs are already C compatible.
  * 
  * The compile-time sized structs have field 'elems', while
  * dynamic-sized structs have separate 'cpuElems' and 
@@ -40,11 +39,9 @@
 
 typedef struct {
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numRows;
+    int numQubits;
+    qindex numRows;
 
-    // elems are not const so that users can modify them after initialisation
     qcomp elems[2][2];
 
 } CompMatr1;
@@ -52,11 +49,9 @@ typedef struct {
 
 typedef struct {
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numRows;
+    int numQubits;
+    qindex numRows;
 
-    // elems are not const so that users can modify them after initialisation
     qcomp elems[4][4];
 
 } CompMatr2;
@@ -64,24 +59,23 @@ typedef struct {
 
 typedef struct {
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numRows;
+    int numQubits;
+    qindex numRows;
 
     // properties of the matrix (0, 1, or -1 to indicate unknown) which are lazily evaluated,
     // deferred until a function actually validates them, at which point they are computed
     // and the flags fixed until the user modifies the matrix (through sync() or setAmps() etc).
     // flag is stored in heap so even copies of structs are mutable, but pointer is immutable.
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
-    int* const isUnitary;
-    int* const isHermitian;
+    int* isUnitary;
+    int* isHermitian;
 
     // whether the user has ever synchronised memory to the GPU, which is performed automatically
     // when calling functions like setCompMatr(), but which requires manual invocation with
     // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
     // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
     // made after an initial sync have been re-synched. This is a heap pointer, as above.
-    int* const wasGpuSynced;
+    int* wasGpuSynced;
 
     // 2D CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
     qcomp** cpuElems;
@@ -103,11 +97,9 @@ typedef struct {
 
 typedef struct {
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numElems;
+    int numQubits;
+    qindex numElems;
 
-    // elems are not const so that users can modify them after initialisation
     qcomp elems[2];
 
 } DiagMatr1;
@@ -115,11 +107,9 @@ typedef struct {
 
 typedef struct {
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numElems;
+    int numQubits;
+    qindex numElems;
 
-    // elems are not const so that users can modify them after initialisation
     qcomp elems[4];
 
 } DiagMatr2;
@@ -127,24 +117,23 @@ typedef struct {
 
 typedef struct {
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numElems;
+    int numQubits;
+    qindex numElems;
 
     // properties of the matrix (0, 1, or -1 to indicate unknown) which are lazily evaluated,
     // deferred until a function actually validates them, at which point they are computed
     // and the flags fixed until the user modifies the matrix (through sync() or setAmps() etc).
     // flag is stored in heap so even copies of structs are mutable, but pointer is immutable.
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
-    int* const isUnitary;
-    int* const isHermitian;
+    int* isUnitary;
+    int* isHermitian;
 
     // whether the user has ever synchronised memory to the GPU, which is performed automatically
     // when calling functions like setCompMatr(), but which requires manual invocation with
     // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
     // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
     // made after an initial sync have been re-synched. This is a heap pointer, as above.
-    int* const wasGpuSynced;
+    int* wasGpuSynced;
 
     // CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
     qcomp* cpuElems;
@@ -163,30 +152,26 @@ typedef struct {
 
 typedef struct {
 
-    // data deployment configuration
-    const int isDistributed;
+    int numQubits;
+    qindex numElems;
 
-    // const to prevent user modification
-    const int numQubits;
-    const qindex numElems;
-
-    // will equal numElems if distribution is disabled at runtime (e.g. via autodeployment)
-    const qindex numElemsPerNode;
+    int isDistributed;
+    qindex numElemsPerNode;
 
     // properties of the matrix (0, 1, or -1 to indicate unknown) which are lazily evaluated,
     // deferred until a function actually validates them, at which point they are computed
     // and the flags fixed until the user modifies the matrix (through sync() or setAmps() etc).
     // flag is stored in heap so even copies of structs are mutable, but pointer is immutable.
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
-    int* const isUnitary;
-    int* const isHermitian;
+    int* isUnitary;
+    int* isHermitian;
 
     // whether the user has ever synchronised memory to the GPU, which is performed automatically
     // when calling functions like setCompMatr(), but which requires manual invocation with
     // syncCompMatr() after manual modification of the cpuElem. Note this can only indicate whether
     // the matrix has EVER been synced; it cannot be used to detect whether manual modifications
     // made after an initial sync have been re-synched. This is a heap pointer, as above.
-    int* const wasGpuSynced;
+    int* wasGpuSynced;
 
     // CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
     qcomp* cpuElems;

--- a/quest/include/paulis.h
+++ b/quest/include/paulis.h
@@ -41,7 +41,7 @@ typedef struct {
 
 typedef struct {
 
-    const qindex numTerms;
+    qindex numTerms;
 
     // arbitrarily-sized collection of Pauli strings and their
     // coefficients are stored in heap memory.
@@ -52,7 +52,7 @@ typedef struct {
     // which is lazily evaluated when a function validates Hermiticity them. The flag is 
     // stored in heap so even copies of structs are mutable, but the pointer is immutable;
     // otherwise, the field of a user's struct could never be modified because of pass-by-copy.
-    int* const isHermitian;
+    int* isHermitian;
 
 } PauliStrSum;
 

--- a/quest/include/qureg.h
+++ b/quest/include/qureg.h
@@ -17,25 +17,25 @@ extern "C" {
 typedef struct {
 
     // deployment configuration
-    const int isMultithreaded;
-    const int isGpuAccelerated;
-    const int isDistributed;
+    int isMultithreaded;
+    int isGpuAccelerated;
+    int isDistributed;
 
     // distributed configuration
-    const int rank;
-    const int numNodes;
-    const int logNumNodes;
+    int rank;
+    int numNodes;
+    int logNumNodes;
 
     // dimension
-    const int isDensityMatrix;
-    const int numQubits;
-    const qindex numAmps;
-    const qindex logNumAmps;
+    int isDensityMatrix;
+    int numQubits;
+    qindex numAmps;
+    qindex logNumAmps;
 
     // distributed load
-    const qindex numAmpsPerNode;
-    const qindex logNumAmpsPerNode;
-    const qindex logNumColsPerNode;
+    qindex numAmpsPerNode;
+    qindex logNumAmpsPerNode;
+    qindex logNumColsPerNode;
 
     // amplitudes in CPU and GPU memory
     qcomp* cpuAmps;

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -255,11 +255,11 @@ FullStateDiagMatr validateAndCreateCustomFullStateDiagMatr(int numQubits, int us
 
     FullStateDiagMatr out = {
 
-        // data deployment configuration; disable distrib if deployed to 1 node
-        .isDistributed = useDistrib && (env.numNodes > 1),
-
         .numQubits = numQubits,
         .numElems = numElems,
+
+        // data deployment configuration; disable distrib if deployed to 1 node
+        .isDistributed = useDistrib && (env.numNodes > 1),
         .numElemsPerNode = numElemsPerNode,
 
         // allocate flags in the heap so that struct copies are mutable


### PR DESCRIPTION
since this prevents users from maintaining collections of the structs, like arrays and vectors. Working around that limitation (e.g. the deletion of the default copy constructor in C++, or writing to read-only memory in C) is an enormous chore for the user, and well outweighs the benefit of preventing them from modifying the struct fields. We are anyway validation the fields are self consistent, so we will likely catch users mischievously modifying the fields