### PR TITLE
added set(FullState)DiagMatrFromMulti*

### DIFF
--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -140,7 +140,7 @@ refactor your code to v4, and should absolutely not continue to use the old v3 A
 #define _ERROR_PHASE_FUNC_REMOVED(oldname) \
     _ERROR_GENERAL_MSG( \
         "The QuEST function '" oldname "' is deprecated. Please instead create a 'DiagMatr' or 'FullStateDiagMatr', initialise it " \
-        "via functions' setDiagMatrFromMultiVarFunc()' or 'setDiagMatrFromMultiDimArray()', and apply it via 'applyDiagMatr() or " \
+        "via functions like 'setDiagMatrFromMultiVarFunc()' or 'setDiagMatrFromMultiDimLists()', and apply it via 'applyDiagMatr() or " \
         "'applyFullStateDiagMatr()'. This procedure cannot be automatically performed here." ) \
     _FORCE_COMPILATION_TO_FAIL()
 

--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -320,13 +320,10 @@ static inline CompMatr2 _getCompMatr2FromArr(qcomp in[4][4]) {
     //   defining the _getCompMatr1FromArr() inner functions to avoid exposing them.
     // - our Generics explicitly check for pointer types (qcomp**), but we use default 
     //   to catch all array types (qcomp[][n], or qcomp(*)[] due to automatic Generic 
-    //   pointer decay in GCC). This avoids us using qcomp(*)[] in the macro which
-    //   would get expanded into our qcomp(re,im) macro and become invalid Generic
-    //   syntax, unless we use a qcomp alias macro (which is gross). It also makes 
-    //   the code more consistent with our variable-size CompMatr macros later in this 
-    //   file, which cannot use VLA in Generics at all. And finally, it avoids the user
-    //   having to see a Generic compilation error message when they pass an invalid
-    //   type. 
+    //   pointer decay in GCC). This makes the code more consistent with our variable-size 
+    //   CompMatr macros later in this  file, which cannot use VLA in Generics at all. It
+    //   also avoids the user having to see a Generic compilation error message when they 
+    //   pass an invalid type. 
     // - Generic expansion does not recurse, hence our macro safely has the same name
     //   (e.g. getCompMatr1) as the inner function, defining a true overload 
     // - we could not have _Generic's 'default' to catch unrecognised types at compile
@@ -692,6 +689,15 @@ extern "C" {
     void setFullStateDiagMatrFromPauliStrSum(FullStateDiagMatr out, PauliStrSum in);
 
     FullStateDiagMatr createFullStateDiagMatrFromPauliStrSumFile(char* fn);
+
+    
+    void setDiagMatrFromMultiVarFunc(DiagMatr out, qcomp (*func)(qindex*), int* numQubitsPerVar, int numVars, int areSigned);
+
+    void setDiagMatrFromMultiDimLists(DiagMatr out, void* lists, int* numQubitsPerDim, int numDims);
+
+    void setFullStateDiagMatrFromMultiVarFunc(FullStateDiagMatr out, qcomp (*func)(qindex*), int* numQubitsPerVar, int numVars, int areSigned);
+
+    void setFullStateDiagMatrFromMultiDimLists(FullStateDiagMatr out, void* lists, int* numQubitsPerDim, int numDims);
 
 #ifdef __cplusplus
 }

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -590,6 +590,122 @@ extern "C" FullStateDiagMatr createFullStateDiagMatrFromPauliStrSumFile(char* fn
 }
 
 
+vector<qindex> getMultiVarValuesFromIndex(qindex index, int* numQubitsPerVar, int numVars, bool areSigned) {
+
+    vector<qindex> varValues(numVars);
+    qindex remainingValue = index;
+
+    // find unsigned integer value of each var by partitioning index bits between vars
+    for (int v=0; v<numVars; v++) {
+        varValues[v] =  getBitsRightOfIndex(remainingValue, numQubitsPerVar[v]);
+        remainingValue = getBitsLeftOfIndex(remainingValue, numQubitsPerVar[v]-1);
+    }
+
+    // two's-complement signed integers are negated if the leftmost variable sign bit is 1 
+    if (areSigned)
+        for (int v=0; v<numVars; v++)
+            if (getBit(varValues[v], numQubitsPerVar[v]-1) == 1)
+                varValues[v] -= powerOf2(numQubitsPerVar[v] - 1);
+
+    return varValues;
+}
+
+
+extern "C" void setDiagMatrFromMultiVarFunc(DiagMatr out, qcomp (*callbackFunc)(qindex*), int* numQubitsPerVar, int numVars, int areSigned) {
+    validate_matrixFields(out, __func__);
+    validate_multiVarFuncQubits(out.numQubits, numQubitsPerVar, numVars, __func__);
+    validate_funcVarSignedFlag(areSigned, __func__);
+
+    // set each element of the diagonal in-turn; user's callback might not be thread-safe
+    for (qindex elemInd=0; elemInd<out.numElems; elemInd++) {
+        vector<qindex> varValues = getMultiVarValuesFromIndex(elemInd, numQubitsPerVar, numVars, areSigned);
+
+        // call user function, and update only the CPU elems
+        out.cpuElems[elemInd] = callbackFunc(varValues.data());
+    }
+
+    // overwrite all GPU elems
+    syncDiagMatr(out);
+}
+
+
+extern "C" void setFullStateDiagMatrFromMultiVarFunc(FullStateDiagMatr out, qcomp (*callbackFunc)(qindex*), int* numQubitsPerVar, int numVars, int areSigned) {
+    validate_matrixFields(out, __func__);
+    validate_multiVarFuncQubits(out.numQubits, numQubitsPerVar, numVars, __func__);
+    validate_funcVarSignedFlag(areSigned, __func__);
+
+    int rank = getQuESTEnv().rank;
+    int numLocalIndBits = logBase2(out.numElemsPerNode);
+
+    // every node updates their local elems embarrassingly parallel, but user's callback might not be thread-safe
+    for (qindex localInd=0; localInd<out.numElemsPerNode; localInd++) {
+
+        // each local index corresponds to a unique global index which informs variable values
+        qindex globalInd = concatenateBits(rank, localInd, numLocalIndBits);
+        vector<qindex> varValues = getMultiVarValuesFromIndex(globalInd, numQubitsPerVar, numVars, areSigned);
+
+        // call user function, and update only the CPU elems
+        out.cpuElems[localInd] = callbackFunc(varValues.data());
+    }
+
+    // overwrite all GPU elems
+    syncFullStateDiagMatr(out);
+}
+
+
+qcomp getElemFromNestedPtrs(void* in, qindex* inds, int numInds) {
+    qindex ind = inds[0];
+
+    if (numInds == 1)
+        return ((qcomp*) in)[ind];
+
+    qcomp* ptr = ((qcomp**) in)[ind];
+    return getElemFromNestedPtrs(ptr, &inds[1], numInds-1); // compiler may optimise tail-recursion
+}
+
+
+extern "C" void setDiagMatrFromMultiDimLists(DiagMatr out, void* lists, int* numQubitsPerDim, int numDims) {
+    validate_matrixFields(out, __func__);
+    validate_multiVarFuncQubits(out.numQubits, numQubitsPerDim, numDims, __func__);
+
+    // set each element of the diagonal in-turn, which is embarrassingly parallel, although we do not parallelise
+    for (qindex elemInd=0; elemInd<out.numElems; elemInd++) {
+
+        // nested list indices = unsigned integer values of variables
+        vector<qindex> listInds = getMultiVarValuesFromIndex(elemInd, numQubitsPerDim, numDims, false);
+
+        // update only the CPU elems
+        out.cpuElems[elemInd] = getElemFromNestedPtrs(lists, listInds.data(), numDims);
+    }
+
+    // overwrite all GPU elems
+    syncDiagMatr(out);
+}
+
+
+extern "C" void setFullStateDiagMatrFromMultiDimLists(FullStateDiagMatr out, void* lists, int* numQubitsPerDim, int numDims) {
+    validate_matrixFields(out, __func__);
+    validate_multiVarFuncQubits(out.numQubits, numQubitsPerDim, numDims, __func__);
+
+    int rank = getQuESTEnv().rank;
+    int numLocalIndBits = logBase2(out.numElemsPerNode);
+
+    // every node updates their local elems embarrassingly parallel, but user's callback might not be thread-safe
+    for (qindex localInd=0; localInd<out.numElemsPerNode; localInd++) {
+
+        // each local diag index corresponds to a unique global index which informs list indices
+        qindex globalInd = concatenateBits(rank, localInd, numLocalIndBits);
+        vector<qindex> listInds = getMultiVarValuesFromIndex(globalInd, numQubitsPerDim, numDims, false);
+
+        // update only the CPU elems using lists which are duplicated on every node
+        out.cpuElems[localInd] = getElemFromNestedPtrs(lists, listInds.data(), numDims);
+    }
+
+    // overwrite all GPU elems
+    syncFullStateDiagMatr(out);
+}
+
+
 
 /*
  * MATRIX REPORTERS

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -312,6 +312,19 @@ namespace report {
         "The declared number of passed elements (${NUM_ELEMS}) differs from the length of the given list (${VEC_LENGTH}).";
 
 
+    string MULTI_VAR_FUNC_INVALID_NUM_VARS = 
+        "Invalid number of variables or dimensions (${NUM_VARS}). Must be a positive integer.";
+
+    string MULTI_VAR_FUNC_INVALID_NUM_QUBITS_PER_VAR =
+        "The variable/dimension at index ${VAR_IND} was constituted by an invalid number of qubits (${VAR_QUBITS}). Each must correspond to 1 or more qubits.";
+
+    string MULTI_VAR_FUNC_MISMATCHING_NUM_QUBITS =
+        "The total number of qubits constituting all variables/dimensions (${NUM_VAR_QUBITS}) does not match the number of qubits in the matrix (${NUM_MATR_QUBITS}).";
+
+    string MULTI_VAR_FUNC_INVALID_ARE_SIGNED_FLAG =
+        "Invalid value for the 'areSigned' flag (${ARE_SIGNED}), which must instead be 1 or 0 to indicate whether or not to interpret the variable sub-register basis states as signed integers (encoded with two's complement).";
+
+
     /*
      * EXISTING MATRIX
      */
@@ -1567,6 +1580,26 @@ void validate_declaredNumElemsMatchesVectorLength(qindex numElems, qindex vecLen
         {"${VEC_LENGTH}", vecLength}};
 
     assertThat(numElems == vecLength, report::MATR_NUM_ELEMS_MISMATCHES_VEC_LENGTH_IN_INLINE_SETTER, vars, caller);
+}
+
+void validate_multiVarFuncQubits(int numMatrQubits, int* numQubitsPerVar, int numVars, const char* caller) {
+
+    assertThat(numVars > 0, report::MULTI_VAR_FUNC_INVALID_NUM_VARS, {{"${NUM_VARS}", numVars}}, caller);
+
+    for (int v=0; v<numVars; v++)
+        assertThat(numQubitsPerVar[v] > 0, report::MULTI_VAR_FUNC_INVALID_NUM_QUBITS_PER_VAR, {{"${VAR_IND}",v},{"${VAR_QUBITS}",numQubitsPerVar[v]}}, caller);
+
+    int numVarQubits = 0;
+    for (int v=0; v<numVars; v++)
+        numVarQubits += numQubitsPerVar[v];
+
+    assertThat(numMatrQubits == numVarQubits, report::MULTI_VAR_FUNC_MISMATCHING_NUM_QUBITS, 
+        {{"${NUM_MATR_QUBITS}", numMatrQubits}, {"${NUM_VAR_QUBITS}", numVarQubits}}, caller);
+}
+
+void validate_funcVarSignedFlag(int areSigned, const char* caller) {
+
+    assertThat(areSigned == 0 || areSigned == 1, report::MULTI_VAR_FUNC_INVALID_ARE_SIGNED_FLAG, {{"${ARE_SIGNED}", areSigned}}, caller);
 }
 
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -131,6 +131,9 @@ void validate_fullStateDiagMatrNewElems(FullStateDiagMatr matr, qindex startInd,
 void validate_matrixNumQubitsMatchesParam(int numMatrQubits, int numSetterQubits, const char* caller);
 void validate_declaredNumElemsMatchesVectorLength(qindex numElems, qindex vecLength, const char* caller);
 
+void validate_multiVarFuncQubits(int numMatrQubits, int* numQubitsPerVar, int numVars, const char* caller);
+void validate_funcVarSignedFlag(int areSigned, const char* caller);
+
 
 
 /*


### PR DESCRIPTION
Specifically
- setDiagMatrFromMultiVarFunc
- setDiagMatrFromMultiDimLists
- setFullStateDiagMatrFromMultiVarFunc
- setFullStateDiagMatrFromMultiDimLists

These form the replacements of v3's numerous phase functions, generalised to support completely general functions, arbitrary amplitudes, significantly simplify the interface, preclude overrides, and generally be more efficient.

They permit Simon et. al. to specify arbitrary potentials in quantum Fourier split-step