### PR TITLE
FindCUQUANTUM.cmake: typo correction

### DIFF
--- a/cmake/FindCUQUANTUM.cmake
+++ b/cmake/FindCUQUANTUM.cmake
@@ -86,7 +86,7 @@ if(CUQUANTUM_FOUND AND NOT TARGET CUQUANTUM::cuQuantum)
   target_link_libraries(CUQUANTUM::cuQuantum INTERFACE ${CUQUANTUM_LIBRARIES})
   target_link_directories(CUQUANTUM::cuQuantum INTERFACE ${CUQUANTUM_LIBRARY_DIRS})
 
-  if(NOT TARGET CUQUANTUM::cuStaterVec)
+  if(NOT TARGET CUQUANTUM::cuStateVec)
     add_library(CUQUANTUM::cuStateVec INTERFACE IMPORTED)
     target_include_directories(CUQUANTUM::cuStateVec INTERFACE ${CUQUANTUM_INCLUDE_DIRS})
     target_link_directories(CUQUANTUM::cuStateVec INTERFACE ${CUQUANTUM_LIBRARY_DIRS})


### PR DESCRIPTION
Apologies for PR spam 😅 

Spotted this while I was checking to see if I'd bothered to set `_FOUND` flags for the individual libraries. I haven't, but if for example you needed a specific minimum version of cuStateVec this could be split into three find project files rather than this monolithic cuQuantum one. 

All a bit messy of course because you can only download them as one...