### PR TITLE
Updated CMAKE_MODULE_PATH for HIP

### DIFF
--- a/QuEST/CMakeLists.txt
+++ b/QuEST/CMakeLists.txt
@@ -132,7 +132,7 @@ if (GPUACCELERATED)
     endif()
 
     if(EXISTS "${HIP_PATH}")
-      set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
+      set(CMAKE_MODULE_PATH "${HIP_PATH}/lib/cmake/hip" ${CMAKE_MODULE_PATH})
       find_package(HIP REQUIRED)
       message(STATUS "Found HIP: " ${HIP_VERSION})
       message(STATUS "HIP PATH: " ${HIP_PATH})


### PR DESCRIPTION
ROCm 6.x has cmake modules installed under ${ROCM_PATH}/lib/cmake. This fixes the cmake configure error:

```
-- Found HIP: 6.2.41134
-- HIP PATH: /opt/COE_modules/rocm/rocm-6.2.2
CMake Error at CMakeLists.txt:380 (hip_add_library):
  Unknown CMake command "hip_add_library".
```