### PR TITLE
added user-configurable sig-figs

### DIFF
--- a/quest/include/debug.h
+++ b/quest/include/debug.h
@@ -44,6 +44,7 @@ qreal getValidationEpsilon();
  */
 
 void setMaxNumReportedItems(qindex numRows, qindex numCols);
+void setMaxNumReportedSigFigs(int numSigFigs);
 
 
 /*

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -11,6 +11,7 @@
 #include "quest/src/gpu/gpu_config.hpp"
 
 #include <vector>
+#include <limits>
 
 // enable invocation by both C and C++ binaries
 extern "C" {
@@ -23,22 +24,27 @@ extern "C" {
 
 
 void setSeeds(unsigned* seeds, int numSeeds) {
+    validate_envIsInit(__func__);
+    validate_randomSeeds(seeds, numSeeds, __func__);
 
     rand_setSeeds(std::vector<unsigned>(seeds, seeds+numSeeds));
 }
 
 void setSeedsToDefault() {
+    validate_envIsInit(__func__);
 
     rand_setSeedsToDefault();
 }
 
 
 int getNumSeeds() {
+    validate_envIsInit(__func__);
 
     return rand_getNumSeeds();
 }
 
 void getSeeds(unsigned* seeds) {
+    validate_envIsInit(__func__);
 
     auto vec = rand_getSeeds();
     auto num = rand_getNumSeeds();
@@ -55,37 +61,46 @@ void getSeeds(unsigned* seeds) {
 
 
 void setValidationOn() {
+    validate_envIsInit(__func__);
+    
     validateconfig_enable();
 }
 
 void setValidationOff() {
+    validate_envIsInit(__func__);
+
     validateconfig_disable();
 }
 
 
 void setValidationEpsilon(qreal eps) {
+    validate_envIsInit(__func__);
     validate_newEpsilonValue(eps, __func__);
 
     validateconfig_setEpsilon(eps);
 }
 
 void setValidationEpsilonToDefault() {
+    validate_envIsInit(__func__);
 
     validateconfig_setEpsilonToDefault();
 }
 
 qreal getValidationEpsilon() {
+    validate_envIsInit(__func__);
+
     return validateconfig_getEpsilon();
 }
 
 
 
 /*
- * REPORTERS
+ * REPORTER CONFIGURATION
  */
 
 
 void setMaxNumReportedItems(qindex numRows, qindex numCols) {
+    validate_envIsInit(__func__);
     validate_newMaxNumReportedScalars(numRows, numCols, __func__);
 
     // replace 0 values (indicating no truncation) with max-val,
@@ -98,6 +113,14 @@ void setMaxNumReportedItems(qindex numRows, qindex numCols) {
 }
 
 
+void setMaxNumReportedSigFigs(int numSigFigs) {
+    validate_envIsInit(__func__);
+    validate_newMaxNumReportedSigFigs(numSigFigs, __func__);
+
+    printer_setMaxNumPrintedSigFig(numSigFigs);
+} 
+
+
 
 /*
  * GPU CACHE
@@ -105,6 +128,7 @@ void setMaxNumReportedItems(qindex numRows, qindex numCols) {
 
 
 qindex getGpuCacheSize() {
+    validate_envIsInit(__func__);
 
     if (getQuESTEnv().isGpuAccelerated)
         return gpu_getCacheMemoryInBytes();
@@ -115,6 +139,7 @@ qindex getGpuCacheSize() {
 
 
 void clearGpuCache() {
+    validate_envIsInit(__func__);
 
     // safely do nothing if not GPU accelerated
     if (getQuESTEnv().isGpuAccelerated)

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -354,34 +354,48 @@ void reportQuregToFile(Qureg qureg, char* fn) {
 
 void syncQuregToGpu(Qureg qureg) {
 
-    // TODO
-    error_functionNotImplemented(__func__);
+    // permit this to be called even in non-GPU mode
+    if (qureg.isGpuAccelerated)
+        gpu_copyCpuToGpu(qureg);
 }
 
 void syncQuregFromGpu(Qureg qureg) {
 
-    // TODO
-    error_functionNotImplemented(__func__);
+    if (qureg.isGpuAccelerated)
+        gpu_copyGpuToCpu(qureg);
 }
 
 
-void syncSubQuregToGpu  (Qureg qureg, qindex startInd, qindex numAmps) {
+void syncSubQuregToGpu(Qureg qureg, qindex startInd, qindex numAmps) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsStateVector(qureg, __func__);
+    validate_basisStateIndices(qureg, startInd, numAmps, __func__);
+
 
     // TODO
     error_functionNotImplemented(__func__);
 }
 void syncSubQuregFromGpu(Qureg qureg, qindex startInd, qindex numAmps) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsStateVector(qureg, __func__);
+    validate_basisStateIndices(qureg, startInd, numAmps, __func__);
 
     // TODO
     error_functionNotImplemented(__func__);
 }
 
-void syncSubDensityQuregToGpu  (Qureg qureg, qindex startRow, qindex startCol, qindex numRows, qindex numCols) {
+void syncSubDensityQuregToGpu(Qureg qureg, qindex startRow, qindex startCol, qindex numRows, qindex numCols) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_basisStateRowCols(qureg, startRow, startCol, numRows, numCols, __func__);
 
     // TODO
     error_functionNotImplemented(__func__);
 }
 void syncSubDensityQuregFromGpu(Qureg qureg, qindex startRow, qindex startCol, qindex numRows, qindex numCols) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_basisStateRowCols(qureg, startRow, startCol, numRows, numCols, __func__);
 
     // TODO
     error_functionNotImplemented(__func__);

--- a/quest/src/core/printer.hpp
+++ b/quest/src/core/printer.hpp
@@ -31,6 +31,8 @@ using std::complex;
 
 void printer_setMaxNumPrintedScalars(qindex numRows, qindex numCols);
 
+void printer_setMaxNumPrintedSigFig(int numSigFigs);
+
 
 
 /*

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -79,9 +79,13 @@ void validate_envIsInit(const char* caller);
  * DEBUG UTILITIES
  */
 
+void validate_randomSeeds(unsigned* seeds, int numSeeds, const char* caller);
+
 void validate_newEpsilonValue(qreal eps, const char* caller);
 
 void validate_newMaxNumReportedScalars(qindex numRows, qindex numCols, const char* caller);
+
+void validate_newMaxNumReportedSigFigs(int numSigFigs, const char* caller);
 
 
 


### PR DESCRIPTION
through function setMaxNumReportedSigFigs, affecting all floating-point scalar reporting.

Also:
- changed reported memory unit from 'bytes' to most-convenient for the reported size
- added validation to debug utilities
- added validation to qureg sync utilities
- renamed validation epsilon global variable