### PR TITLE
misc tidying and v4 bug patches

### DIFF
--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -137,6 +137,8 @@ void applyMultiStateControlledDiagMatrPower(Qureg qureg, int* controls, int* sta
 
 void multiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 
+void multiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+
 void applyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 
 void applyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);

--- a/quest/include/precision.h
+++ b/quest/include/precision.h
@@ -86,21 +86,21 @@
 /*
  * RE-CONFIGURABLE DEFAULT VALIDATION PRECISION
  *
- * which is compile-time overridable by pre-defining DEAULT_VALIDATION_EPSILON (e.g. 
+ * which is compile-time overridable by pre-defining DEFAULT_VALIDATION_EPSILON (e.g. 
  * in user code before importing QuEST, or passed as a preprocessor constant by the
  * compiler using argument -D), and runtime overridable using setValidationEpsilon()
  */
 
-#ifndef DEAULT_VALIDATION_EPSILON
+#ifndef DEFAULT_VALIDATION_EPSILON
 
     #if FLOAT_PRECISION == 1
-        #define DEAULT_VALIDATION_EPSILON 1E-5
+        #define DEFAULT_VALIDATION_EPSILON 1E-5
 
     #elif FLOAT_PRECISION == 2
-        #define DEAULT_VALIDATION_EPSILON 1E-12
+        #define DEFAULT_VALIDATION_EPSILON 1E-12
 
     #elif FLOAT_PRECISION == 4
-        #define DEAULT_VALIDATION_EPSILON 1E-13
+        #define DEFAULT_VALIDATION_EPSILON 1E-13
 
     #endif
 

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -1,20 +1,19 @@
 /** @file
  * C-compatible functions which are alternatives to C++-only API
  * functions, ultimately providing an identical interface. This is 
- * necessary because these functions otherwise pass qcomps by-value
+ * necessary because these functions otherwise return qcomps by-value
  * which is prohibited between C and C++ compiled binaries (because
  * complex numbers are not agreed upon in their ABI, despite having 
  * identical memory layouts in the C and C++ standard libraries).
  * Ergo this file defines no new API functions as far as the user/
  * documentation is aware, but secretly ensures the backend C++ 
- * binaries pass qcomps to the user's C code only by pointer.
+ * binaries return qcomps to the user's C code only by pointer.
+ * 
+ * (( _passing_ qcomps by value to a function seems to be okay,
+ *    although I am not entirely sure why ))
  * 
  * Note that matrix getters and setters (like getCompMatr1()) are
- * missing from this file, even though they contain qcomp[2][2] (which
- * are NOT pointers) and cannot be directly passed between binaries.
- * Those functions are instead defined in matrices.h/.cpp because
- * those structs are declared 'const'; they must be intiailised inline, 
- * and can never be modified by pointer. We shouldn't even address them!
+ * excluded, and instead defined directly in matrices.h/.cpp .
  * 
  * An unimportant by-product of this method of achieving interoperability
  * is that the internal wrapped functions are exposed to the C user; so

--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -49,10 +49,15 @@ extern "C" void _wrap_calcInnerProduct(Qureg bra, Qureg ket, qcomp* out) {
 
 
 qcomp calcExpecNonHermitianPauliStrSum(Qureg qureg, PauliStrSum sum) {
+    validate_quregFields(qureg, __func__);
+    validate_pauliStrSumFields(sum, __func__);
+    validate_pauliStrSumTargets(sum, qureg, __func__);
 
-    // TODO
-    error_functionNotImplemented(__func__);
-    return -1;
+    qcomp value = (qureg.isDensityMatrix)?
+        localiser_densmatr_calcExpecPauliStrSum(qureg, sum):
+        localiser_statevec_calcExpecPauliStrSum(qureg, sum);
+
+    return value;
 }
 extern "C" void _wrap_calcExpecNonHermitianPauliStrSum(qcomp* out, Qureg qureg, PauliStrSum sum) {
 

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1258,17 +1258,17 @@ int applyQubitMeasurementAndGetProb(Qureg qureg, int target, qreal* probability)
     // find only the outcome=0 probability, to avoid reducing all amps;
     // this halves the total iterations though assumes normalisation
     int outcome = 0;
-    qreal prob = calcProbOfQubitOutcome(qureg, target, outcome);
+    *probability = calcProbOfQubitOutcome(qureg, target, outcome);
 
     // randomly choose the outcome
-    outcome = rand_getRandomSingleQubitOutcome(prob);
+    outcome = rand_getRandomSingleQubitOutcome(*probability);
     if (outcome == 1)
-        prob = 1 - prob;
+        *probability = 1 - *probability;
 
     // collapse to the outcome
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, {target}, {outcome}, prob):
-        localiser_statevec_multiQubitProjector(qureg, {target}, {outcome}, prob);
+        localiser_densmatr_multiQubitProjector(qureg, {target}, {outcome}, *probability):
+        localiser_statevec_multiQubitProjector(qureg, {target}, {outcome}, *probability);
 
     return outcome;
 }

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -345,7 +345,6 @@ void accel_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qco
     bool quregGPU = qureg.isGpuAccelerated;
     bool matrGPU = matr.isGpuAccelerated;
 
-    // our chosen function must be correctly templated
     bool hasPower = exponent != qcomp(1, 0);
     auto cpuFunc = GET_FUNC_OPTIMISED_FOR_BOOL( cpu_statevec_allTargDiagMatr_sub, hasPower );
     auto gpuFunc = GET_FUNC_OPTIMISED_FOR_BOOL( gpu_statevec_allTargDiagMatr_sub, hasPower );
@@ -356,15 +355,14 @@ void accel_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qco
 
     // deployments differing is a strange and expectedly rare scenario;
     // why use GPU-acceleration for a Qureg but not the equally-sized
-    // matrix? We provide the below fallbacks for defensive design.
-
-    // When GPU-accel differs, we fall-back to copying memory to RAM and
-    // using the CPU backend. In theory, we could leverage exsting GPU 
-    // memory of the Qureg's communication buffer (if it existed), but
-    // this is an even rarer situation and is hacky. We could also 
-    // create new, temporary GPU memory and graft it to the non-
-    // accelerated object, but the new allocation would be the same
-    // size as the objects and ergo be dangerously large.
+    // matrix? We provide the below fallbacks for defensive design, and
+    // fall-back to copying memory to RAM and using the CPU backend. 
+    // In theory, we could leverage exsting GPU memory of the Qureg's 
+    // communication buffer (if it existed), but this is an even rarer 
+    // situation and is hacky. We could also create new, temporary GPU 
+    // memory and graft it to the non-accelerated object, but the new 
+    // allocation would be the same size as the objects and ergo be 
+    // dangerously large.
 
     if (!quregGPU && matrGPU) {
 
@@ -390,7 +388,6 @@ void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qc
     bool quregGPU = qureg.isGpuAccelerated;
     bool matrGPU = matr.isGpuAccelerated;
 
-    // our chosen CPU or GPU dispatched function must be correctly templated
     bool hasPower = exponent != qcomp(1, 0);
     auto cpuFunc = GET_FUNC_OPTIMISED_FOR_TWO_BOOLS( cpu_densmatr_allTargDiagMatr_sub, hasPower, multiplyOnly );
     auto gpuFunc = GET_FUNC_OPTIMISED_FOR_TWO_BOOLS( cpu_densmatr_allTargDiagMatr_sub, hasPower, multiplyOnly );
@@ -533,18 +530,15 @@ void accel_densmatr_mixQureg_subA(qreal outProb, Qureg out, qreal inProb, Qureg 
         cpu_densmatr_mixQureg_subA(outProb, out, inProb, in);
 
     // deployments differing is a strange and expectedly rare scenario;
-    // why use GPU-acceleration for one Qureg but not the equally-sized
-    // other qureg? We provide the below fallbacks for defensive design.
-
-    // When GPU-accel differs, we fall-back to copying memory to RAM and
-    // using the CPU backend. In theory, we could instead copy
-    // the non-GPU qureg into the VRAM buffer of the GPU qureg and
-    // always use the GPU backend, but this is only possible when
-    // the buffer exists (GPU qureg is distributed), and complicates
-    // the backend; unworthwhile for such a rare scenario. We could
-    // also create new, temporary GPU memory and attach it to the
-    // non-GPU Qureg, but the new allocation is the same size of
-    // the Quregs so is dangerously large, and may fail.
+    // why use GPU-acceleration for a Qureg but not the equally-sized
+    // matrix? We provide the below fallbacks for defensive design, and
+    // fall-back to copying memory to RAM and using the CPU backend. 
+    // In theory, we could leverage exsting GPU memory of the Qureg's 
+    // communication buffer (if it existed), but this is an even rarer 
+    // situation and is hacky. We could also create new, temporary GPU 
+    // memory and graft it to the non-accelerated object, but the new 
+    // allocation would be the same size as the objects and ergo be 
+    // dangerously large.
 
     if (!outGPU && inGPU) {
         gpu_copyGpuToCpu(in);

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -379,7 +379,7 @@ void assert_mixedQuregsAreBothOrNeitherDistributed(Qureg a, Qureg b) {
 
 void assert_mixQuregTempGpuAllocSucceeded(qcomp* gpuPtr) {
 
-    if (gpuPtr == nullptr)
+    if (!mem_isAllocated(gpuPtr))
         raiseInternalError("An internal function invoked by mixQuregs() attempted to allocate temporary GPU memory but failed.");
 }
 
@@ -420,7 +420,7 @@ void assert_quregGpuBufferIsNotGraftedToMatrix(Qureg qureg, FullStateDiagMatr ma
 
 void assert_applyFullStateDiagMatrTempGpuAllocSucceeded(qcomp* gpuPtr) {
 
-    if (gpuPtr == nullptr)
+    if (!mem_isAllocated(gpuPtr))
         raiseInternalError("An internal function invoked by applying a FullStateDiagMatr upon a density matrix attempted to allocate temporary GPU memory but failed.");
 }
 

--- a/quest/src/core/fastmath.hpp
+++ b/quest/src/core/fastmath.hpp
@@ -56,7 +56,7 @@ INLINE qindex fast_getGlobalColFromFlatIndex(qindex globalInd, qindex numAmpsPer
 
 INLINE qindex fast_getLocalIndexOfDiagonalAmp(qindex localIndOfBasisState, qindex localIndOfFirstDiagAmp, qindex numAmpsPerCol) {
 
-    qindex interDiagSpace = 1 + numAmpsPerCol;
+    qindex interDiagSpace = 1 + numAmpsPerCol; // constant and optimised away
     return localIndOfFirstDiagAmp + (localIndOfBasisState * interDiagSpace);
 }
 

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -67,6 +67,9 @@ bool util_isBraQubitInSuffix(int ketQubit, Qureg qureg) {
 
 vector<int> getPrefixOrSuffixQubits(vector<int> qubits, Qureg qureg, bool getSuffix) {
 
+    // note that when the qureg is local/duplicated, 
+    // all qubits will be suffix, none will be prefix
+
     vector<int> subQubits(0);
     subQubits.reserve(qubits.size());
 
@@ -449,7 +452,7 @@ bool isHermitian(qcomp* diags, qindex dim, qreal eps) {
     // check every element has a zero (or <eps) imaginary component
     for (qindex i=0; i<dim; i++)
         if (std::abs(imag(diags[i])) > eps)
-        return false;
+            return false;
 
     return true;
 }

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -201,6 +201,12 @@ qindex util_getGlobalIndexOfFirstLocalAmp(Qureg qureg) {
     return qureg.rank * qureg.numAmpsPerNode;
 }
 
+qindex util_getGlobalColumnOfFirstLocalAmp(Qureg qureg) {
+    assert_utilsGivenDensMatr(qureg);
+
+    return qureg.rank * powerOf2(qureg.logNumColsPerNode);
+}
+
 qindex util_getLocalIndexOfGlobalIndex(Qureg qureg, qindex globalInd) {
 
     // equivalent to below, but clearer

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -65,6 +65,7 @@ qindex util_getBitMask(vector<int> ctrls, vector<int> ctrlStates, vector<int> ta
  */
 
 qindex util_getGlobalIndexOfFirstLocalAmp(Qureg qureg);
+qindex util_getGlobalColumnOfFirstLocalAmp(Qureg qureg);
 
 qindex util_getLocalIndexOfGlobalIndex(Qureg qureg, qindex globalInd);
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -1025,13 +1025,13 @@ bool validateconfig_isEnabled() {
  * overwritten (so will stay validate_STRUCT_PROPERTY_UNKNOWN_FLAG)
  */
 
-static qreal global_validationEpsilon = DEAULT_VALIDATION_EPSILON;
+static qreal global_validationEpsilon = DEFAULT_VALIDATION_EPSILON;
 
 void validateconfig_setEpsilon(qreal eps) {
     global_validationEpsilon = eps;
 }
 void validateconfig_setEpsilonToDefault() {
-    global_validationEpsilon = DEAULT_VALIDATION_EPSILON;
+    global_validationEpsilon = DEFAULT_VALIDATION_EPSILON;
 }
 qreal validateconfig_getEpsilon() {
     return global_validationEpsilon;
@@ -3062,8 +3062,9 @@ void validate_basisStateIndices(Qureg qureg, qindex startInd, qindex numInds, co
         {{"${START_IND}", startInd}, {"${MAX_IND_EXCL}", qureg.numAmps}, {"${NUM_QB}", qureg.numQubits}},
         caller);
 
+    // permit numInds=0
     assertThat(
-        numInds > 0 && numInds <= qureg.numAmps,
+        numInds >= 0 && numInds <= qureg.numAmps,
         report::INVALID_NUM_BASIS_STATE_INDICES, 
         {{"${NUM_INDS}", numInds}, {"${MAX_NUM_INDS_INCL}", qureg.numAmps}, {"${NUM_QB}", qureg.numQubits}}, caller);
 
@@ -3511,8 +3512,8 @@ void validateDensMatrCanBeInitialisedToPureState(Qureg qureg, Qureg pure, const 
     // initPureState calls mixQureg which only additionally
     // constrains that pure.isDistributed only if qureg.isDistributed
 
-    if (qureg.isDistributed)
-        assertThat(!pure.isDistributed, report::INIT_DENSMATR_LOCAL_BUT_PURE_STATE_DISTRIBUTED, caller);
+    if (pure.isDistributed)
+        assertThat(qureg.isDistributed, report::INIT_DENSMATR_LOCAL_BUT_PURE_STATE_DISTRIBUTED, caller);
 }
 
 void validateStateVecCanBeInitialisedToPureState(Qureg qureg, Qureg pure, const char* caller) {

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -579,9 +579,6 @@ void cpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
     assert_quregAndFullStateDiagMatrHaveSameDistrib(qureg, matr);
     assert_exponentMatchesTemplateParam(exponent, HasPower);
 
-    // suppress warnings that 'exponent' is unused when HasPower=false (we cannot use C++17 [[maybe_unused]])
-    (void) exponent;
-
     // every iteration modifies one amp, using one element
     qindex numIts = qureg.numAmpsPerNode;
 
@@ -603,9 +600,6 @@ void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
 
     assert_exponentMatchesTemplateParam(exponent, HasPower);
 
-    // suppress warnings that 'exponent' is unused when HasPower=false (we cannot use C++17 [[maybe_unused]])
-    (void) exponent;
-
     // every iteration modifies one qureg amp, using one matr element
     qindex numIts = qureg.numAmpsPerNode;
 
@@ -616,9 +610,11 @@ void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
         qindex i = fast_getGlobalRowFromFlatIndex(n, matr.numElems);
         qcomp fac = matr.cpuElems[i];
 
+        // compile-time decide if applying power to avoid in-loop branching...
         if constexpr (HasPower)
             fac = pow(fac, exponent);
 
+        // and whether we should also right-apply matr to qureg
         if constexpr (!MultiplyOnly) {
 
             // m = global index corresponding to n
@@ -628,6 +624,7 @@ void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
             qindex j = fast_getGlobalColFromFlatIndex(m, matr.numElems);
             qcomp term = matr.cpuElems[j];
 
+            // right-apply matrix elem may also need to be exponentiated
             if constexpr(HasPower)
                 term = pow(term, exponent);
 
@@ -1768,7 +1765,7 @@ template qcomp cpu_densmatr_calcFidelityWithPureState_sub<false>(Qureg, Qureg);
 
 
 /*
- * EXPECTATION VALUES
+ * PAULI EXPECTATION VALUES
  */
 
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -1848,6 +1848,14 @@ qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int
 
 qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
 
+    // TODO:
+    // this is identical to the subA() version above, except that
+    // qureg.cpuAmps[j] becomes qureg.cpuCommBuffer[j]. We could
+    // ergo replace subA() with an invocation of subB(), binding
+    // the buffer to the amps ptr. Would this affect/interfere
+    // with memory movement optimisations? I doubt so, but check
+    // and if not, perform the replacement to reduce code-dupe!
+
     qcomp value = 0;
 
     // all local amps contribute to the sum

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -1465,7 +1465,7 @@ template qcomp gpu_densmatr_calcFidelityWithPureState_sub<false>(Qureg, Qureg);
 
 
 /*
- * EXPECTATION VALUES
+ * PAULI EXPECTATION VALUES
  */
 
 

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -638,9 +638,9 @@ qreal thrust_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> q
 
     auto rawIter = thrust::make_counting_iterator(0);
     auto indIter = thrust::make_transform_iterator(rawIter, basisIndFunctor);
-    auto diagIter = thrust::make_transform_iterator(indIter, diagIndFunctor);
+    auto diagIter= thrust::make_transform_iterator(indIter, diagIndFunctor);
     auto ampIter = thrust::make_permutation_iterator(getStartPtr(qureg), diagIter);
-    auto probIter = thrust::make_transform_iterator(ampIter, probFunctor);
+    auto probIter= thrust::make_transform_iterator(ampIter, probFunctor);
 
     qindex numIts = powerOf2(qureg.logNumColsPerNode - qubits.size());
     qreal prob = thrust::reduce(probIter, probIter + numIts);
@@ -700,7 +700,7 @@ cu_qcomp thrust_densmatr_calcFidelityWithPureState_sub(Qureg rho, Qureg psi) {
 
 
 /*
- * EXPECTATION VALUES
+ * PAULI EXPECTATION VALUES
  */
 
 


### PR DESCRIPTION
specifically:
-centralised localiser's struct spoofing
- added missing multiplyFullStateDiagMatrPower API declaration
- corrected `DEAULT_VALIDATION_EPSILON` typo (eep!)
- added calcExpecNonHermitianPauliStrSum definition, missing from https://github.com/QuEST-Kit/QuEST/commit/4621e89d6235b5a391e646d6eac5e7264a8f14e0
- patched applyQubitMeasurementAndGetProb which was not modifying output probability pointer
- patched initPureState validation
- changed nullptr comparisons in errors.cpp to use mem_isAllocated for consistency
- removed now-superfluous warning-suppressing code from cpu_subroutines
- improved some doc