### PR TITLE
refactored Paulis in backend

### DIFF
--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -808,7 +808,6 @@ void multiplyPauliStrSum(Qureg qureg, PauliStrSum str)
     _NOT_IMPLEMENTED_ERROR_DEF
 
 void applyTrotterizedTimeEvol(Qureg qureg, PauliStrSum hamiltonian, qreal time, int order, int reps) {
-    _TODO_VALIDATION()
 
     // validate that PauliStrSum is Hermitian
     

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -29,8 +29,8 @@ using std::vector;
  */
 
 extern bool paulis_hasOddNumY(PauliStr str);
-
 extern PauliStr paulis_getShiftedPauliStr(PauliStr str, int pauliShift);
+extern PauliStr paulis_getKetAndBraPauliStr(PauliStr str, Qureg qureg);
 
 // T can be CompMatr, CompMatr1, CompMatr2, DiagMatr, DiagMatr1, DiagMatr2
 template <class T>
@@ -781,36 +781,21 @@ void applyMultiStateControlledPauliStr(Qureg qureg, int* controls, int* states, 
     validate_controlsAndPauliStrTargets(qureg, controls, numControls, str, __func__);
     validate_controlStates(states, numControls, __func__); // permits states==nullptr
 
+    qcomp factor = 1;
     auto ctrlVec = util_getVector(controls, numControls);
     auto stateVec = util_getVector(states, numControls); // empty if states==nullptr
-    localiser_statevec_anyCtrlPauliTensor(qureg, ctrlVec, stateVec, str);
 
-    if (!qureg.isDensityMatrix)
-        return;
+    // when qureg is a density matrix, we must additionally apply conj(shift(str));
+    // to avoid re-enumeration of the state, we growing the PauliStr to double-qubits,
+    // and conjugate (factor=-1), potentially losing the compile-time #ctrls benefit
+    if (qureg.isDensityMatrix) {
+        factor = paulis_hasOddNumY(str)? -1 : 1;
+        ctrlVec = util_getConcatenated(ctrlVec, util_getBraQubits(ctrlVec, qureg));
+        stateVec = util_getConcatenated(stateVec, stateVec); 
+        str = paulis_getKetAndBraPauliStr(str, qureg);
+    }
 
-    // TODO:
-    // when qureg is a density matrix, we exact the same pauli string
-    // on the corresponding bra-qubits. In principle, we could have 
-    // instead expanded the previous Pauli string to call anyCtrlPauliTensor()
-    // exactly once - this has no communication benefit (the str upon
-    // the ket state invokes no communication) but avoids re-enumeration
-    // of the state and might shrink caching costs. However, we might then
-    // expand the control list beyond the max compiler-optimised number, and
-    // slow down each iteration. The memory savings likely beat this slowdown.
-    // Test this! It may also be worth templating anyCtrlPauliTensor() in
-    // ordet to avoid the final *=-1, though this will be a nuisance.
-
-    ctrlVec = util_getBraQubits(ctrlVec, qureg);
-    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, ctrlVec, stateVec, str); // excludes conj
-
-    // effect conj by qureg *= -1. This involves re-enumerating the amps after
-    // the above backend functions, so is not ideal, but simplififes the backend.
-    // note the use of setQuregToSuperposition() needlessly involves three flops
-    // per amplitude (instead of the needed one), but this slowdown will almost
-    // definitely be occluded by the memory movement costs
-    if (paulis_hasOddNumY(str))
-        localiser_statevec_setQuregToSuperposition(-1, qureg, 0, qureg, 0, qureg);
+    localiser_statevec_anyCtrlPauliTensor(qureg, ctrlVec, stateVec, str, factor);
 }
 
 
@@ -823,6 +808,7 @@ void multiplyPauliStrSum(Qureg qureg, PauliStrSum str)
     _NOT_IMPLEMENTED_ERROR_DEF
 
 void applyTrotterizedTimeEvol(Qureg qureg, PauliStrSum hamiltonian, qreal time, int order, int reps) {
+    _TODO_VALIDATION()
 
     // validate that PauliStrSum is Hermitian
     
@@ -1000,7 +986,8 @@ void multiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
 
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, angle);
+    qreal phase = util_getPhaseFromGateAngle(angle);
+    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
 }
 
 void applyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
@@ -1035,17 +1022,19 @@ void applyMultiStateControlledPauliGadget(Qureg qureg, int* controls, int* state
     // effect a global phase change of theta (I think). Should validate against this
     // sitaution just in case, or make the doc extremely explicit
 
+    qreal phase = util_getPhaseFromGateAngle(angle);
     auto ctrlVec = util_getVector(controls, numControls);
     auto stateVec = util_getVector(states, numControls); // empty if states==nullptr
-    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlVec, stateVec, str, angle);
+    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlVec, stateVec, str, phase);
 
     if (!qureg.isDensityMatrix)
         return;
 
-    angle *= paulis_hasOddNumY(str) ? -1 : +1;
+    // conj(e^iXZ) = e^(-iXZ), but conj(Y)=-Y, so odd-Y undoes phase negation
+    phase *= paulis_hasOddNumY(str) ? 1 : -1;
     ctrlVec = util_getBraQubits(ctrlVec, qureg);
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlVec, stateVec, str, angle);
+    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlVec, stateVec, str, phase);
 }
 
 
@@ -1058,7 +1047,8 @@ void multiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle)
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
-    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, util_getVector(targets,numTargets), angle);
+    qreal phase = util_getPhaseFromGateAngle(angle);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, util_getVector(targets,numTargets), phase);
 }
 
 void applyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
@@ -1090,15 +1080,16 @@ void applyMultiStateControlledPhaseGadget(Qureg qureg, int* controls, int* state
     validate_controlsAndTargets(qureg, controls, numControls, targets, numTargets, __func__);
     validate_controlStates(states, numControls, __func__);
 
+    qreal phase = util_getPhaseFromGateAngle(angle);
     auto ctrlVec = util_getVector(controls, numControls);
     auto targVec = util_getVector(targets,  numTargets);
     auto stateVec = util_getVector(states,  numControls); // empty if states==nullptr
-    localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlVec, stateVec, targVec, angle);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlVec, stateVec, targVec, phase);
 
     if (!qureg.isDensityMatrix)
         return;
 
-    angle *= -1;
+    phase *= -1;
     ctrlVec = util_getBraQubits(ctrlVec, qureg);
     targVec = util_getBraQubits(ctrlVec, qureg);
     localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlVec, stateVec, targVec, angle);

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -20,7 +20,6 @@
 #include "quest/src/core/accelerator.hpp"
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"
-#include "quest/src/core/utilities.hpp"
 #include "quest/src/cpu/cpu_config.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
 #include "quest/src/cpu/cpu_subroutines.hpp"
@@ -479,25 +478,25 @@ void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qc
  */
 
 
-void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qcomp fac0, qcomp fac1) {
+void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> states, vector<int> x, vector<int> y, vector<int> z, qcomp f0, qcomp f1) {
 
-    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( statevector_anyCtrlPauliTensorOrGadget_subA, qureg, ctrls.size(), data.sortedSuffixTargsXY.size() );
-    func(qureg, ctrls, ctrlStates, data, fac0, fac1);
+    // only X and Y constitute target qubits (Z merely induces a phase)
+    int numTargs = x.size() + y.size();
+
+    auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( statevector_anyCtrlPauliTensorOrGadget_subA, qureg, ctrls.size(), numTargs );
+    func(qureg, ctrls, states, x, y, z, f0, f1);
 }
-void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qindex bufferMaskXY, qcomp fac0, qcomp fac1) {
+void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> states, vector<int> x, vector<int> y, vector<int> z, qcomp f0, qcomp f1, qindex mask) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevector_anyCtrlPauliTensorOrGadget_subB, qureg, ctrls.size() );
-    func(qureg, ctrls, ctrlStates, data, bufferMaskXY, fac0, fac1);
+    func(qureg, ctrls, states, x, y, z, f0, f1, mask);
 }
 
 
-void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(
-    Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, 
-    qcomp fac0, qcomp fac1
-) {
-    // no template nor compile-time optimisation necessary for the number of targs
+void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> states, vector<int> targs, qcomp f0, qcomp f1) {
+
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevector_anyCtrlAnyTargZOrPhaseGadget_sub, qureg, ctrls.size() );
-    func(qureg, ctrls, ctrlStates, targs, fac0, fac1);
+    func(qureg, ctrls, states, targs, f0, f1);
 }
 
 
@@ -964,23 +963,23 @@ qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, util_pauliStrData data) {
+qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
 
     return (qureg.isGpuAccelerated)?
-        gpu_statevec_calcExpecPauliStr_subA(qureg, data):
-        cpu_statevec_calcExpecPauliStr_subA(qureg, data);
+        gpu_statevec_calcExpecPauliStr_subA(qureg, x, y, z):
+        cpu_statevec_calcExpecPauliStr_subA(qureg, x, y, z);
 }
-qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, util_pauliStrData data) {
+qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
 
     return (qureg.isGpuAccelerated)?
-        gpu_statevec_calcExpecPauliStr_subB(qureg, data):
-        cpu_statevec_calcExpecPauliStr_subB(qureg, data);
+        gpu_statevec_calcExpecPauliStr_subB(qureg, x, y, z):
+        cpu_statevec_calcExpecPauliStr_subB(qureg, x, y, z);
 }
-qcomp accel_densmatr_calcExpecPauliStr_sub(Qureg qureg, util_pauliStrData data) {
+qcomp accel_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
 
     return (qureg.isGpuAccelerated)?
-        gpu_densmatr_calcExpecPauliStr_sub(qureg, data):
-        cpu_densmatr_calcExpecPauliStr_sub(qureg, data);
+        gpu_densmatr_calcExpecPauliStr_sub(qureg, x, y, z):
+        cpu_densmatr_calcExpecPauliStr_sub(qureg, x, y, z);
 }
 
 

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -10,8 +10,6 @@
 #include "quest/include/qureg.h"
 #include "quest/include/matrices.h"
 
-#include "quest/src/core/utilities.hpp"
-
 #include <vector>
 
 using std::vector;
@@ -202,10 +200,10 @@ void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qc
  * PAULI TENSOR AND GADGET
  */
 
-void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qcomp fac0, qcomp fac1);
-void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qindex bufferMaskXY, qcomp fac0, qcomp fac1);
+void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
 
-void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp fac0, qcomp fac1);
+void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
+void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
 
 
 /*
@@ -289,9 +287,9 @@ qreal accel_densmatr_calcHilbertSchmidtDistance_sub(Qureg quregA, Qureg quregB);
 qreal accel_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> sufTargs);
 qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> allTargs);;
 
-qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, util_pauliStrData data);
-qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, util_pauliStrData data);
-qcomp accel_densmatr_calcExpecPauliStr_sub (Qureg qureg, util_pauliStrData data);
+qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp accel_densmatr_calcExpecPauliStr_sub (Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
 
 
 /*

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -232,6 +232,16 @@ void error_localiserFailedToAllocTempMemory() {
     raiseInternalError("A localiser function attempted and failed to allocate temporary memory.");
 }
 
+void error_localiserGivenPauliStrWithoutXorY() {
+
+    raiseInternalError("A localiser function was given a PauliStr which unexpectedly contained no X or Y Paulis.");
+}
+
+void error_localiserGivenNonUnityGlobalFactorToZTensor() {
+
+    raiseInternalError("A localiser function to apply a PauliStr (as a tensor, not a gadget) was given a PauliStr containing only Z and I, along with a non-unity global factor. This is an illegal combination.");
+}
+
 void assert_localiserSuccessfullyAllocatedTempMemory(qcomp* ptr, bool isGpu) {
 
     if (mem_isAllocated(ptr))

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -108,6 +108,10 @@ void error_localiserGivenDistribMatrixAndLocalQureg();
 
 void error_localiserFailedToAllocTempMemory();
 
+void error_localiserGivenPauliStrWithoutXorY();
+
+void error_localiserGivenNonUnityGlobalFactorToZTensor();
+
 void assert_localiserSuccessfullyAllocatedTempMemory(qcomp* ptr, bool isGpu);
 
 void assert_localiserGivenStateVec(Qureg qureg);

--- a/quest/src/core/fastmath.hpp
+++ b/quest/src/core/fastmath.hpp
@@ -13,7 +13,6 @@
 
 #include "quest/src/core/inliner.hpp"
 #include "quest/src/core/bitwise.hpp"
-#include "quest/src/core/utilities.hpp"
 
 
 
@@ -25,6 +24,25 @@
 INLINE int fast_getPlusOrMinusOne(int isMinus) {
 
     return 1 - 2 * isMinus;
+}
+
+
+INLINE int fast_getPlusOrMinusMaskedBitParity(qindex num, qindex mask) {
+
+    qindex bits = num & mask;
+    int pari = getBitMaskParity(bits);
+    int sign = fast_getPlusOrMinusOne(pari);
+    return sign;
+}
+
+
+INLINE qcomp fast_getPowerOfI(size_t exponent) {
+
+    // beware non-const static inlined variables!
+    static const qcomp values[] = {1, 1_i, -1, -1_i};
+
+    // seems silly, but is fast and precision agnostic
+    return values[exponent % 4];
 }
 
 
@@ -56,21 +74,6 @@ INLINE qindex fast_getLocalIndexOfDiagonalAmp(qindex localIndOfBasisState, qinde
 INLINE qindex fast_getLocalFlatIndex(qindex row, qindex localCol, qindex numAmpsPerCol) {
 
     return row +  localCol * numAmpsPerCol;
-}
-
-
-
-/*
- * PAULI ALGEBRA
- */
-
-
-INLINE qcomp fast_getPauliStrCoeff(qindex i, util_pauliStrData data) {
-
-    // (str)|i> = (coeff)|j>
-    int par = getBitMaskParity(i & data.allMaskYZ);
-    int fac = fast_getPlusOrMinusOne(par);
-    return fac * data.powI;
 }
 
 

--- a/quest/src/core/fastmath.hpp
+++ b/quest/src/core/fastmath.hpp
@@ -36,16 +36,6 @@ INLINE int fast_getPlusOrMinusMaskedBitParity(qindex num, qindex mask) {
 }
 
 
-INLINE qcomp fast_getPowerOfI(size_t exponent) {
-
-    // beware non-const static inlined variables!
-    static const qcomp values[] = {1, 1_i, -1, -1_i};
-
-    // seems silly, but is fast and precision agnostic
-    return values[exponent % 4];
-}
-
-
 
 /*
  * INDEX ALGEBRA

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -110,11 +110,11 @@ void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg qureg, vector<int> ctrls, ve
  * PAULI TENSORS AND GADGETS
  */
 
-void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str);
+void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qcomp globalFactor=1);
 
-void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qreal angle);
+void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qreal phase);
 
-void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qreal angle);
+void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qreal phase);
 
 
 /*

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <complex>
 #include <vector>
+#include <array>
 #include <new>
 
 using std::vector;
@@ -76,26 +77,11 @@ vector<int> getPrefixOrSuffixQubits(vector<int> qubits, Qureg qureg, bool getSuf
     return subQubits;
 }
 
-vector<int> util_getSuffixQubits(vector<int> qubits, Qureg qureg) {
-    return getPrefixOrSuffixQubits(qubits, qureg, true);
-}
-
-vector<int> util_getPrefixQubits(vector<int> qubits, Qureg qureg) {
-    return getPrefixOrSuffixQubits(qubits, qureg, false);
-}
-
-vector<int> util_getPrefixInds(vector<int> qubits, Qureg qureg) {
-    vector<int> inds;
-    inds.reserve(qubits.size());
-
-    for (int qubit : qubits) {
-        if (qubit < qureg.logNumAmpsPerNode)
-            error_utilsGetPrefixIndGivenSuffixQubit();
-
-        inds.push_back(qubit - qureg.logNumAmpsPerNode);
-    }
-
-    return inds;
+std::array<vector<int>,2> util_getPrefixAndSuffixQubits(vector<int> qubits, Qureg qureg) {
+    return {
+        getPrefixOrSuffixQubits(qubits, qureg, false), 
+        getPrefixOrSuffixQubits(qubits, qureg, true)
+    };
 }
 
 int util_getRankBitOfQubit(int ketQubit, Qureg qureg) {
@@ -112,11 +98,20 @@ int util_getRankBitOfBraQubit(int ketQubit, Qureg qureg) {
     return rankBit;
 }
 
-int util_getRankWithQubitFlipped(int ketQubit, Qureg qureg) {
+int util_getRankWithQubitFlipped(int prefixKetQubit, Qureg qureg) {
 
-    int rankInd = util_getPrefixInd(ketQubit, qureg);
+    int rankInd = util_getPrefixInd(prefixKetQubit, qureg);
     int rankFlip = flipBit(qureg.rank, rankInd);
     return rankFlip;
+}
+
+int util_getRankWithQubitsFlipped(vector<int> prefixQubits,  Qureg qureg) {
+
+    int rank = qureg.rank;
+    for (int qubit : prefixQubits)
+        rank = flipBit(rank, util_getPrefixInd(qubit, qureg));
+
+    return rank;
 }
 
 int util_getRankWithBraQubitFlipped(int ketQubit, Qureg qureg) {
@@ -266,49 +261,6 @@ int util_getRankContainingColumn(Qureg qureg, qindex globalCol) {
 
     qindex numColsPerNode = powerOf2(qureg.logNumColsPerNode);
     return globalCol / numColsPerNode; // floors
-}
-
-
-
-/* 
- * PAULI TENSOR DATA 
- */
-
-extern vector<int> paulis_getSortedIndsOfNonIdentityPaulis(PauliStr str);
-extern vector<int> paulis_getTargsWithEitherPaulis(vector<int> targs, PauliStr str, int pauliA, int pauliB);
-
-util_pauliStrData util_getPauliStrData(Qureg qureg, PauliStr str) {
-
-    // readable flags (you're welcome, beautiful reader)
-    const int X=1, Y=2, Z=3;
-
-    // X and Y on prefix qubits determines pair rank (because X and Y are anti-diagonal)
-    auto allTargs = paulis_getSortedIndsOfNonIdentityPaulis(str);
-    auto allTargsXY = paulis_getTargsWithEitherPaulis(allTargs, str, X, Y);
-    auto prefixTargsXY = util_getPrefixQubits(allTargsXY, qureg);
-    auto prefixIndsXY = util_getPrefixInds(prefixTargsXY, qureg);
-    int pairRank = flipBits(qureg.rank, prefixIndsXY.data(), prefixIndsXY.size());
-
-    // parity of Y and Z on all qubits determines phase factor on updated amps (because Y and Z contain -1)
-    auto allTargsYZ = paulis_getTargsWithEitherPaulis(allTargs, str, Y, Z);
-    auto allMaskYZ = getBitMask(allTargsYZ.data(), allTargsYZ.size());
-
-    // X and Y on suffix qubits determine local amp movement (because X and Y are anti-diagonal)
-    auto suffixTargsXY = util_getSuffixQubits(allTargsXY, qureg); // sorted
-    auto suffixMaskXY = getBitMask(suffixTargsXY.data(), suffixTargsXY.size());
-
-    // total number of Y determines a phase factor on all updated amps (because Y contains i)
-    int numY = paulis_getTargsWithEitherPaulis(allTargs, str, Y, Y).size();
-    vector<qcomp> powersOfI = {1, 1_i, -1, -1_i};
-    qcomp powI = powersOfI[numY % 4]; // i^numY (precision agnostic)
-
-    return {
-        .pairRank = pairRank,
-        .allMaskYZ = allMaskYZ,
-        .suffixMaskXY = suffixMaskXY,
-        .sortedSuffixTargsXY = suffixTargsXY, // caller copies vector
-        .powI = powI
-    };
 }
 
 
@@ -700,6 +652,17 @@ util_VectorIndexRange util_getLocalIndRangeOfVectorElemsWithinNode(int rank, qin
         .localDuplicStartInd = localOffsetInd,
         .numElems = numLocalElems
     };
+}
+
+
+
+/*
+ * GATE PARAMETERS
+ */
+
+qreal util_getPhaseFromGateAngle(qreal angle) {
+
+    return - angle / 2;
 }
 
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -266,6 +266,19 @@ int util_getRankContainingColumn(Qureg qureg, qindex globalCol) {
 
 
 /*
+ * COMPLEX ALGEBRA
+ */
+
+qcomp util_getPowerOfI(size_t exponent) {
+
+    // seems silly, but at least it's precision agnostic!
+    qcomp values[] = {1, 1_i, -1, -1_i};
+    return values[exponent % 4];
+}
+
+
+
+/*
  * MATRIX CONJUGATION
  */
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -79,6 +79,14 @@ int util_getRankContainingIndex(FullStateDiagMatr matr, qindex globalInd);
 
 
 /*
+ * COMPLEX ALGEBRA
+ */
+
+qcomp util_getPowerOfI(size_t exponent);
+
+
+
+/*
  * STRUCT TYPING
  *
  * defined here in the header since templated, and which use compile-time inspection.

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 #include <string>
 #include <vector>
+#include <array>
 
 using std::is_same_v;
 using std::vector;
@@ -33,15 +34,14 @@ int util_getBraQubit(int ketQubit, Qureg qureg);
 int util_getPrefixInd(int qubit, Qureg qureg);
 int util_getPrefixBraInd(int ketQubit, Qureg qureg);
 
-vector<int> util_getSuffixQubits(vector<int> qubits, Qureg qureg);
-vector<int> util_getPrefixQubits(vector<int> qubits, Qureg qureg);
-vector<int> util_getPrefixInds(vector<int> qubits, Qureg qureg);
+std::array<vector<int>,2> util_getPrefixAndSuffixQubits(vector<int> qubits, Qureg qureg);
 
 int util_getRankBitOfQubit(int ketQubit, Qureg qureg);
 int util_getRankBitOfBraQubit(int ketQubit, Qureg qureg);
 
 int util_getRankWithQubitFlipped(int ketQubit, Qureg qureg);
 int util_getRankWithBraQubitFlipped(int ketQubit, Qureg qureg);
+int util_getRankWithQubitsFlipped(vector<int> prefixQubits, Qureg qureg);
 
 vector<int> util_getBraQubits(vector<int> ketQubits, Qureg qureg);
 
@@ -75,30 +75,6 @@ qindex util_getGlobalFlatIndex(Qureg qureg, qindex globalRow, qindex globalCol);
 int util_getRankContainingIndex(Qureg qureg, qindex globalInd);
 int util_getRankContainingColumn(Qureg qureg, qindex globalCol);
 int util_getRankContainingIndex(FullStateDiagMatr matr, qindex globalInd);
-
-
-
-/*
- * PAULI TENSOR DATA
- */
-
-struct util_pauliStrData {
-
-    // the rank containing amplitudes needed by this node
-    int pairRank;
-
-    // the location (as a bit mask) of all Y and Z operators
-    qindex allMaskYZ;
-
-    // the location of all X and Y operators in the suffix partition
-    qindex suffixMaskXY;
-    vector<int> sortedSuffixTargsXY;
-
-    // i^(total number of Y)
-    qcomp powI;
-};
-
-util_pauliStrData util_getPauliStrData(Qureg qureg, PauliStr str);
 
 
 
@@ -311,6 +287,14 @@ struct util_VectorIndexRange {
 bool util_areAnyVectorElemsWithinNode(int rank, qindex numElemsPerNode, qindex startInd, qindex numInds);
 
 util_VectorIndexRange util_getLocalIndRangeOfVectorElemsWithinNode(int rank, qindex numElemsPerNode, qindex elemStartInd, qindex numInds);
+
+
+
+/*
+ * GATE PARAMETERS
+ */
+
+qreal util_getPhaseFromGateAngle(qreal angle);
 
 
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -691,7 +691,7 @@ void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(
     qindex numInnerIts = numTargAmps / 2; // divides evenly
 
     // we will scale pairAmp by i^numY, so that each amp need only choose the +-1 sign
-    pairAmpFac *= fast_getPowerOfI(y.size());
+    pairAmpFac *= util_getPowerOfI(y.size());
     
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numOuterIts; n++) {
@@ -743,7 +743,7 @@ void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(
     SET_VAR_AT_COMPILE_TIME(int, numCtrlBits, NumCtrls, ctrls.size());
 
     // we will scale pairAmp by i^numY, so that each amp need only choose the +-1 sign
-    pairAmpFac *= fast_getPowerOfI(y.size());
+    pairAmpFac *= util_getPowerOfI(y.size());
 
     #pragma omp parallel for if(qureg.isMultithreaded)
     for (qindex n=0; n<numIts; n++) {
@@ -1873,7 +1873,7 @@ qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int
     }
 
     // scale by i^numY (because sign above exlcuded i)
-    value *= fast_getPowerOfI(y.size());
+    value *= util_getPowerOfI(y.size());
     return value;
 }
 
@@ -1901,7 +1901,7 @@ qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int
     }
 
     // scale by i^numY (because sign above exlcuded i)
-    value *= fast_getPowerOfI(y.size());
+    value *= util_getPowerOfI(y.size());
     return value;
 }
 
@@ -1937,7 +1937,7 @@ qcomp cpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int>
     }
 
     // scale by i^numY (because sign above exlcuded i)
-    value *= fast_getPowerOfI(y.size());
+    value *= util_getPowerOfI(y.size());
     return value;
 }
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -73,9 +73,9 @@ template <bool HasPower, bool MultiplyOnly> void cpu_densmatr_allTargDiagMatr_su
  * PAULI TENSOR AND GADGET
  */
 
-template <int NumCtrls, int NumTargs> void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qcomp fac0, qcomp fac1);
+template <int NumCtrls, int NumTargs> void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
 
-template <int NumCtrls> void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qindex bufferMaskXY, qcomp fac0, qcomp fac1);
+template <int NumCtrls> void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
 
 template <int NumCtrls> void cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp fac0, qcomp fac1);
 
@@ -160,9 +160,9 @@ template <bool Conj> qcomp cpu_densmatr_calcFidelityWithPureState_sub(Qureg rho,
 qreal cpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
 qcomp cpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
 
-qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, util_pauliStrData data);
-qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, util_pauliStrData data);
-qcomp cpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, util_pauliStrData data);
+qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp cpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
 
 
 /*

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -1500,21 +1500,21 @@ qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, util_pauliStrData data){
+qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
 
     // TODO
     return -1;
 }
 
 
-qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, util_pauliStrData data) {
+qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
 
     // TODO
     return -1;
 }
 
 
-qcomp gpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, util_pauliStrData data) {
+qcomp gpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
     
     // TODO
     return -1;

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -647,7 +647,7 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ct
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size() + x.size() + y.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    qcomp powI = fast_getPowerOfI(y.size());
+    qcomp powI = util_getPowerOfI(y.size());
     auto targsXY = util_getConcatenated(x, y);
     auto maskXY = util_getBitMask(targsXY);
     auto maskYZ = util_getBitMask(util_getConcatenated(y, z));
@@ -680,7 +680,7 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ct
     qindex numBlocks = getNumBlocks(numThreads);
     qindex recvInd = getBufferRecvInd();
 
-    qcomp powI = fast_getPowerOfI(y.size());
+    qcomp powI = util_getPowerOfI(y.size());
     auto maskXY = util_getBitMask(util_getConcatenated(x, y));
     auto maskYZ = util_getBitMask(util_getConcatenated(y, z));
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -622,15 +622,17 @@ template void gpu_densmatr_allTargDiagMatr_sub<false, false>(Qureg, FullStateDia
 
 
 template <int NumCtrls, int NumTargs> 
-void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qcomp fac0, qcomp fac1) {
+void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
-    assert_numTargsMatchesTemplateParam(data.sortedSuffixTargsXY.size(), NumTargs);
+    assert_numTargsMatchesTemplateParam(x.size() + y.size(), NumTargs);
 
     // we do not make use of cuQuantum's custatevecApplyGeneralizedPermutationMatrix() to effect
     // a pauli tensor because we wish to avoid creating the (2^#paulis) large permutation matrix.
-    // we also do not make use of cuQuantum's custatevecApplyPauliRotation() because it cannot
+    // We also cannot make use of cuQuantum's custatevecApplyPauliRotation() because it cannot
     // handle Pauli operators upon the prefix substate as our singly-communicating method does.
+    // This is true even if we passed down the gadget phase to this function; cuStateVec would
+    // exact amp -> a amp + b other_amp for the wrong b, which we cannot thereafter remedy.
 
 #if COMPILE_CUDA || COMPILE_CUQUANTUM
 
@@ -642,20 +644,23 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ct
     //  which modifies 2 amps per invocation and compare performance; if as fast for
     //  few paulis, delete this implementation
 
-    qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size() + data.sortedSuffixTargsXY.size());
+    qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size() + x.size() + y.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints deviceTargs = data.sortedSuffixTargsXY;
-    devints deviceQubits = util_getSorted(ctrls, data.sortedSuffixTargsXY);
-    auto suffixStates = vector<int>(data.sortedSuffixTargsXY.size(), 0);
-    qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, data.sortedSuffixTargsXY, suffixStates);
+    qcomp powI = fast_getPowerOfI(y.size());
+    auto targsXY = util_getConcatenated(x, y);
+    auto maskXY = util_getBitMask(targsXY);
+    auto maskYZ = util_getBitMask(util_getConcatenated(y, z));
+
+    devints deviceTargs = targsXY;
+    devints deviceQubits = util_getSorted(ctrls, targsXY);
+    qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targsXY, vector<int>(targsXY.size(),0));
 
     kernel_statevector_anyCtrlPauliTensorOrGadget_subA <NumCtrls, NumTargs> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
-        toCuQcomps(qureg.gpuAmps), numThreads, qureg.rank, qureg.logNumAmpsPerNode,
+        toCuQcomps(qureg.gpuAmps), numThreads,
         getPtr(deviceQubits), ctrls.size(), qubitStateMask, 
         getPtr(deviceTargs), deviceTargs.size(),
-        data.suffixMaskXY, data.allMaskYZ, 
-        toCuQcomp(data.powI), toCuQcomp(fac0), toCuQcomp(fac1)
+        maskXY, maskYZ, toCuQcomp(powI), toCuQcomp(ampFac), toCuQcomp(pairAmpFac)
     );
 
 #else
@@ -665,7 +670,7 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ct
 
 
 template <int NumCtrls> 
-void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qindex bufferMaskXY, qcomp fac0, qcomp fac1) {
+void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -675,15 +680,18 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ct
     qindex numBlocks = getNumBlocks(numThreads);
     qindex recvInd = getBufferRecvInd();
 
+    qcomp powI = fast_getPowerOfI(y.size());
+    auto maskXY = util_getBitMask(util_getConcatenated(x, y));
+    auto maskYZ = util_getBitMask(util_getConcatenated(y, z));
+
     devints sortedCtrls = util_getSorted(ctrls);
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
 
     kernel_statevector_anyCtrlPauliTensorOrGadget_subB <NumCtrls> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
-        toCuQcomps(qureg.gpuAmps), &toCuQcomps(qureg.gpuCommBuffer)[recvInd], 
-        numThreads, data.pairRank, qureg.logNumAmpsPerNode,
+        toCuQcomps(qureg.gpuAmps), &toCuQcomps(qureg.gpuCommBuffer)[recvInd], numThreads, 
         getPtr(sortedCtrls), ctrls.size(), ctrlStateMask,
-        data.suffixMaskXY, bufferMaskXY, data.allMaskYZ, 
-        toCuQcomp(data.powI), toCuQcomp(fac0), toCuQcomp(fac1)
+        maskXY, maskYZ, bufferMaskXY,
+        toCuQcomp(powI), toCuQcomp(ampFac), toCuQcomp(pairAmpFac)
     );
 
 #else
@@ -707,7 +715,7 @@ void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> c
     qindex targMask = util_getBitMask(targs);
 
     kernel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub <NumCtrls> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
-        toCuQcomps(qureg.gpuAmps), numThreads, qureg.rank, qureg.logNumAmpsPerNode,
+        toCuQcomps(qureg.gpuAmps), numThreads,
         getPtr(sortedCtrls), ctrls.size(), ctrlStateMask, targMask,
         toCuQcomp(fac0), toCuQcomp(fac1)
     );
@@ -718,8 +726,8 @@ void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> c
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subA, (Qureg, vector<int>, vector<int>, util_pauliStrData, qcomp, qcomp) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subB, (Qureg, vector<int>, vector<int>, util_pauliStrData, qindex, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subA, (Qureg, vector<int>, vector<int>, vector<int>, vector<int>, vector<int>, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subB, (Qureg, vector<int>, vector<int>, vector<int>, vector<int>, vector<int>, qcomp, qcomp, qindex) )
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub, (Qureg, vector<int>, vector<int>, vector<int>, qcomp, qcomp) )
 
 

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -10,8 +10,6 @@
 #include "quest/include/paulis.h"
 #include "quest/include/matrices.h"
 
-#include "quest/src/core/utilities.hpp"
-
 #include <vector>
 
 using std::vector;
@@ -73,9 +71,9 @@ template <bool HasPower, bool MultiplyOnly> void gpu_densmatr_allTargDiagMatr_su
  * PAULI TENSOR AND GADGET
  */
 
-template <int NumCtrls, int NumTargs> void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qcomp fac0, qcomp fac1);
+template <int NumCtrls, int NumTargs> void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
 
-template <int NumCtrls> void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, util_pauliStrData data, qindex bufferMaskXY, qcomp fac0, qcomp fac1);
+template <int NumCtrls> void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
 
 template <int NumCtrls> void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp fac0, qcomp fac1);
 
@@ -160,9 +158,10 @@ template <bool Conj> qcomp gpu_densmatr_calcFidelityWithPureState_sub(Qureg rho,
 qreal gpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
 qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
 
-qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, util_pauliStrData data);
-qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, util_pauliStrData data);
-qcomp gpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, util_pauliStrData data);
+
+qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp gpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
 
 
 /*


### PR DESCRIPTION
such that backend functions which apply Pauli tensors and gadgets are agnostic to whether simulation is distributed.

Previously, these functions received masks encoding Paulis even on the prefix substate, for which necessary pre-communication had already been performed. This violated the convention maintained by other backend functions to receive only suffix target qubits, and disrupted the modularity of communication and backend simulation. Now, the backend functions receive only suffix Paulis; the impact of the prefix Paulis is to change the complex coefficients passed to the backend.

This refactor involved removing the messy `util_pauliStrData` type.