### PR TITLE
Fixing MSVC Compiler Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,12 @@ option(
 )
 message(STATUS "Deprecated API support is turned ${ENABLE_DEPRECATED_API}. Set ENABLE_DEPRECATED_API to modify.")
 
+# Windows Specific Options
+if(MSVC)
+    set(ENABLE_MULTITHREADING OFF)
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
 ## Library
 
 add_library(QuEST)
@@ -175,7 +181,7 @@ target_include_directories(QuEST
 target_compile_features(QuEST
   PUBLIC
   c_std_11
-  cxx_std_17
+  cxx_std_20
 )
 
 # Turn on all compiler warnings
@@ -286,7 +292,7 @@ add_subdirectory(quest)
 add_executable(min_example
   examples/tutorials/min_example.cpp
 )
-target_link_libraries(min_example PUBLIC QuEST::QuEST)
+target_link_libraries(min_example PRIVATE QuEST::QuEST)
 
 install(TARGETS min_example
   RUNTIME

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ message(STATUS "Deprecated API support is turned ${ENABLE_DEPRECATED_API}. Set E
 # Windows Specific Options
 if(WIN32)
     set(ENABLE_MULTITHREADING OFF)
+    message(WARNING "multithreading disabled on Windows")
     # Force MSVC to export all symbols in a shared library, like GCC and clang
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     if (ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(GNUInstallDirs)
 
 # Maths
-if (NOT MSVC)
+if (NOT WIN32)
   find_library(MATH_LIBRARY m REQUIRED)
 endif()
 
@@ -155,9 +155,13 @@ option(
 message(STATUS "Deprecated API support is turned ${ENABLE_DEPRECATED_API}. Set ENABLE_DEPRECATED_API to modify.")
 
 # Windows Specific Options
-if(MSVC)
+if(WIN32)
     set(ENABLE_MULTITHREADING OFF)
-    set(BUILD_SHARED_LIBS OFF)
+    # Force MSVC to export all symbols in a shared library, like GCC and clang
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    if (ENABLE_TESTING)
+      set(BUILD_SHARED_LIBS OFF)
+    endif ()
 endif()
 
 ## Library

--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -216,18 +216,19 @@ typedef struct {
 
 static inline CompMatr1 getCompMatr1(qcomp** in) {
 
-    return (CompMatr1) {
+     CompMatr1 out = {
         .numQubits = 1,
         .numRows = 2,
         .elems = {
             {in[0][0], in[0][1]}, 
             {in[1][0], in[1][1]}}
     };
+    return out;
 }
 
 static inline CompMatr2 getCompMatr2(qcomp** in) {
 
-    return (CompMatr2) {
+    CompMatr2 out = {
         .numQubits = 2,
         .numRows = 4,
         .elems = {
@@ -236,25 +237,28 @@ static inline CompMatr2 getCompMatr2(qcomp** in) {
             {in[2][0], in[2][1], in[2][2], in[2][3]},
             {in[3][0], in[3][1], in[3][2], in[3][3]}}
     };
+    return out;
 }
 
 
 static inline DiagMatr1 getDiagMatr1(qcomp* in) {
 
-    return (DiagMatr1) {
+    DiagMatr1 out = {
         .numQubits = 1,
         .numElems = 2,
         .elems = {in[0], in[1]}
     };
+    return out;
 }
 
 static inline DiagMatr2 getDiagMatr2(qcomp* in) {
 
-    return (DiagMatr2) {
+    DiagMatr2 out = {
         .numQubits = 2,
         .numElems = 4,
         .elems = {in[0], in[1], in[2], in[3]}
     };
+    return out;
 }
 
 

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -4,7 +4,7 @@
  * arbitrary matrices) upon Quregs, which can be
  * statevectors or density matrices
  */
-
+#define _USE_MATH_DEFINES
 #include "quest/include/qureg.h"
 #include "quest/include/matrices.h"
 #include "quest/include/operations.h"

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -1584,7 +1584,7 @@ void localiser_densmatr_oneQubitDamping(Qureg qureg, int qubit, qreal prob) {
 
 CompMatr getCompMatrFromSuperOp(SuperOp op) {
 
-    return (CompMatr) {
+     CompMatr out = {
         // superoperator acts on twice as many qubits
         .numQubits = 2 * op.numQubits,
         .numRows = op.numRows,
@@ -1596,6 +1596,7 @@ CompMatr getCompMatrFromSuperOp(SuperOp op) {
         .cpuElems = op.cpuElems,
         .gpuElemsFlat = op.gpuElemsFlat
     };
+    return out;
 }
 
 

--- a/quest/src/core/printer.cpp
+++ b/quest/src/core/printer.cpp
@@ -24,10 +24,12 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <memory>
 #include <vector>
 #include <tuple>
 #include <string>
 #include <new>
+
 
 using std::cout;
 using std::endl;
@@ -144,19 +146,40 @@ void printer_setMaxNumPrintedSigFig(int numSigFigs) {
 #define GET_STR(x) GET_STR_INTERNAL(x)
 
 
+inline std::string demangleTypeName(const char* mangledName) {
+#if defined(__GNUC__) || defined(__clang__)
+    int status = 0;
+
+    // __cxa_demangle returns a malloc'd string, so we wrap it in a unique_ptr
+    // for automatic cleanup. (The custom deleter calls free().)
+    std::unique_ptr<char, void(*)(void*)> demangled(
+        abi::__cxa_demangle(mangledName, nullptr, nullptr, &status),
+        std::free
+    );
+
+    if (status == 0 && demangled) {
+        return demangled.get();
+    } else {
+        // fall back to the mangled name
+        return mangledName;
+    }
+#else
+    // e.g. MSVC or unknown compiler: no standard demangler
+    return mangledName;
+#endif
+}
+
+
 // type T can be anything in principle, although it's currently only used for qcomp
-template<typename T> 
-string getTypeName(T) { 
+template <typename T>
+std::string getTypeName(T _unused) {
+    // For MSVC, typeid(T).name() typically returns something like "class Foo"
+    // or "struct Foo", but it's still not exactly "Foo".
+    // For GCC/Clang, you get a raw "mangled" name, e.g. "N3FooE".
+    const char* rawName = typeid(T).name();
 
-    // get possibly-mangled type name
-    string name = typeid(T).name();
-
-    // non-MSVC compilers can de-mangle
-    #ifdef DEMANGLE_TYPE
-        name = abi::__cxa_demangle(name.c_str(), nullptr, nullptr, nullptr);
-    #endif
-
-    return name;
+    // We'll try to demangle if we can:
+    return demangleTypeName(rawName);
 }
 
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -986,7 +986,7 @@ namespace report {
 /*
  * INVALID INPUT RESPONSE BEHAVIOUR
  */
-
+extern "C" {
 // default C/C++ compatible error response is to simply exit in fail state
 void default_invalidQuESTInputError(const char* msg, const char* func) {
 
@@ -1008,7 +1008,9 @@ void default_invalidQuESTInputError(const char* msg, const char* func) {
 }
 
 // enable default error response to be user-overriden as a weak symbol (even in C, and on Windows)
-extern "C" {
+
+    // Always declare invalidQuESTInputError so the compiler sees it:
+    void invalidQuESTInputError(const char* msg, const char* func);
 
     #ifndef _WIN32
         #pragma weak invalidQuESTInputError

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(tests
   main.cpp
 )
-target_link_libraries(tests PUBLIC QuEST::QuEST Catch2::Catch2)
+target_link_libraries(tests PRIVATE QuEST::QuEST Catch2::Catch2)
 
 add_subdirectory(unit)
 add_subdirectory(utils)

--- a/tests/utils/linalg.cpp
+++ b/tests/utils/linalg.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include "qvector.hpp"
 #include "qmatrix.hpp"
 #include "linalg.hpp"

--- a/tests/utils/random.cpp
+++ b/tests/utils/random.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include "qvector.hpp"
 #include "qmatrix.hpp"
 #include "macros.hpp"


### PR DESCRIPTION
**Fixes #538**

### Summary

This PR resolves compiler errors on MSVC by replacing non-standard usage of designated initializers combined with C-style casts. Previously, the code used:

```c++
return (CompMatr1) {
    .numQubits = 1,
    .numRows = 2,
    .elems = {
        {in[0][0], in[0][1]},
        {in[1][0], in[1][1]}
    }
};
```

which is incompatible with MSVC. The updated implementation ensures standard compliance by using:

```c++
CompMatr1 out = {
    .numQubits = 1,
    .numRows = 2,
    .elems = {
        {in[0][0], in[0][1]},
        {in[1][0], in[1][1]}
    }
};
return out;
```

Additionally, functions relying on GCC-specific intrinsics have been refactored to improve cross-compiler compatibility.

### Background

Attempting to build the v4 branch on Windows with MSVC resulted in the following errors:

```
E:\projects\QuEST\quest\include\matrices.h(220,9): error C7555: use of designated initializers requires at least '/std:c++20'
```

and

```
E:\projects\QuEST\quest\include\matrices.h(219,12): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
```

These errors occurred due to a combination of designated initializers and a C-style cast, which MSVC does not support, even with C++20 enabled. Removing the cast resolves this issue.

### Testing & Known Issues

- **Static Library Mode:** Successfully builds and passes all tests.
- **Shared Library Mode:** The build fails and requires further investigation.

Cheers,  
Erich

