### PR TITLE
Scaffolding v4 unit tests

### DIFF
--- a/quest/src/core/randomiser.cpp
+++ b/quest/src/core/randomiser.cpp
@@ -60,7 +60,8 @@ void rand_setSeeds(vector<unsigned> seeds) {
 
     // all nodes learn root node's #seeds
     unsigned numRootSeeds = seeds.size();
-    comm_broadcastUnsignedsFromRoot(&numRootSeeds, 1);
+    if (comm_isInit())
+        comm_broadcastUnsignedsFromRoot(&numRootSeeds, 1);
 
     // all nodes ensure they have space to receive root node's seeds
     seeds.resize(numRootSeeds);

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -15,13 +15,13 @@
 FLOAT_PRECISION=2
 
 # deployments to compile (0, 1)
-COMPILE_MPI=1        # distribution
-COMPILE_OPENMP=1     # multithreading
+COMPILE_MPI=0        # distribution
+COMPILE_OPENMP=0     # multithreading
 COMPILE_CUDA=0       # GPU acceleration
 COMPILE_CUQUANTUM=0  # GPU + cuQuantum
 
-GPU_CC=90
 # GPU compute capability
+GPU_CC=90
 
 # backend compilers
 TESTS_COMPILER=g++

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -36,7 +36,7 @@ LINKER=g++
 # whether to compile unit tests (1) or the below user files (0),
 # or the v3 deprecated unit tests (2). when either tests are
 # compiled, all user-source related settings are ignored. 
-COMPILE_TESTS=1
+COMPILE_TESTS=0
 
 # name of the compiled test executable
 TEST_EXEC_FILE="test"
@@ -46,7 +46,7 @@ USER_EXEC_FILE="main"
 
 # user files (.c or .cpp, intermixed)
 USER_FILES=(
-    "diagmatrtest.cpp"
+    "main.cpp"
 )
 
 # location of user files

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -34,7 +34,8 @@ GPU_COMPILER=nvcc
 LINKER=g++
 
 # whether to compile unit tests (1) or the below user files (0),
-# which are otherwise ignored along with all USER settings
+# or the v3 deprecated unit tests (2). when either tests are
+# compiled, all user-source related settings are ignored. 
 COMPILE_TESTS=1
 
 # name of the compiled test executable
@@ -72,6 +73,12 @@ CUQUANTUM_LIB_DIR="${CUQUANTUM_ROOT}"
 CUDA_LIB_DIR="/usr/local/cuda"
 OMP_LIB_DIR="/opt/homebrew/opt/libomp"
 MPI_LIB_DIR="/opt/homebrew/opt/openmpi"
+CATCH_LIB_DIR="tests/deprecated/catch"
+
+# TODO:
+# use of 'CATCH_LIB_DIR' above will change when v4 tests 
+# switch to using Catch2 as supplied by CMake, rather
+# than the hacky use of deprecated v3's single-header  
 
 
 
@@ -79,6 +86,7 @@ MPI_LIB_DIR="/opt/homebrew/opt/openmpi"
 
 USER_OBJ_PREF="user_"
 QUEST_OBJ_PREF="quest_"
+TEST_OBJ_PREF='test_'
 
 INDENT='  '
 
@@ -89,13 +97,19 @@ INDENT='  '
 # directories
 ROOT_DIR='quest'
 INCLUDE_DIR="${ROOT_DIR}/include"
+
 SRC_DIR="${ROOT_DIR}/src"
 API_DIR="${SRC_DIR}/api"
 OMP_DIR="${SRC_DIR}/cpu"
 GPU_DIR="${SRC_DIR}/gpu"
 MPI_DIR="${SRC_DIR}/comm"
 CORE_DIR="${SRC_DIR}/core"
-TEST_DIR='tests/deprecated'
+
+TEST_MAIN_DIR="tests"
+TEST_UTIL_DIR="${TEST_MAIN_DIR}/utils"
+TEST_UNIT_DIR="${TEST_MAIN_DIR}/unit"
+TEST_DEPR_DIR="${TEST_MAIN_DIR}/deprecated"
+TEST_DEPR_CATCH_DIR="${TEST_DEPR_DIR}/catch"
 
 # files in API_DIR
 API_FILES=(
@@ -145,8 +159,38 @@ MPI_FILES=(
     "comm_routines"
 )
 
-# files in TEST_DIR
-TEST_FILES=(
+# files in TEST_MAIN_DIR
+TEST_MAIN_FILES=(
+    "main"
+)
+
+# files in TEST_UTIL_DIR
+TEST_UTIL_FILES=(
+    "compare"
+    "convert"
+    "evolve"
+    "linalg"
+    "lists"
+    "qmatrix"
+    "qvector"
+    "random"
+)
+
+# files in TEST_UNIT_DIR
+TEST_UNIT_FILES=(
+    "calculations"
+    "decoherence"
+    "environment"
+    "initialisations"
+    "matrices"
+    "operations"
+    "paulis"
+    "qureg"
+    "types"
+)
+
+# files in TEST_DEPR_DIR
+TEST_DEPR_FILES=(
     "test_main"
     "test_gates"
     "test_unitaries"
@@ -156,7 +200,9 @@ TEST_FILES=(
     "test_data_structures"
     "test_state_initialisations"
 )
-TEST_MPI_FILES=(
+
+# files in TEST_DEPR_DIR which use MPI
+TEST_DEPR_MPI_FILES=(
     "test_utilities"
 )
 
@@ -164,8 +210,11 @@ TEST_MPI_FILES=(
 
 # COMPILER AND LINKER FLAG OPTIONS
 
-# compiler flags given to test files
-TEST_COMP_FLAGS="-std=c++17 -I${TEST_DIR}/catch"
+# compiler flags given to all (non-deprecated) files
+TEST_COMP_FLAGS="-std=c++17 -I${CATCH_LIB_DIR}"
+
+# compiler flags given to deprecated test files
+TEST_DEPR_COMP_FLAGS="-std=c++17 -I${TEST_DEPR_CATCH_DIR}"
 
 # compiler flags given to all backend files
 BACKEND_COMP_FLAGS='-std=c++17 -O3'
@@ -233,6 +282,7 @@ HEADER_FLAGS="-I. -I${INCLUDE_DIR}"
 
 # ASSEMBLE FLAGS
 
+echo ""
 echo "deployment modes:"
 
 # flags given to every compilation unit
@@ -295,7 +345,8 @@ else
 fi
 
 # choose linker warning flag (to avoid pass them to nvcc)
-if [ "${LINKER}" = "nvcc" ]; then
+if [ "${LINKER}" = "nvcc" ]
+then
     ALL_LINK_FLAGS+="-Xcompiler ${WARNING_FLAGS}"
 else
     ALL_LINK_FLAGS+=" ${WARNING_FLAGS}"
@@ -325,16 +376,25 @@ echo ""
 echo "chosen compilers and flags..."
 
 # user compilers
-if (( $COMPILE_TESTS == 0 )); then
+if (( $COMPILE_TESTS == 0 ))
+then
     echo "${INDENT}user compilers and flags (for .c and .cpp files respectively):"
     echo "${INDENT}${INDENT}${USER_C_COMPILER} ${USER_C_COMP_FLAGS} ${WARNING_FLAGS}"
     echo "${INDENT}${INDENT}${USER_CXX_COMPILER} ${USER_CXX_COMP_FLAGS} ${WARNING_FLAGS}"
 fi
 
 # test compiler
-if (( $COMPILE_TESTS == 1 )); then
+if (( $COMPILE_TESTS == 1 ))
+then
     echo "${INDENT}tests compiler and flags:"
     echo "${INDENT}${INDENT}${TESTS_COMPILER} ${TEST_COMP_FLAGS} ${WARNING_FLAGS}"
+fi
+
+# deprecated compiler
+if (( $COMPILE_TESTS == 2 ))
+then
+    echo "${INDENT}deprecated tests compiler and flags:"
+    echo "${INDENT}${INDENT}${TESTS_COMPILER} ${TEST_DEPR_COMP_FLAGS} ${WARNING_FLAGS}"
 fi
 
 # base compiler
@@ -370,8 +430,8 @@ echo ""
 # abort script if any compilation fails
 set -e
 
-if (( $COMPILE_TESTS == 0 )); then
-
+if (( $COMPILE_TESTS == 0 ))
+then
     echo "compiling user files:"
 
     for fn in ${USER_FILES[@]}
@@ -399,24 +459,59 @@ fi
 
 # COMPILING TESTS
 
-if (( $COMPILE_TESTS == 1 )); then
+if (( $COMPILE_TESTS == 1 ))
+then
 
-    echo "compiling test files:"
+    echo "compiling unit test files:"
 
-    for fn in ${TEST_FILES[@]}
+    echo "${INDENT}main:"
+
+    for fn in ${TEST_MAIN_FILES[@]}
     do
-        echo "${INDENT}${fn}.cpp ..."
-        $TESTS_COMPILER -c $TEST_DIR/$fn.cpp -o ${QUEST_OBJ_PREF}${fn}.o $TEST_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
+        echo "${INDENT}${INDENT}${fn}.cpp ..."
+        $TESTS_COMPILER -c $TEST_MAIN_DIR/$fn.cpp -o ${TEST_OBJ_PREF}${fn}.o $TEST_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
     done
 
-    for fn in ${TEST_MPI_FILES[@]}
+    echo "${INDENT}utils:"
+
+    for fn in ${TEST_UTIL_FILES[@]}
     do
-        echo "${INDENT}${fn}.cpp ..."
-        $MPI_COMPILER -c $TEST_DIR/$fn.cpp -o ${QUEST_OBJ_PREF}${fn}.o $TEST_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
+        echo "${INDENT}${INDENT}${fn}.cpp ..."
+        $TESTS_COMPILER -c $TEST_UTIL_DIR/$fn.cpp -o ${TEST_OBJ_PREF}${fn}.o $TEST_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
+    done
+
+    echo "${INDENT}unit:"
+
+    for fn in ${TEST_UNIT_FILES[@]}
+    do
+        echo "${INDENT}${INDENT}${fn}.cpp ..."
+        $TESTS_COMPILER -c $TEST_UNIT_DIR/$fn.cpp -o ${TEST_OBJ_PREF}${fn}.o $TEST_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
     done
 
     echo ""
+fi
 
+
+
+# COMPILING DEPRECATED TESTS
+
+if (( $COMPILE_TESTS == 2 ))
+then
+    echo "compiling deprecated test files:"
+
+    for fn in ${TEST_DEPR_FILES[@]}
+    do
+        echo "${INDENT}${fn}.cpp ..."
+        $TESTS_COMPILER -c $TEST_DEPR_DIR/$fn.cpp -o ${TEST_OBJ_PREF}${fn}.o $TEST_DEPR_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
+    done
+
+    for fn in ${TEST_DEPR_MPI_FILES[@]}
+    do
+        echo "${INDENT}${fn}.cpp ..."
+        $MPI_COMPILER -c $TEST_DEPR_DIR/$fn.cpp -o ${TEST_OBJ_PREF}${fn}.o $TEST_DEPR_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
+    done
+
+    echo ""
 fi
 
 
@@ -453,7 +548,8 @@ echo ""
 
 echo "compiling CPU/OMP files..."
 
-for fn in ${OMP_FILES[@]}; do
+for fn in ${OMP_FILES[@]}
+do
     echo "${INDENT}${fn}.cpp ..."
     $CPU_FILES_COMPILER -c $OMP_DIR/$fn.cpp -o ${QUEST_OBJ_PREF}${fn}.o $CPU_FILES_FLAGS $BACKEND_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
 done
@@ -466,7 +562,8 @@ echo ""
 
 echo "compiling GPU files..."
 
-for fn in ${GPU_FILES[@]}; do
+for fn in ${GPU_FILES[@]}
+do
     echo "${INDENT}${fn}.cpp ..."
     $GPU_FILES_COMPILER -c $GPU_DIR/$fn.cpp -o ${QUEST_OBJ_PREF}${fn}.o $GPU_FILES_FLAGS $BACKEND_COMP_FLAGS $GLOBAL_COMP_FLAGS $GPU_WARNING_FLAGS
 done
@@ -479,7 +576,8 @@ echo ""
 
 echo "compiling communication/MPI files..."
 
-for fn in ${MPI_FILES[@]}; do
+for fn in ${MPI_FILES[@]}
+do
     echo "${INDENT}${fn}.cpp ..."
     $MPI_FILES_COMPILER -c $MPI_DIR/$fn.cpp -o ${QUEST_OBJ_PREF}${fn}.o $MPI_FILES_FLAGS $BACKEND_COMP_FLAGS $GLOBAL_COMP_FLAGS $WARNING_FLAGS
 done
@@ -500,13 +598,26 @@ OBJECTS+=" $(printf " ${QUEST_OBJ_PREF}%s.o" "${GPU_FILES[@]}")"
 OBJECTS+=" $(printf " ${QUEST_OBJ_PREF}%s.o" "${OMP_FILES[@]}")"
 OBJECTS+=" $(printf " ${QUEST_OBJ_PREF}%s.o" "${MPI_FILES[@]}")"
 
-if (( $COMPILE_TESTS == 1 )); then
-    OBJECTS+=" $(printf " ${QUEST_OBJ_PREF}%s.o" "${TEST_FILES[@]}")"
-    OBJECTS+=" $(printf " ${QUEST_OBJ_PREF}%s.o" "${TEST_MPI_FILES[@]}")"
-    EXEC_FN=$TEST_EXEC_FILE
-else
+if (( $COMPILE_TESTS == 0 ))
+then
     OBJECTS+=" $(printf " ${USER_OBJ_PREF}%s.o" "${USER_FILES[@]}")"
+elif (( $COMPILE_TESTS == 1 ))
+then
+    OBJECTS+=" $(printf " ${TEST_OBJ_PREF}%s.o" "${TEST_MAIN_FILES[@]}")"
+    OBJECTS+=" $(printf " ${TEST_OBJ_PREF}%s.o" "${TEST_UTIL_FILES[@]}")"
+    OBJECTS+=" $(printf " ${TEST_OBJ_PREF}%s.o" "${TEST_UNIT_FILES[@]}")"
+elif (( $COMPILE_TESTS == 2 ))
+then
+    OBJECTS+=" $(printf " ${TEST_OBJ_PREF}%s.o" "${TEST_DEPR_FILES[@]}")"
+    OBJECTS+=" $(printf " ${TEST_OBJ_PREF}%s.o" "${TEST_DEPR_MPI_FILES[@]}")"
+fi
+
+# decide executable name
+if (( $COMPILE_TESTS == 0 ))
+then
     EXEC_FN=$USER_EXEC_FILE
+else
+    EXEC_FN=$TEST_EXEC_FILE
 fi
 
 # link all objects

--- a/tests/integration/placeholder.cpp
+++ b/tests/integration/placeholder.cpp
@@ -1,0 +1,3 @@
+
+// TODO:
+// integration tests will live here!

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,36 @@
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+// TODO:
+// when we switch to CMake-supplied Catch2,
+// we must replace the above include with:
+// #include <catch2/catch_session.hpp>
+
+
+#include "quest.h"
+#include <stdexcept>
+
+
+// TODO:
+// implement a custom reporter in order to avoid output
+// duplication when running tests distributed
+
+
+// recast QuEST errors into exceptions which Catch can catch  
+extern "C" void invalidQuESTInputError(const char* errMsg, const char* errFunc) {
+
+    throw std::runtime_error(errMsg);
+}
+
+
+// custom catch2 main so that we can prepare QuEST (needed due to MPI)
+int main(int argc, char* argv[]) {
+
+    initQuESTEnv();
+
+    int result = Catch::Session().run( argc, argv );
+
+    finalizeQuESTEnv();
+    return result;
+}

--- a/tests/unit/calculations.cpp
+++ b/tests/unit/calculations.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func1", "[calculations]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/decoherence.cpp
+++ b/tests/unit/decoherence.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func2", "[decoherence]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/environment.cpp
+++ b/tests/unit/environment.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func3", "[environment]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/initialisations.cpp
+++ b/tests/unit/initialisations.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func4", "[initialisations]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/matrices.cpp
+++ b/tests/unit/matrices.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func5", "[matrices]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func6", "[operations]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/paulis.cpp
+++ b/tests/unit/paulis.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func7", "[paulis]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/qureg.cpp
+++ b/tests/unit/qureg.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func8", "[qureg]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/unit/types.cpp
+++ b/tests/unit/types.cpp
@@ -1,0 +1,27 @@
+#include "quest.h"
+#include "catch.hpp"
+
+#include "tests/utils/qvector.hpp"
+#include "tests/utils/qmatrix.hpp"
+#include "tests/utils/compare.hpp"
+#include "tests/utils/convert.hpp"
+#include "tests/utils/evolve.hpp"
+#include "tests/utils/linalg.hpp"
+#include "tests/utils/lists.hpp"
+#include "tests/utils/macros.hpp"
+#include "tests/utils/random.hpp"
+
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+TEST_CASE( "func9", "[types]" ) {
+
+    SECTION( "a" ) {
+
+        REQUIRE( true );
+    }
+}

--- a/tests/utils/compare.cpp
+++ b/tests/utils/compare.cpp
@@ -1,0 +1,85 @@
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+#include "convert.hpp"
+#include "linalg.hpp"
+#include "macros.hpp"
+
+#include <complex>
+using std::abs;
+
+
+/*
+ * VECTOR & VECTOR
+ */
+
+bool operator == (const qvector& v1, const qvector& v2) {
+    DEMAND( v1.size() == v2.size() );
+
+    for (size_t i=0; i<v1.size(); i++)
+        if (abs(v1[i] - v2[i]) > TEST_EPSILON)
+            return false;
+
+    return true;
+}
+
+
+/*
+ * MATRIX & MATRIX
+ */
+
+bool operator == (const qmatrix& m1, const qmatrix& m2) {
+    DEMAND( m1.size() == m2.size() );
+
+    for (size_t i=0; i<m1.size(); i++)
+        for (size_t j=0; j<m1.size(); j++)
+            if (abs(m1[i][j] - m2[i][j]) > TEST_EPSILON)
+                return false;
+
+    return true;
+}
+
+
+/*
+ * VECTOR & QUREG
+ */
+
+bool operator == (const qvector& v, const Qureg& q) {
+    DEMAND( !q.isDensityMatrix );
+    DEMAND( q.numAmps == v.size() );
+
+    return v == getVector(q);
+}
+
+bool operator == (const Qureg& q, const qvector& v) {
+    return v == q;
+}
+
+
+/*
+ * MATRIX & QUREG
+ */
+
+bool operator == (const qmatrix& m, const Qureg& q) {
+    DEMAND( q.isDensityMatrix );
+    DEMAND( pow2(q.numQubits) == m.size() );
+
+    return m == getMatrix(q);
+}
+
+bool operator == (const Qureg& q, const qmatrix& m) {
+    return m == q;
+}
+
+
+/*
+ * QUREG & QUREG
+ */
+
+bool operator == (const Qureg& q1, const Qureg& q2) {
+    DEMAND( q1.isDensityMatrix == q2.isDensityMatrix );
+    DEMAND( q1.numQubits == q2.numQubits );
+
+    return q1.isDensityMatrix?
+        getMatrix(q1) == getMatrix(q2) :
+        getVector(q1) == getVector(q2);
+}

--- a/tests/utils/compare.cpp
+++ b/tests/utils/compare.cpp
@@ -45,7 +45,7 @@ bool operator == (const qmatrix& m1, const qmatrix& m2) {
 
 bool operator == (const qvector& v, const Qureg& q) {
     DEMAND( !q.isDensityMatrix );
-    DEMAND( q.numAmps == v.size() );
+    DEMAND( q.numAmps == (qindex) v.size() );
 
     return v == getVector(q);
 }
@@ -61,7 +61,7 @@ bool operator == (const Qureg& q, const qvector& v) {
 
 bool operator == (const qmatrix& m, const Qureg& q) {
     DEMAND( q.isDensityMatrix );
-    DEMAND( pow2(q.numQubits) == m.size() );
+    DEMAND( getPow2(q.numQubits) == (qindex) m.size() );
 
     return m == getMatrix(q);
 }

--- a/tests/utils/compare.hpp
+++ b/tests/utils/compare.hpp
@@ -1,0 +1,18 @@
+#ifndef COMPARE_HPP
+#define COMPARE_HPP
+
+#include "quest.h"
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+
+
+bool operator == (const qvector&, const qvector&);
+bool operator == (const qmatrix&, const qmatrix&);
+bool operator == (const qvector&, const Qureg&);
+bool operator == (const Qureg&,   const qvector&);
+bool operator == (const qmatrix&, const Qureg&);
+bool operator == (const Qureg&,   const qmatrix&);
+bool operator == (const Qureg&,   const Qureg&);
+
+
+#endif // COMPARE_HPP

--- a/tests/utils/convert.cpp
+++ b/tests/utils/convert.cpp
@@ -1,0 +1,113 @@
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+#include "linalg.hpp"
+#include "macros.hpp"
+#include "quest.h"
+
+#include <type_traits>
+using std::is_same_v;
+
+
+
+/*
+ * TO QUREG
+ */
+
+
+void setQureg(Qureg qureg, qvector vector) {
+    DEMAND( !qureg.isDensityMatrix );
+    DEMAND( qureg.numAmps == vector.size() );
+
+    setQuregAmps(qureg, 0, vector.data(), vector.size());
+}
+
+
+void setQureg(Qureg qureg, qmatrix matrix) {
+    DEMAND( qureg.isDensityMatrix );
+    DEMAND( pow2(qureg.numQubits) == matrix.size() );
+
+    qindex numRows = 1;
+    qindex numCols = pow2(qureg.numQubits);
+
+    for (size_t r=0; r<matrix.size(); r++) {
+        qcomp* arr[] = {matrix[r].data()};
+        setDensityQuregAmps(qureg, r, 0, arr, numRows, numCols);
+    }
+}
+
+
+
+/*
+ * FROM QUREG
+ */
+
+
+qvector getVector(Qureg qureg) {
+    DEMAND( !qureg.isDensityMatrix );
+
+    qvector out = getZeroVector(qureg.numAmps);
+    getQuregAmps(out.data(), qureg, 0, qureg.numAmps);
+    return out;
+}
+
+
+qmatrix getMatrix(Qureg qureg) {
+    DEMAND( qureg.isDensityMatrix );
+
+    qindex numRows = 1;
+    qindex numCols = pow2(qureg.numQubits);
+    qmatrix out = getZeroMatrix(numCols);
+
+    for (size_t r=0; r<out.size(); r++) {
+        qcomp* arr[] = {out[r].data()};
+        getDensityQuregAmps(arr, qureg, r, 0, numRows, numCols);
+
+    }
+
+    return out;
+}
+
+
+
+/*
+ * TO MATRIX
+ */
+
+
+template <typename T> 
+qcomp getElem(T m, size_t r, size_t c) {
+
+    if constexpr (is_same_v<T, CompMatr>)
+        return m.cpuElems[r][c];
+    
+    if constexpr (is_same_v<T, CompMatr1> || is_same_v<T, CompMatr2>)
+        return m.elems[r][c];
+
+    if constexpr (is_same_v<T, DiagMatr>)
+        return (r==c)? m.cpuElems[r] : 0;
+
+    if constexpr (is_same_v<T, DiagMatr1> || is_same_v<T, DiagMatr2>)
+        return (r==c)? m.elems[r] : 0;
+}
+
+
+template <typename T> 
+qmatrix getMatrix(T m) {
+
+    qmatrix out = getZeroMatrix(pow2(m.numQubits));
+
+    for (size_t r=0; r<out.size(); r++)
+        for (size_t c=0; c<out.size(); c++)
+            out[r][c] = getElem<T>(m, r, c);
+
+    return out;
+}
+
+template qmatrix getMatrix(CompMatr1);
+template qmatrix getMatrix(CompMatr2);
+template qmatrix getMatrix(CompMatr );
+template qmatrix getMatrix(DiagMatr1);
+template qmatrix getMatrix(DiagMatr2);
+template qmatrix getMatrix(DiagMatr );
+
+// FullStateDiagMatr excluded

--- a/tests/utils/convert.cpp
+++ b/tests/utils/convert.cpp
@@ -16,7 +16,7 @@ using std::is_same_v;
 
 void setQureg(Qureg qureg, qvector vector) {
     DEMAND( !qureg.isDensityMatrix );
-    DEMAND( qureg.numAmps == vector.size() );
+    DEMAND( qureg.numAmps == (qindex) vector.size() );
 
     setQuregAmps(qureg, 0, vector.data(), vector.size());
 }
@@ -24,10 +24,10 @@ void setQureg(Qureg qureg, qvector vector) {
 
 void setQureg(Qureg qureg, qmatrix matrix) {
     DEMAND( qureg.isDensityMatrix );
-    DEMAND( pow2(qureg.numQubits) == matrix.size() );
+    DEMAND( getPow2(qureg.numQubits) == (qindex) matrix.size() );
 
     qindex numRows = 1;
-    qindex numCols = pow2(qureg.numQubits);
+    qindex numCols = getPow2(qureg.numQubits);
 
     for (size_t r=0; r<matrix.size(); r++) {
         qcomp* arr[] = {matrix[r].data()};
@@ -55,7 +55,7 @@ qmatrix getMatrix(Qureg qureg) {
     DEMAND( qureg.isDensityMatrix );
 
     qindex numRows = 1;
-    qindex numCols = pow2(qureg.numQubits);
+    qindex numCols = getPow2(qureg.numQubits);
     qmatrix out = getZeroMatrix(numCols);
 
     for (size_t r=0; r<out.size(); r++) {
@@ -94,7 +94,7 @@ qcomp getElem(T m, size_t r, size_t c) {
 template <typename T> 
 qmatrix getMatrix(T m) {
 
-    qmatrix out = getZeroMatrix(pow2(m.numQubits));
+    qmatrix out = getZeroMatrix(getPow2(m.numQubits));
 
     for (size_t r=0; r<out.size(); r++)
         for (size_t c=0; c<out.size(); c++)

--- a/tests/utils/convert.hpp
+++ b/tests/utils/convert.hpp
@@ -1,0 +1,18 @@
+#ifndef CONVERT_HPP
+#define CONVERT_HPP
+
+#include "quest.h"
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+
+
+void setQureg(Qureg, qvector);
+void setQureg(Qureg, qmatrix);
+
+qvector getVector(Qureg);
+qmatrix getMatrix(Qureg);
+
+template <typename T> qmatrix getMatrix(T);
+
+
+#endif // CONVERT_HPP

--- a/tests/utils/evolve.cpp
+++ b/tests/utils/evolve.cpp
@@ -22,7 +22,7 @@ qmatrix getSwapMatrix(int qb1, int qb2, int numQb) {
     DEMAND( (qb2 >= 0 && qb2 < numQb) );
 
     if (qb1 == qb2)
-        return getIdentityMatrix(pow2(numQb));
+        return getIdentityMatrix(getPow2(numQb));
         
     if (qb1 > qb2)
         std::swap(qb1, qb2);
@@ -35,7 +35,7 @@ qmatrix getSwapMatrix(int qb1, int qb2, int numQb) {
     
     // or distant
     } else {
-        int block = pow2(qb2 - qb1);
+        int block = getPow2(qb2 - qb1);
         out = getZeroMatrix(block*2);
         qmatrix iden = getIdentityMatrix(block/2);
         
@@ -45,7 +45,7 @@ qmatrix getSwapMatrix(int qb1, int qb2, int numQb) {
         qmatrix l1{{0,0},{1,0}};
         qmatrix p1{{0,0},{0,1}};
         
-        // notating a^(n+1) = identity(pow2(n)) (otimes) a, we construct the matrix
+        // notating a^(n+1) = identity(getPow2(n)) (otimes) a, we construct the matrix
         // [ p0^(N) l1^N ]
         // [ l0^(N) p1^N ]
         // where N = qb2 - qb1 */
@@ -57,10 +57,10 @@ qmatrix getSwapMatrix(int qb1, int qb2, int numQb) {
     
     // pad swap with outer identities
     if (qb1 > 0)
-        out = getKroneckerProduct(out, getIdentityMatrix(pow2(qb1)));
+        out = getKroneckerProduct(out, getIdentityMatrix(getPow2(qb1)));
 
     if (qb2 < numQb-1)
-        out = getKroneckerProduct(getIdentityMatrix(pow2(numQb-qb2-1)), out);
+        out = getKroneckerProduct(getIdentityMatrix(getPow2(numQb-qb2-1)), out);
         
     return out;
 }
@@ -70,13 +70,13 @@ auto getSwapAndUnswapMatrices(vector<int> ctrls, vector<int> targs, size_t numQu
     DEMAND( numQubits >= ctrls.size() + targs.size() );
 
     // matrices which swap targs+ctrls to be contiguous from 0
-    qmatrix swaps   = getIdentityMatrix(pow2(numQubits));
-    qmatrix unswaps = getIdentityMatrix(pow2(numQubits));
+    qmatrix swaps   = getIdentityMatrix(getPow2(numQubits));
+    qmatrix unswaps = getIdentityMatrix(getPow2(numQubits));
 
     // swap targs to {0, ..., ntargs - 1}
     for (size_t i=0; i<targs.size(); i++) {
 
-        if (i == targs[i])
+        if (i == (size_t) targs[i])
             continue;
 
         qmatrix m = getSwapMatrix(i, targs[i], numQubits);
@@ -91,7 +91,7 @@ auto getSwapAndUnswapMatrices(vector<int> ctrls, vector<int> targs, size_t numQu
     for (size_t i=0; i<ctrls.size(); i++) {
 
         size_t j = i + targs.size();
-        if (j == ctrls[i])
+        if (j == (size_t) ctrls[i])
             continue;
 
         qmatrix m = getSwapMatrix(j, ctrls[i], numQubits);
@@ -107,19 +107,19 @@ auto getSwapAndUnswapMatrices(vector<int> ctrls, vector<int> targs, size_t numQu
 
 qmatrix getFullStateOperator(vector<int> ctrls, vector<int> targs, qmatrix matrix, size_t numQubits) {
     DEMAND( numQubits >= ctrls.size() + targs.size() );
-    DEMAND( matrix.size() == pow2(targs.size()) );
+    DEMAND( getPow2(targs.size()) == (qindex) matrix.size() );
     
     auto [swaps, unswaps] = getSwapAndUnswapMatrices(ctrls, targs, numQubits);
 
     // construct controlled-(matrix)
-    size_t dim = pow2(ctrls.size() + targs.size());
+    size_t dim = getPow2(ctrls.size() + targs.size());
     size_t off = dim - matrix.size();
     qmatrix full = getIdentityMatrix(dim);
     setSubMatrix(full, matrix, off, off);
 
     // left-pad 'out' to full size
     if (numQubits > ctrls.size() + targs.size()) {
-        size_t pad = pow2(numQubits - ctrls.size() - targs.size());
+        size_t pad = getPow2(numQubits - ctrls.size() - targs.size());
         full = getKroneckerProduct(getIdentityMatrix(pad), full);
     }
     
@@ -136,14 +136,14 @@ qmatrix getFullStateOperator(vector<int> ctrls, vector<int> targs, qmatrix matri
 
 void applyReferenceOperator(qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
     
-    qmatrix ref = getFullStateOperator(ctrls, targs, matrix, log2(state.size()));
+    qmatrix ref = getFullStateOperator(ctrls, targs, matrix, getLog2(state.size()));
     state = ref * state;
 }
 
 
 void applyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
     
-    qmatrix left = getFullStateOperator(ctrls, targs, matrix, log2(state.size()));
+    qmatrix left = getFullStateOperator(ctrls, targs, matrix, getLog2(state.size()));
     qmatrix right = getConjugateTranspose(left);
     state = left * state * right;
 }
@@ -151,7 +151,7 @@ void applyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs
 
 void multiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
     
-    qmatrix left = getFullStateOperator(ctrls, targs, matrix, log2(state.size()));
+    qmatrix left = getFullStateOperator(ctrls, targs, matrix, getLog2(state.size()));
     state = left * state;
 }
 

--- a/tests/utils/evolve.hpp
+++ b/tests/utils/evolve.hpp
@@ -1,0 +1,20 @@
+#ifndef EVOLVE_HPP
+#define EVOLVE_HPP
+
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+
+#include <vector>
+using std::vector;
+
+
+void applyReferenceOperator(   qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator(   qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void multiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+
+void applyReferenceOperator(   qvector& state, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator(   qmatrix& state, vector<int> targs, qmatrix matrix);
+void multiplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix);
+
+
+#endif // EVOLVE_HPP

--- a/tests/utils/linalg.cpp
+++ b/tests/utils/linalg.cpp
@@ -1,0 +1,271 @@
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+#include "linalg.hpp"
+#include "macros.hpp"
+
+#include <vector>
+
+using std::vector;
+
+
+
+/*
+ * SCALAR OPERATIONS
+ */
+
+
+int log2(qindex a) {
+    DEMAND( a >= 0 );
+    DEMAND( (a & (a - 1)) == 0 )  // is pow2
+
+    int n = 0;
+    while (a >>= 1)
+        n++;
+
+    return n;
+}
+
+
+qindex pow2(int a) {
+    DEMAND( a >= 0 );
+
+    return ((qindex) 1) << a;
+}
+
+
+qcomp expI(qreal x) {
+    return qcomp(cos(x), sin(x));
+}
+
+
+
+/*
+ * VECTOR OPERATIONS
+ */
+
+
+qvector getNormalised(qvector vec) {
+
+    qreal norm = 0;
+    qreal y, t, c=0;
+    
+    // compute norm via Kahan summation
+    for (auto& x : vec) {
+        y = real(x)*real(x) - c;
+        t = norm + y;
+        c = ( t - norm ) - y;
+        norm = t;
+        
+        y = imag(x)*imag(x) - c;
+        t = norm + y;
+        c = ( t - norm ) - y;
+        norm = t;
+    }
+    
+    // normalise vector
+    for (auto& x : vec)
+        x /= sqrt(norm);
+
+    return vec;
+}
+
+
+qvector getDisceteFourierTransform(qvector in) {
+    REQUIRE( in.size() > 0 );
+    
+    size_t dim = in.size();
+    qvector out = getZeroVector(dim);
+
+    qreal a = 1 / sqrt(dim);
+    qreal b = 2 * M_PI / dim;
+    
+    for (size_t x=0; x<dim; x++)
+        for (size_t y=0; y<dim; y++)
+            out[x] += a * expI(b * x * y) * in[y];
+
+    return out;
+}
+
+
+
+/*
+ * VECTOR & VECTOR OPERATIONS
+ */
+
+
+qcomp getInnerProduct(const qvector &bra, const qvector& ket) {
+    DEMAND( bra.size() == ket.size() );
+
+    qcomp out = 0;
+
+    for (size_t i=0; i<bra.size(); i++)
+        out += conj(bra[i]) * ket[i];
+
+    return out;
+}
+
+
+qmatrix getOuterProduct(const qvector &ket, const qvector &bra) {
+    DEMAND( bra.size() == ket.size() );
+
+    qmatrix out = getZeroMatrix(bra.size());
+
+    for (size_t i=0; i<ket.size(); i++)
+        for (size_t j=0; j<ket.size(); j++)
+            out[i][j] = ket[i] * conj(bra[j]);
+
+    return out;
+}
+
+
+
+/*
+ * MATRIX OPERATIONS
+ */
+
+
+bool isDiagonal(qmatrix m) {
+
+    for (size_t r=0; r<m.size(); r++)
+        for (size_t c=0; c<m.size(); c++)
+            if (r!=c && m[r][c] != 0_i)
+                return false;
+
+    return true;
+}
+
+
+bool isUnitary(qmatrix m) {
+
+    qmatrix md = m * getConjugateTranspose(m);
+    qmatrix id = getIdentityMatrix(m.size());
+    return md == id;
+}
+
+
+qmatrix getTranspose(qmatrix m) {
+
+    qmatrix out = getZeroMatrix(m.size());
+
+    for (size_t r=0; r<m.size(); r++)
+        for (size_t c=0; c<m.size(); c++)
+            out[r][c] = m[c][r];
+
+    return out;
+}
+
+
+qmatrix getConjugateTranspose(qmatrix m) {
+
+    qmatrix out = getZeroMatrix(m.size());
+
+    for (size_t r=0; r<m.size(); r++)
+        for (size_t c=0; c<m.size(); c++)
+            out[r][c] = conj(m[c][r]);
+
+    return out;
+}
+
+
+qmatrix getExponentialOfDiagonalMatrix(qmatrix m) {
+    DEMAND( isDiagonal(m) );
+
+    qmatrix out = getZeroMatrix(m.size());
+
+    for (size_t i=0; i<m.size(); i++)
+        out[i][i] = exp(m[i][i]);
+
+    return out;
+}
+
+
+qmatrix getExponentialOfPauliMatrix(qreal arg, qmatrix m) {
+    
+    qmatrix id = getIdentityMatrix(m.size());
+    qmatrix out = cos(arg/2)*id - 1_i*sin(arg/2)*m;
+    return out;
+}
+
+
+qmatrix getOrthonormalisedRows(qmatrix matr) {
+
+    // perform the Gram-Schmidt process, processing each row of matr in-turn
+    for (size_t i=0; i<matr.size(); i++) {
+        qvector row = matr[i];
+        
+        // compute new orthogonal row by subtracting proj row onto prevs
+        for (int k=i-1; k>=0; k--) {
+
+            // compute inner_product(row, prev) = row . conj(prev)
+            qcomp prod = getInnerProduct(matr[k], row);
+                            
+            // subtract (proj row onto prev) = (prod * prev) from final row
+            matr[i] -= prod * matr[k];
+        }
+    
+        // normalise the row 
+        matr[i] = getNormalised(matr[i]);
+    }
+    
+    // return the new orthonormal matrix
+    return matr;
+}
+
+
+
+/*
+ * MATRIX & VECTOR OPERATIONS
+ */
+
+
+qvector operator * (const qmatrix& m, const qvector& v) {
+    DEMAND( m.size() == v.size() );
+
+    qvector out = getZeroVector(v.size());
+
+    for (size_t r=0; r<v.size(); r++)
+        for (size_t c=0; c<v.size(); c++)
+            out[r] += m[r][c] * v[c];
+
+    return out;
+}
+
+
+
+/*
+ * MATRIX & MATRIX OPERATIONS
+ */
+
+
+qmatrix getKroneckerProduct(qmatrix a, qmatrix b) {
+
+    qmatrix out = getZeroMatrix(a.size() * b.size());
+
+    for (size_t r=0; r<b.size(); r++)
+        for (size_t c=0; c<b.size(); c++)
+            for (size_t i=0; i<a.size(); i++)
+                for (size_t j=0; j<a.size(); j++)
+                    out[r+b.size()*i][c+b.size()*j] = a[i][j] * b[r][c];
+
+    return out;
+}
+
+
+
+/*
+ * MATRIX COLLECTIONS
+ */
+
+
+bool isCompletelyPositiveTracePreserving(vector<qmatrix> matrices) {
+    DEMAND( matrices.size() >= 1 )
+
+    size_t dim = matrices[0].size();
+    qmatrix id = getIdentityMatrix(dim);
+    qmatrix sum = getZeroMatrix(dim);
+
+    for (auto& m : matrices)
+        sum += getConjugateTranspose(m) * m;
+
+    return sum == id;
+}

--- a/tests/utils/linalg.cpp
+++ b/tests/utils/linalg.cpp
@@ -14,7 +14,7 @@ using std::vector;
  */
 
 
-int log2(qindex a) {
+int getLog2(qindex a) {
     DEMAND( a >= 0 );
     DEMAND( (a & (a - 1)) == 0 )  // is pow2
 
@@ -26,14 +26,14 @@ int log2(qindex a) {
 }
 
 
-qindex pow2(int a) {
+qindex getPow2(int a) {
     DEMAND( a >= 0 );
 
     return ((qindex) 1) << a;
 }
 
 
-qcomp expI(qreal x) {
+qcomp getExpI(qreal x) {
     return qcomp(cos(x), sin(x));
 }
 
@@ -81,7 +81,7 @@ qvector getDisceteFourierTransform(qvector in) {
     
     for (size_t x=0; x<dim; x++)
         for (size_t y=0; y<dim; y++)
-            out[x] += a * expI(b * x * y) * in[y];
+            out[x] += a * getExpI(b * x * y) * in[y];
 
     return out;
 }

--- a/tests/utils/linalg.hpp
+++ b/tests/utils/linalg.hpp
@@ -8,9 +8,9 @@
 using std::vector;
 
 
-int log2(qindex);
-qindex pow2(int);
-qcomp expI(qreal);
+int getLog2(qindex);
+qindex getPow2(int);
+qcomp getExpI(qreal);
 
 qvector getNormalised(qvector);
 qvector getDisceteFourierTransform(qvector);

--- a/tests/utils/linalg.hpp
+++ b/tests/utils/linalg.hpp
@@ -1,0 +1,37 @@
+#ifndef LINALG_HPP
+#define LINALG_HPP
+
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+
+#include <vector>
+using std::vector;
+
+
+int log2(qindex);
+qindex pow2(int);
+qcomp expI(qreal);
+
+qvector getNormalised(qvector);
+qvector getDisceteFourierTransform(qvector);
+
+qcomp   getInnerProduct(const qvector &bra, const qvector& ket);
+qmatrix getOuterProduct(const qvector &ket, const qvector &bra);
+
+qvector operator * (const qmatrix&, const qvector&);
+
+bool isDiagonal(qmatrix);
+bool isUnitary(qmatrix);
+
+qmatrix getTranspose(qmatrix);
+qmatrix getConjugateTranspose(qmatrix);
+qmatrix getExponentialOfDiagonalMatrix(qmatrix);
+qmatrix getExponentialOfPauliMatrix(qreal, qmatrix);
+qmatrix getOrthonormalisedRows(qmatrix);
+qmatrix getOrthonormalisedRows(qmatrix);
+qmatrix getKroneckerProduct(qmatrix, qmatrix);
+
+bool isCompletelyPositiveTracePreserving(vector<qmatrix>);
+
+
+#endif // LINALG_HPP

--- a/tests/utils/lists.cpp
+++ b/tests/utils/lists.cpp
@@ -1,0 +1,43 @@
+#include "catch.hpp"
+#include "macros.hpp"
+
+#include <vector>
+using std::vector;
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp" with:
+// #include <catch2/generators/catch_generators.hpp>
+// #include <catch2/generators/catch_generators_adapters.hpp>
+
+
+
+/*
+ * RANGE
+ */
+
+
+vector<int> getRange(int start, int endExcl) {
+    DEMAND( endExcl >= start );
+
+    vector<int> out(endExcl - start);
+
+    for (size_t i=0; i<out.size(); i++)
+        out[i] = start + i;
+
+    return out;
+}
+
+
+vector<int> getRange(int endExcl) {
+    return getRange(0, endExcl);
+}
+
+
+
+/*
+ * GENERATORS
+ */
+
+
+// TODO:
+// rework v3 generators to use vectors

--- a/tests/utils/lists.hpp
+++ b/tests/utils/lists.hpp
@@ -1,0 +1,12 @@
+#ifndef LISTS_HPP
+#define LISTS_HPP
+
+#include <vector>
+using std::vector;
+
+
+vector<int> getRange(int start, int endExcl);
+vector<int> getRange(int endExcl);
+
+
+#endif // LISTS_HPP

--- a/tests/utils/macros.hpp
+++ b/tests/utils/macros.hpp
@@ -1,0 +1,26 @@
+#ifndef MACROS_HPP
+#define MACROS_HPP
+
+#include "catch.hpp"
+
+// TODO: 
+// use CMake to obtain catch2 and replace #include "catch.hpp"
+// with "#include <catch2/catch_test_macros.hpp>""
+
+
+
+// TODO:
+// adjust TEST_EPSILON according to QuEST's FLOAT_PRECISION
+
+#define TEST_EPSILON 1E-10
+
+
+/*
+ * preconditions to the internal unit testing functions are checked using 
+ * DEMAND rather than Catch2's REQUIRE, so that they are not counted in the 
+ * total unit testing statistics (e.g. number of checks passed).
+ */
+#define DEMAND( cond ) if (!(cond)) FAIL( );
+
+
+#endif // MACROS_HPP

--- a/tests/utils/qmatrix.cpp
+++ b/tests/utils/qmatrix.cpp
@@ -1,0 +1,176 @@
+#include "qmatrix.hpp"
+#include "qvector.hpp"
+#include "macros.hpp"
+
+
+/*
+ * MATRIX CREATION
+ */
+
+qmatrix getZeroMatrix(size_t dim) {
+    DEMAND( dim > 1 );
+
+    qmatrix out = qmatrix(dim);
+
+    for (auto& row : out)
+        row.resize(dim);
+
+    return out;
+}
+
+qmatrix getIdentityMatrix(size_t dim) {
+    DEMAND( dim > 1 );
+
+    qmatrix out = getZeroMatrix(dim);
+
+    for (size_t i=0; i<dim; i++)
+        out[i][i] = 1;
+    
+    return out;
+}
+
+qmatrix getDiagonalMatrix(qvector v) {
+    DEMAND( v.size() > 1 );
+
+    qmatrix out = getZeroMatrix(v.size());
+
+    for (size_t i=0; i<v.size(); i++)
+        out[i][i] = v[i];
+    
+    return out;
+}
+
+
+/*
+ * SCALAR MULTIPLICATION
+ */
+
+qmatrix operator * (const qcomp& a, const qmatrix& m) {
+    qmatrix out = m;
+
+    for (auto& row : out)
+        for (auto& elem : row)
+            elem *= a;
+    
+    return out;
+}
+
+qmatrix operator * (const qmatrix& m, const qcomp& a) {
+    return a * m;
+}
+
+qmatrix operator *= (qmatrix& m, const qcomp& a) {
+    m = a * m;
+    return m;
+}
+
+qmatrix operator * (const qreal& a, const qmatrix& m) {
+    return qcomp(a,0) * m;
+}
+
+qmatrix operator * (const qmatrix& m, const qreal& a) {
+    return a * m;
+}
+
+qmatrix operator *= (qmatrix& m, const qreal& a) {
+    m = a * m;
+    return m;
+}
+
+
+/*
+ * SCALAR DIVISION
+ */
+
+qmatrix operator / (const qmatrix& m, const qcomp& a) {
+    DEMAND( abs(a) != 0 );
+
+    return (1/a) * m;
+}
+
+qmatrix operator /= (qmatrix& m, const qcomp& a) {
+    m = m / a;
+    return m;
+}
+
+qmatrix operator / (const qmatrix& m, const qreal& a) {
+    return m / qcomp(a,0);
+}
+
+qmatrix operator /= (qmatrix& m, const qreal& a) {
+    m = m / a;
+    return m;
+}
+
+
+/*
+ * MATRIX ADDITION
+ */
+
+qmatrix operator + (const qmatrix& m1, const qmatrix& m2) {
+    DEMAND( m1.size() == m2.size() );
+
+    qmatrix out = m1;
+
+    for (size_t r=0; r<m1.size(); r++)
+        for (size_t c=0; c<m1.size(); c++)
+            out[r][c] += m2[r][c];
+
+    return out;
+}
+
+qmatrix operator += (qmatrix& m1, const qmatrix& m2) {
+    m1 = m1 + m2;
+    return m1;
+}
+
+
+/*
+ * MATRIX SUBTRACTION
+ */
+
+qmatrix operator - (const qmatrix& m1, const qmatrix& m2) {
+    return m1 + (-1 * m2);
+}
+
+qmatrix operator -= (qmatrix& m1, const qmatrix& m2) {
+    m1 = m1 - m2;
+    return m1;
+}
+
+
+/*
+ * MATRIX MULTIPLICATION
+ */
+
+qmatrix operator * (const qmatrix& m1, const qmatrix& m2) {
+    DEMAND( m1.size() == m2.size() );
+
+    qmatrix out = getZeroMatrix(m1.size());
+
+    for (size_t r=0; r<m1.size(); r++)
+        for (size_t c=0; c<m1.size(); c++)
+            for (size_t k=0; k<m1.size(); k++)
+                out[r][c] += m1[r][k] * m2[k][c];
+    
+    return out;
+}
+
+qmatrix operator *= (qmatrix& m1, const qmatrix& m2) {
+    m1 = m1 * m2;
+    return m1;
+}
+
+
+/*
+ * SETTERS
+ */
+
+void setSubMatrix(qmatrix &dest, qmatrix sub, size_t r, size_t c) {
+    DEMAND( sub.size() + r <= dest.size() );
+    DEMAND( sub.size() + c <= dest.size() );
+
+    for (size_t i=0; i<sub.size(); i++)
+        for (size_t j=0; j<sub.size(); j++)
+            dest[r+i][c+j] = sub[i][j];
+}

--- a/tests/utils/qmatrix.hpp
+++ b/tests/utils/qmatrix.hpp
@@ -1,0 +1,42 @@
+#ifndef QMATRIX_HPP
+#define QMATRIX_HPP
+
+#include "quest.h"
+#include "qvector.hpp"
+
+#include <vector>
+using std::vector;
+
+
+typedef vector<vector<qcomp>> qmatrix;
+
+
+qmatrix getZeroMatrix(size_t dim);
+qmatrix getIdentityMatrix(size_t dim);
+qmatrix getDiagonalMatrix(qvector v);
+
+qmatrix operator * (const qcomp&,   const qmatrix& );
+qmatrix operator * (const qmatrix&, const qcomp&);
+qmatrix operator * (const qreal&,   const qmatrix&);
+qmatrix operator * (const qmatrix&, const qreal&);
+qmatrix operator *= (qmatrix&, const qcomp&);
+qmatrix operator *= (qmatrix&, const qreal&);
+
+qmatrix operator / (const qmatrix&, const qcomp&);
+qmatrix operator / (const qmatrix&, const qreal&) ;
+qmatrix operator /= (qmatrix&, const qcomp&);
+qmatrix operator /= (qmatrix&, const qreal&);
+
+qmatrix operator + (const qmatrix&, const qmatrix&);
+qmatrix operator += (qmatrix&, const qmatrix&);
+
+qmatrix operator - (const qmatrix&, const qmatrix&);
+qmatrix operator -= (qmatrix&, const qmatrix&);
+
+qmatrix operator * (const qmatrix&, const qmatrix&);
+qmatrix operator *= (qmatrix&, const qmatrix&);
+
+void setSubMatrix(qmatrix &dest, qmatrix sub, size_t r, size_t c);
+
+
+#endif // QMATRIX_HPP

--- a/tests/utils/qvector.cpp
+++ b/tests/utils/qvector.cpp
@@ -1,0 +1,107 @@
+#include "qvector.hpp"
+#include "macros.hpp"
+
+
+/*
+ * VECTOR CREATION
+ */
+
+qvector getZeroVector(size_t dim) {
+    return qvector(dim, 0);
+}
+
+
+/*
+ * SCALAR MULTIPLICATION
+ */
+
+qvector operator * (const qcomp& a, const qvector& v) {
+    qvector out = v;
+
+    for (auto& x : out)
+        x *= a;
+
+    return out;
+}
+
+qvector operator * (const qvector& v, const qcomp& a) {
+    return a * v;
+}
+
+qvector operator *= (qvector& v, const qcomp& a) {
+    v = a * v;
+    return v;
+}
+
+qvector operator * (const qreal& a, const qvector& v) {
+    return qcomp(a,0) * v;
+}
+
+qvector operator * (const qvector& v, const qreal& a) {
+    return a * v;
+}
+
+qvector operator *= (qvector& v, const qreal& a) {
+    v = a * v;
+    return v;
+}
+
+
+/*
+ * SCALAR DIVISION
+ */
+
+qvector operator / (const qvector& v, const qcomp& a) {
+    DEMAND( abs(a) != 0 );
+
+    return (1/a) * v;
+}
+
+qvector operator /= (qvector& v, const qcomp& a) {
+    v = v / a;
+    return v;
+}
+
+qvector operator / (const qvector& v, const qreal& a) {
+    return v / qcomp(a,0);
+}
+
+qvector operator /= (qvector& v, const qreal& a) {
+    v = v / a;
+    return v;
+}
+
+
+/*
+ * VECTOR ADDITION
+ */
+
+qvector operator + (const qvector& v1, const qvector& v2) {
+    DEMAND( v1.size() == v2.size() );
+
+    qvector out = v1;
+    
+    for (size_t i=0; i<v2.size(); i++)
+        out[i] += v2[i];
+
+    return out;
+}
+
+qvector operator += (qvector& v1, const qvector& v2) {
+    v1 = v1 + v2;
+    return v1;
+}
+
+
+/*
+ * VECTOR SUBTRACTION
+ */
+
+qvector operator - (const qvector& v1, const qvector& v2) {
+    return v1 + (-1 * v2);
+}
+
+qvector operator -= (qvector& v1, const qvector& v2) {
+    v1 = v1 - v2;
+    return v1;
+}

--- a/tests/utils/qvector.hpp
+++ b/tests/utils/qvector.hpp
@@ -1,0 +1,33 @@
+#ifndef QVECTOR_HPP
+#define QVECTOR_HPP
+
+#include "quest.h"
+#include "macros.hpp"
+#include <vector>
+
+
+typedef std::vector<qcomp> qvector;
+
+
+qvector getZeroVector(size_t dim);
+
+qvector operator * (const qcomp&, const qvector&);
+qvector operator * (const qvector&, const qcomp&);
+qvector operator * (const qreal&, const qvector&);
+qvector operator * (const qvector&, const qreal&);
+qvector operator *= (qvector&, const qcomp&);
+qvector operator *= (qvector&, const qreal&);
+
+qvector operator / (const qvector&, const qcomp&);
+qvector operator / (const qvector&, const qreal&);
+qvector operator /= (qvector&, const qcomp&);
+qvector operator /= (qvector&, const qreal&);
+
+qvector operator + (const qvector&, const qvector&);
+qvector operator += (qvector&, const qvector&);
+
+qvector operator - (const qvector&, const qvector&);
+qvector operator -= (qvector&, const qvector&);
+
+
+#endif // QVECTOR_HPP

--- a/tests/utils/random.cpp
+++ b/tests/utils/random.cpp
@@ -175,13 +175,13 @@ vector<qreal> getRandomProbabilities(int numProbs) {
 
 qvector getRandomStateVector(int numQb) {
 
-    return getNormalised(getRandomVector(pow2(numQb)));
+    return getNormalised(getRandomVector(getPow2(numQb)));
 }
 
 
 vector<qvector> getRandomOrthonormalStateVectors(int numQb, int numStates) {
 
-    return getRandomOrthonormalVectors(pow2(numQb), numStates);
+    return getRandomOrthonormalVectors(getPow2(numQb), numStates);
 }
 
 
@@ -189,7 +189,7 @@ qmatrix getRandomDensityMatrix(int numQb) {
     DEMAND( numQb > 0 );
     
     // generate random probabilities to weight random pure states
-    int dim = pow2(numQb);
+    int dim = getPow2(numQb);
     vector<qreal> probs = getRandomProbabilities(dim);
     
     // add random pure states
@@ -221,7 +221,7 @@ qmatrix getRandomUnitary(int numQb) {
     DEMAND( numQb >= 1 );
 
     // create Z ~ random complex matrix (distribution not too important)
-    size_t dim = pow2(numQb);
+    size_t dim = getPow2(numQb);
     qmatrix matrZ = getRandomMatrix(dim);
     qmatrix matrZT = getTranspose(matrZ);
 
@@ -251,10 +251,10 @@ qmatrix getRandomUnitary(int numQb) {
 qmatrix getRandomDiagonalUnitary(int numQb) {
     DEMAND( numQb >= 1 );
 
-    qmatrix matr = getZeroMatrix(pow2(numQb));
+    qmatrix matr = getZeroMatrix(getPow2(numQb));
 
     for (size_t i=0; i<matr.size(); i++)
-        matr[i][i] = expI(getRandomReal(0,4*M_PI));
+        matr[i][i] = getExpI(getRandomReal(0,4*M_PI));
 
     return matr;
 }

--- a/tests/utils/random.cpp
+++ b/tests/utils/random.cpp
@@ -1,0 +1,335 @@
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+#include "macros.hpp"
+#include "linalg.hpp"
+#include "lists.hpp"
+#include "quest.h"
+
+#include <random>
+#include <vector>
+
+using std::vector;
+
+
+
+/*
+ * RNG
+ */
+
+
+static std::mt19937 RNG;
+
+
+void setRandomTestStateSeeds() {
+
+    // generate a random seed from hardware rng
+    std::random_device cspnrg;
+    unsigned seed = cspnrg();
+    
+    // seed QuEST, using only the root node's seed
+    setSeeds(&seed, 1);
+
+    // broadcat root node seed to all nodes
+    getSeeds(&seed);
+
+    // seed rand()
+    srand(seed);
+
+    // seed RNG
+    RNG.seed(seed);
+}
+
+
+
+/*
+ * SCALAR
+ */
+
+
+qreal getRandomReal(qreal min, qreal max) {
+    DEMAND( min <= max );
+
+    qreal r = rand() / (qreal) RAND_MAX;
+    return min + r * (max - min);
+}
+
+
+int getRandomInt(int min, int max) {
+    return (int) round(getRandomReal(min, max-1));
+}
+
+
+qcomp getRandomComplex() {
+    qreal re = getRandomReal(-1,1);
+    qreal im = getRandomReal(-1,1);
+    return qcomp(re, im);
+}
+
+
+
+/*
+ * VECTOR
+ */
+
+
+qvector getRandomVector(size_t dim) { 
+
+    qvector vec = getZeroVector(dim);
+
+    for (auto& elem : vec)
+        elem = getRandomComplex();
+        
+    return vec;
+}
+
+
+vector<qvector> getRandomOrthonormalVectors(size_t dim, int numVecs) {
+    DEMAND( dim >= 1 );
+    DEMAND( numVecs >= 1);
+    
+    vector<qvector> vecs(numVecs);
+
+    // produce each vector in-turn
+    for (int n=0; n<numVecs; n++) {
+
+        // from a random vector
+        vecs[n] = getRandomVector(dim);
+
+        // orthogonalise by substracting projections of existing vectors
+        for (int m=0; m<n; m++)
+            vecs[n] -= vecs[m] * getInnerProduct(vecs[m], vecs[n]);
+
+        // then re-normalise
+        vecs[n] = getNormalised(vecs[n]);
+    }
+
+    return vecs;
+}
+
+
+
+/*
+ * MATRIX
+ */
+
+
+qmatrix getRandomMatrix(size_t dim) {
+    DEMAND( dim > 1 );
+    
+    qmatrix out = getZeroMatrix(dim);
+    qreal max = RAND_MAX;
+
+    for (auto& row : out) {
+        for (auto& elem : row) {
+            
+            // generate 2 normally-distributed random numbers via Box-Muller
+            qreal a = rand()/max;
+            qreal b = rand()/max;
+            
+            // prevent log(0) NaNs
+            if (a == 0)
+                a = 1/max;
+
+            qreal fa = sqrt(-2 * log(a));
+            qreal re = fa * cos(2 * 3.14159265 * b);
+            qreal im = fa * sin(2 * 3.14159265 * b);
+            elem = qcomp(re, im);
+        }
+    }
+    
+    return out;
+}
+
+
+
+/*
+ * PROBABILITIES
+ */
+
+
+vector<qreal> getRandomProbabilities(int numProbs) {
+    
+    vector<qreal> probs(numProbs, 0);
+
+    // generate random unnormalised scalars
+    for (auto& p : probs)
+        p = getRandomReal(0, 1);
+
+    // normalise
+    qreal total = 0;
+    for (auto& p : probs)
+        total += p;
+
+    for (auto& p : probs)
+        p /= total;
+ 
+    return probs;
+}
+
+
+
+/*
+ * STATES
+ */
+
+
+qvector getRandomStateVector(int numQb) {
+
+    return getNormalised(getRandomVector(pow2(numQb)));
+}
+
+
+vector<qvector> getRandomOrthonormalStateVectors(int numQb, int numStates) {
+
+    return getRandomOrthonormalVectors(pow2(numQb), numStates);
+}
+
+
+qmatrix getRandomDensityMatrix(int numQb) {
+    DEMAND( numQb > 0 );
+    
+    // generate random probabilities to weight random pure states
+    int dim = pow2(numQb);
+    vector<qreal> probs = getRandomProbabilities(dim);
+    
+    // add random pure states
+    qmatrix dens = getZeroMatrix(dim);
+    for (int i=0; i<dim; i++) {
+        qvector pure = getRandomStateVector(numQb);
+        dens += probs[i] * getOuterProduct(pure, pure);
+    }
+    
+    return dens;
+}
+
+
+qmatrix getRandomPureDensityMatrix(int numQb) {
+
+    qvector vec = getRandomStateVector(numQb);
+    qmatrix mat = getOuterProduct(vec, vec);
+    return mat;
+}
+
+
+
+/*
+ * OPERATORS
+ */
+
+
+qmatrix getRandomUnitary(int numQb) {
+    DEMAND( numQb >= 1 );
+
+    // create Z ~ random complex matrix (distribution not too important)
+    size_t dim = pow2(numQb);
+    qmatrix matrZ = getRandomMatrix(dim);
+    qmatrix matrZT = getTranspose(matrZ);
+
+    // create Z = Q R (via QR decomposition) ...
+    qmatrix matrQT = getOrthonormalisedRows(matrZ);
+    qmatrix matrQ = getTranspose(matrQT);
+    qmatrix matrR = getZeroMatrix(dim);
+
+    // ... where R_rc = (columm c of Z) . (column r of Q) = (row c of ZT) . (row r of QT) = <r|c>
+    for (size_t r=0; r<dim; r++)
+        for (size_t c=r; c<dim; c++)
+            matrR[r][c] = getInnerProduct(matrQT[r], matrZT[c]);
+
+    // create D = normalised diagonal of R
+    qmatrix matrD = getZeroMatrix(dim);
+    for (size_t i=0; i<dim; i++)
+        matrD[i][i] = matrR[i][i] / abs(matrR[i][i]);
+
+    // create U = Q D
+    qmatrix matrU = matrQ * matrD;
+
+    DEMAND( isUnitary(matrU) );
+    return matrU;
+}
+
+
+qmatrix getRandomDiagonalUnitary(int numQb) {
+    DEMAND( numQb >= 1 );
+
+    qmatrix matr = getZeroMatrix(pow2(numQb));
+
+    for (size_t i=0; i<matr.size(); i++)
+        matr[i][i] = expI(getRandomReal(0,4*M_PI));
+
+    return matr;
+}
+
+
+vector<qmatrix> getRandomKrausMap(int numQb, int numOps) {
+    DEMAND( numOps >= 1 );
+
+    // generate random unitaries
+    vector<qmatrix> ops(numOps);
+    for (auto& u : ops)
+        u = getRandomUnitary(numQb);
+
+    // generate random weights
+    vector<qreal> weights(numOps);
+    for (auto& w : weights)
+        w = getRandomReal(0, 1);
+        
+    // normalise random weights
+    qreal sum = 0;
+    for (auto& w : weights)
+        sum += w;
+    for (auto& w : weights)
+        w = sqrt(w/sum);
+        
+    // normalise unitaries according to weights
+    for (int i=0; i<numOps; i++)
+        ops[i] *= weights[i];
+
+    DEMAND( isCompletelyPositiveTracePreserving(ops) );
+    return ops;
+}
+
+
+
+/*
+ * PAULIS
+ */
+
+
+PauliStr getRandomPauliStr(int numQubits) {
+
+    std::string paulis = "";
+    for (int i=0; i<numQubits; i++)
+        paulis += "IXYZ"[getRandomInt(0,4)];
+
+    return getPauliStr(paulis);
+}
+
+
+PauliStr getRandomDiagPauliStr(int numQubits) {
+
+    std::string paulis = "";
+    for (int i=0; i<numQubits; i++)
+        paulis += "IZ"[getRandomInt(0,2)];
+
+    return getPauliStr(paulis);
+}
+
+
+
+/*
+ * QUBITS
+ */
+
+
+vector<int> getRandomSubRange(int start, int endExcl, int numElems) {
+    DEMAND( endExcl >= start );
+    DEMAND( numElems >= 1 );
+    DEMAND( numElems <= endExcl - start );
+
+    // shuffle entire range
+    vector<int> range = getRange(start, endExcl);
+    std::shuffle(range.begin(), range.end(), RNG);
+    
+    // return first subrange
+    return vector<int>(range.begin(), range.begin() + numElems);
+}

--- a/tests/utils/random.hpp
+++ b/tests/utils/random.hpp
@@ -1,0 +1,40 @@
+#ifndef RANDOM_HPP
+#define RANDOM_HPP
+
+#include "qvector.hpp"
+#include "qmatrix.hpp"
+#include "macros.hpp"
+#include "linalg.hpp"
+#include "quest.h"
+
+#include <vector>
+using std::vector;
+
+
+void setRandomTestStateSeeds();
+
+int getRandomInt(int min, int max);
+qreal getRandomReal(qreal min, qreal max);
+qcomp getRandomComplex();
+
+qvector getRandomVector(size_t dim);
+qmatrix getRandomMatrix(size_t dim);
+
+qvector getRandomStateVector(int numQb);
+qmatrix getRandomDensityMatrix(int numQb);
+qmatrix getRandomPureDensityMatrix(int numQb);
+
+qmatrix getRandomUnitary(int numQb);
+qmatrix getRandomDiagonalUnitary(int numQb);
+vector<qmatrix> getRandomKrausMap(int numQb, int numOps);
+
+PauliStr getRandomPauliStr(int numQubits);
+PauliStr getRandomDiagPauliStr(int numQubits);
+
+vector<int> getRandomSubRange(int start, int endExcl, int numElems);
+vector<qreal> getRandomProbabilities(int numProbs);
+vector<qvector> getRandomOrthonormalVectors(size_t dim, int numVecs);
+vector<qvector> getRandomOrthonormalStateVectors(int numQb, int numStates);
+
+
+#endif // RANDOM_HPP


### PR DESCRIPTION
The v4 utility functions are refactored and significantly de-cluttered from v3, and separated into semantic files. The unit tests are also placed into a 'unit' subfolder, with an 'integration' subfolder reserved for future integration tests.

QMatrix and QVector respectively became qmatrix and qvector, and several functions were renamed (notably, areEqual() became a == overload).

These changes were motivated by the possibility of exposing testing utilities to users for use in their own C++ source, to leverage the convenient matrix algebra/overloads and random generators