### PR TITLE
added row-major CPU matrices

### DIFF
--- a/quest/include/channels.h
+++ b/quest/include/channels.h
@@ -33,7 +33,15 @@ typedef struct {
     int numQubits;
     qindex numRows;
     
+    // 2D CPU memory, which users can manually overwrite like cpuElems[i][j],
+    // but which actually merely aliases the 1D cpuElemsFlat below
     qcomp** cpuElems;
+
+    // row-major flattened elements of cpuElems, always allocated
+    qcomp* cpuElemsFlat;
+
+    // row-major flattened elems in GPU memory, allocated 
+    // only and always in GPU-enabled QuEST environments
     qcomp* gpuElemsFlat;
 
     // whether the user has ever synchronised memory to the GPU, which is performed automatically

--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -77,11 +77,15 @@ typedef struct {
     // made after an initial sync have been re-synched. This is a heap pointer, as above.
     int* wasGpuSynced;
 
-    // 2D CPU memory; not const, so users can overwrite addresses (e.g. with nullptr)
+    // 2D CPU memory, which users can manually overwrite like cpuElems[i][j],
+    // but which actually merely aliases the 1D cpuElemsFlat below
     qcomp** cpuElems;
 
-    // row-flattened elems in GPU memory, allocated only
-    // and always in GPU-enabled QuEST environments
+    // row-major flattened elements of cpuElems, always allocated 
+    qcomp* cpuElemsFlat;
+
+    // row-major flattened elems in GPU memory, allocated 
+    // only and always in GPU-enabled QuEST environments
     qcomp* gpuElemsFlat;
 
 } CompMatr;

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -588,6 +588,11 @@ void error_gpuMemSyncQueriedButEnvNotGpuAccelerated() {
     raiseInternalError("A function checked whether persistent GPU memory (such as in a CompMatr) had been synchronised, but the QuEST environment is not GPU accelerated.");  
 }
 
+void error_gpuDeadCopyMatrixFunctionCalled() {
+
+    raiseInternalError("The internal GPU function copyMatrixIfGpuCompiled() was called, though is intended as dead-code - matrices needing copying to GPU should be stored as flat row-wise lists.");
+}
+
 void assert_quregIsGpuAccelerated(Qureg qureg) {
 
     if (!qureg.isGpuAccelerated)

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -228,6 +228,8 @@ void error_gpuMemSyncQueriedButEnvNotGpuAccelerated();
 
 void error_gpuUnexpectedlyInaccessible();
 
+void error_gpuDeadCopyMatrixFunctionCalled();
+
 void assert_gpuIsAccessible();
 
 void assert_quregIsGpuAccelerated(Qureg qureg);

--- a/quest/src/cpu/cpu_config.hpp
+++ b/quest/src/cpu/cpu_config.hpp
@@ -41,6 +41,9 @@ int cpu_getOpenmpThreadInd();
 qcomp* cpu_allocArray(qindex length);
 void cpu_deallocArray(qcomp* arr);
 
+qcomp** cpu_allocAndInitMatrixWrapper(qcomp* arr, qindex dim);
+void cpu_deallocMatrixWrapper(qcomp** wrapper);
+
 qcomp** cpu_allocMatrix(qindex dim);
 void cpu_deallocMatrix(qcomp** matrix, qindex dim);
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -333,6 +333,14 @@ void copyArrayIfGpuCompiled(qcomp* cpuArr, qcomp* gpuArr, qindex numElems, enum 
 void copyMatrixIfGpuCompiled(qcomp** cpuMatr, qcomp* gpuArr, qindex matrDim, enum CopyDirection direction) {
 #if COMPILE_CUDA
 
+    // NOTE:
+    // this function copies a 2D CPU matrix into a 1D row-major GPU array,
+    // although this is not actually needed by the QuEST backend which
+    // maintains 1D row-major CPU memories merely aliased by 2D structures
+    // for the user's benefit. As such, this is dead code, but preserved in
+    // case it is ever needed (like if custom user 2D data was needed in GPU).
+    error_gpuDeadCopyMatrixFunctionCalled();
+
     // for completeness, we permit copying from the 1D GPU memory to the 2D CPU memory,
     // although we never actually have the need to do this!
     auto flag = (direction == TO_HOST)? 
@@ -400,11 +408,25 @@ void gpu_copyGpuToCpu(Qureg qureg) {
 
 void gpu_copyCpuToGpu(CompMatr matr) {
     assertHeapObjectGpuMemIsAllocated(matr);
-    copyMatrixIfGpuCompiled(matr.cpuElems, util_getGpuMemPtr(matr), matr.numRows, TO_DEVICE);
+
+    // note matr.cpuElems is merely a 2D alias for matr.cpuElemsFlat, which
+    // matches the format of matr.gpuElemsFlat. Ergo, we do not invoke 
+    // copyMatrixIfGpuCompiled(), and instead more efficiently overwrite
+    // the contiguous memory, which retains any user changes to .cpuElems
+
+    qindex numElems = matr.numRows * matr.numRows;
+    copyArrayIfGpuCompiled(matr.cpuElemsFlat, util_getGpuMemPtr(matr), numElems, TO_DEVICE);
 }
 void gpu_copyGpuToCpu(CompMatr matr) {
     assertHeapObjectGpuMemIsAllocated(matr);
-    copyMatrixIfGpuCompiled(matr.cpuElems, util_getGpuMemPtr(matr), matr.numRows, TO_HOST);
+
+    // note matr.cpuElems is merely a 2D alias for matr.cpuElemsFlat, which
+    // matches the format of matr.gpuElemsFlat. Ergo, we do not invoke 
+    // copyMatrixIfGpuCompiled(), and instead more efficiently overwrite
+    // the contiguous matr.cpuElemsFlat, which users can access via .cpuElems
+
+    qindex numElems = matr.numRows * matr.numRows;
+    copyArrayIfGpuCompiled(matr.cpuElemsFlat, util_getGpuMemPtr(matr), numElems, TO_HOST);
 }
 
 
@@ -420,11 +442,25 @@ void gpu_copyGpuToCpu(DiagMatr matr) {
 
 void gpu_copyCpuToGpu(SuperOp op) {
     assertHeapObjectGpuMemIsAllocated(op);
-    copyMatrixIfGpuCompiled(op.cpuElems, util_getGpuMemPtr(op), op.numRows, TO_DEVICE);
+
+    // note op.cpuElems is merely a 2D alias for op.cpuElemsFlat, which
+    // matches the format of op.gpuElemsFlat. Ergo, we do not invoke 
+    // copyMatrixIfGpuCompiled(), and instead more efficiently overwrite
+    // the contiguous memory, which retains any user changes to .cpuElems
+
+    qindex numElems = op.numRows * op.numRows;
+    copyArrayIfGpuCompiled(op.cpuElemsFlat, util_getGpuMemPtr(op), numElems, TO_DEVICE);
 }
 void gpu_copyGpuToCpu(SuperOp op) {
     assertHeapObjectGpuMemIsAllocated(op);
-    copyMatrixIfGpuCompiled(op.cpuElems, util_getGpuMemPtr(op), op.numRows, TO_HOST);
+
+    // note op.cpuElems is merely a 2D alias for op.cpuElemsFlat, which
+    // matches the format of op.gpuElemsFlat. Ergo, we do not invoke 
+    // copyMatrixIfGpuCompiled(), and instead more efficiently overwrite
+    // the contiguous op.cpuElemsFlat, which users can access via .cpuElems
+
+    qindex numElems = op.numRows * op.numRows;
+    copyArrayIfGpuCompiled(op.cpuElemsFlat, util_getGpuMemPtr(op), numElems, TO_HOST);
 }
 
 


### PR DESCRIPTION
replacing the 2D CPU memory of CompMatr and SuperOp, which each retain a 2D alias to the new 1D memory for user convenience.

Existing code which accesses .cpuElems of both these structs remains valid, although some usages may be accelerated by switching to accesing .cpuElemsFlat (like some unit-testing code).

Prompted by discussion #540