### PR TITLE
CMake: minor tweak to hip compilation

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -182,7 +182,7 @@ jobs:
           -DCMAKE_CUDA_ARCHITECTURES=${{ env.cuda_arch }}
           -DCMAKE_HIP_ARCHITECTURES=${{ env.hip_arch }}
           -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
-          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && 'OFF' || 'ON' }}
+          -DINTERPROCEDURAL_OPTIMIZATION=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && 'OFF' || 'ON' }}
 
       # force 'Release' build (needed by MSVC to enable optimisations)
       - name: Compile

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -159,6 +159,22 @@ jobs:
           sudo apt install amdgpu-dkms rocm
           echo "${{ env.rocm_path }}" >> $GITHUB_PATH
 
+      # adjust compiler flags (in OS-agnostic fashion)
+      - name: Adjusting compiler and flags
+        run: |
+          echo "flags=''" >> $GITHUB_ENV
+          echo "compiler=${{ matrix.compiler }}" >> $GITHUB_ENV
+      - name: Disabling LTO on MPI + CUDA
+        if: ${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' }}
+        run: |
+          echo "flags='-fno-lto'" >> $GITHUB_ENV
+      - name: Disabling LTO + RDC on MPI + HIP, using HIPCC
+        if: ${{ matrix.mpi == 'ON' && matrix.hip == 'ON' }}
+        run: |
+          echo "flags='-fno-lto -fno-gpu-rdc'" >> $GITHUB_ENV
+          echo "compiler=hipcc" >> $GITHUB_ENV
+          export MPICXX=hipcc
+
       # invoke cmake, disabling LTO (it duplicates symbols with CUDA + MPI)
       - name: Configure CMake
         run: >
@@ -175,8 +191,8 @@ jobs:
           -DENABLE_CUQUANTUM=${{ matrix.cuquantum }}
           -DCMAKE_CUDA_ARCHITECTURES=${{ env.cuda_arch }}
           -DCMAKE_HIP_ARCHITECTURES=${{ env.hip_arch }}
-          -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
-          -DCMAKE_CXX_FLAGS=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && '-fno-lto' || '' }}
+          -DCMAKE_CXX_COMPILER=${{ env.compiler }}
+          -DCMAKE_CXX_FLAGS=${{ env.flags }}
 
       # force 'Release' build (needed by MSVC to enable optimisations)
       - name: Compile

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -191,6 +191,8 @@ jobs:
           -DENABLE_CUQUANTUM=${{ matrix.cuquantum }}
           -DCMAKE_CUDA_ARCHITECTURES=${{ env.cuda_arch }}
           -DCMAKE_HIP_ARCHITECTURES=${{ env.hip_arch }}
+          -DGPU_TARGETS=${{ env.hip_arch }}
+          -DAMDGPU_TARGETS=${{ env.hip_arch }}
           -DCMAKE_CXX_COMPILER=${{ env.compiler }}
           -DCMAKE_CXX_FLAGS=${{ env.flags }}
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -88,6 +88,12 @@ jobs:
           - hip: ON
             os: windows-latest
 
+          # cannot presently compile HIP + MPI; the linker fails with
+          # "undefined reference to 'vtable for thrust::system::system_error'
+          # (see failed attempted solutions in PR #554)
+          - hip: ON
+            mpi: ON
+
     # constants
     env:
       build_dir: "build"
@@ -159,25 +165,6 @@ jobs:
           sudo apt install amdgpu-dkms rocm
           echo "${{ env.rocm_path }}" >> $GITHUB_PATH
 
-      # adjust compiler flags (in OS-agnostic fashion)
-      - name: Adjusting compiler and flags
-        run: |
-          echo "flags=''" >> $GITHUB_ENV
-          echo "compiler=${{ matrix.compiler }}" >> $GITHUB_ENV
-      - name: Disabling LTO on MPI + CUDA
-        if: ${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' }}
-        run: |
-          echo "flags='-fno-lto'" >> $GITHUB_ENV
-      - name: Using hipcc as base compiler (even MPI or not)
-        if: ${{ matrix.hip == 'ON' }}
-        run: |
-          echo "compiler=hipcc" >> $GITHUB_ENV
-      # - name: Disabling LTO + RDC on MPI + HIP, using HIPCC
-      #   if: ${{ matrix.mpi == 'ON' && matrix.hip == 'ON' }}
-      #   run: |
-      #     echo "compiler=hipcc" >> $GITHUB_ENV
-      #     export MPICXX=hipcc
-
       # invoke cmake, disabling LTO (it duplicates symbols with CUDA + MPI)
       - name: Configure CMake
         run: >
@@ -194,10 +181,8 @@ jobs:
           -DENABLE_CUQUANTUM=${{ matrix.cuquantum }}
           -DCMAKE_CUDA_ARCHITECTURES=${{ env.cuda_arch }}
           -DCMAKE_HIP_ARCHITECTURES=${{ env.hip_arch }}
-          -DGPU_TARGETS=${{ env.hip_arch }}
-          -DAMDGPU_TARGETS=${{ env.hip_arch }}
-          -DCMAKE_CXX_COMPILER=${{ env.compiler }}
-          -DCMAKE_CXX_FLAGS=${{ env.flags }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && 'OFF' || 'ON' }}
 
       # force 'Release' build (needed by MSVC to enable optimisations)
       - name: Compile

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -182,7 +182,7 @@ jobs:
           -DCMAKE_CUDA_ARCHITECTURES=${{ env.cuda_arch }}
           -DCMAKE_HIP_ARCHITECTURES=${{ env.hip_arch }}
           -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
-          -DINTERPROCEDURAL_OPTIMIZATION=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && 'OFF' || 'ON' }}
+          -DCMAKE_CXX_FLAGS=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && '-fno-lto' || '' }}
 
       # force 'Release' build (needed by MSVC to enable optimisations)
       - name: Compile

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -88,11 +88,6 @@ jobs:
           - hip: ON
             os: windows-latest
 
-          # cannot presently compile HIP + MPI; the linker fails with
-          # "undefined reference to 'vtable for thrust::system::system_error'
-          - hip: ON
-            mpi: ON
-
     # constants
     env:
       build_dir: "build"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -168,12 +168,15 @@ jobs:
         if: ${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' }}
         run: |
           echo "flags='-fno-lto'" >> $GITHUB_ENV
-      - name: Disabling LTO + RDC on MPI + HIP, using HIPCC
-        if: ${{ matrix.mpi == 'ON' && matrix.hip == 'ON' }}
+      - name: Using hipcc as base compiler (even MPI or not)
+        if: ${{ matrix.hip == 'ON' }}
         run: |
-          echo "flags='-fno-lto -fno-gpu-rdc'" >> $GITHUB_ENV
           echo "compiler=hipcc" >> $GITHUB_ENV
-          export MPICXX=hipcc
+      # - name: Disabling LTO + RDC on MPI + HIP, using HIPCC
+      #   if: ${{ matrix.mpi == 'ON' && matrix.hip == 'ON' }}
+      #   run: |
+      #     echo "compiler=hipcc" >> $GITHUB_ENV
+      #     export MPICXX=hipcc
 
       # invoke cmake, disabling LTO (it duplicates symbols with CUDA + MPI)
       - name: Configure CMake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,13 +294,12 @@ if (ENABLE_HIP)
 
   find_package(HIP REQUIRED)
   message(STATUS "Found HIP: " ${HIP_VERSION})
-  
+
   target_compile_definitions(QuEST
     PUBLIC COMPILE_CUQUANTUM=0
-    PUBLIC __HIP_PLATFORM_AMD__
   )
 
-  target_link_libraries(QuEST PRIVATE hip::amdhip64)
+  target_link_libraries(QuEST PRIVATE hip::host)
 
   if (VERBOSE_LIB_NAME)
     string(CONCAT LIB_NAME ${LIB_NAME} "+hip")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,13 +293,14 @@ if (ENABLE_HIP)
   set_property(TARGET QuEST PROPERTY HIP_STANDARD 20)
 
   find_package(HIP REQUIRED)
+  find_package(rocthrust REQUIRED)
+
   message(STATUS "Found HIP: " ${HIP_VERSION})
 
-  target_compile_definitions(QuEST
-    PUBLIC COMPILE_CUQUANTUM=0
-  )
+  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=0)
 
   target_link_libraries(QuEST PRIVATE hip::host)
+  target_link_libraries(QuEST PRIVATE roc::rocthrust)
 
   if (VERBOSE_LIB_NAME)
     string(CONCAT LIB_NAME ${LIB_NAME} "+hip")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,14 +293,10 @@ if (ENABLE_HIP)
   set_property(TARGET QuEST PROPERTY HIP_STANDARD 20)
 
   find_package(HIP REQUIRED)
-  find_package(rocthrust REQUIRED)
-
   message(STATUS "Found HIP: " ${HIP_VERSION})
 
   target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=0)
-
   target_link_libraries(QuEST PRIVATE hip::host)
-  target_link_libraries(QuEST PRIVATE roc::rocthrust)
 
   if (VERBOSE_LIB_NAME)
     string(CONCAT LIB_NAME ${LIB_NAME} "+hip")


### PR DESCRIPTION
Hi Tyson, 

Without wishing to traumatise you further, I thought I'd have a look into the AMD GPU CI failures, you were battling yesterday. I can't see any obvious fix unfortunately. One thing to try might be adding:
```
find_package(rocthrust REQUIRED)
target_link_libraries(QuEST PRIVATE roc::rocthrust)
```
however, when I tried that on A2 it a) broke the ability for us to compile the non-GPU code with anything but hipcc, as it adds the offload target flag everywhere, and b) lead to an unexpected link-time failure. 

It might be more interesting to just try `find_package(rocthrust REQUIRED)` to check that the build system does actually see that package _somewhere_. From brief inspection it looks like rocThrust is a header only template libary, so there shouldn't need to be any actual linkage, just the right include directories. I just ran compilation with `-H` and we for sure are picking up these includes from the generic hip target on ARCHER2, so I would _expect_ the same to be true elsewhere, but this could be ROCm version dependent, which may be the issue on the CI. I can see in the logs that `rocmthrust-dev` is on the install list so it would be surprising.

Anyway -- the two actual things which are in this PR!
- ROCm documentation suggests using `hip::host` as the link target. I checked the CMake files and it is just an interface target to `hip::amdhip64`, so it should (and does as far as I can tell) generate the same build files, but ought to be more robust across platforms as it's what AMD expects. 
- I removed the definition of `__HIP_PLATFORM_AMD__` as CMake adds this anyway when the target language is HIP, so it ends up double defined in the compile line currently. That doesn't break anything, but it's just cruft.