### PR TITLE
tidied heap flags

### DIFF
--- a/quest/include/channels.h
+++ b/quest/include/channels.h
@@ -102,7 +102,7 @@ typedef struct {
 
     // CPTP-ness is determined at validation; 0 or 1, or -1 to indicate unknown. The flag is 
     // stored in heap so even copies of structs are mutable, but pointer itself is immutable.
-    int* isCPTP;
+    int* isApproxCPTP;
 
 } KrausMap;
 

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -90,14 +90,14 @@ void setValidationEpsilon(qreal eps) {
     validate_newEpsilonValue(eps, __func__);
 
     validateconfig_setEpsilon(eps);
-    util_setEpsilonSensitiveStructFieldsToUnknown();
+    util_setEpsilonSensitiveHeapFlagsToUnknown();
 }
 
 void setValidationEpsilonToDefault() {
     validate_envIsInit(__func__);
 
     validateconfig_setEpsilonToDefault();
-    util_setEpsilonSensitiveStructFieldsToUnknown();
+    util_setEpsilonSensitiveHeapFlagsToUnknown();
 }
 
 qreal getValidationEpsilon() {

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -187,14 +187,14 @@ template <class T>
 void setInitialHeapFlags(T matr) {
 
     // set initial propreties of the newly created matrix to unknown
-    *(matr.isApproxUnitary)     = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
-    *(matr.isApproxHermitian)   = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
+    util_setFlagToUnknown(matr.isApproxUnitary);
+    util_setFlagToUnknown(matr.isApproxHermitian);
 
     // only diagonal matrices (which can be exponentiated)
     // have these additional fields
     if constexpr (!util_isDenseMatrixType<T>()) {
-        *(matr.isApproxNonZero)       = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
-        *(matr.isStrictlyNonNegative) = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
+        util_setFlagToUnknown(matr.isApproxNonZero);
+        util_setFlagToUnknown(matr.isStrictlyNonNegative);
     }
 
     // indicate that GPU memory has not yet been synchronised
@@ -228,8 +228,9 @@ extern "C" CompMatr createCompMatr(int numQubits) {
 
         // allocate flags in the heap so that struct copies are mutable
         .isApproxUnitary    = util_allocEpsilonSensitiveHeapFlag(), // nullptr if failed
-        .isApproxHermitian  = util_allocEpsilonSensitiveHeapFlag(), // nullptr if failed
-        .wasGpuSynced = cpu_allocHeapFlag(),                        // nullptr if failed
+        .isApproxHermitian  = util_allocEpsilonSensitiveHeapFlag(),
+
+        .wasGpuSynced = cpu_allocHeapFlag(), // nullptr if failed
 
         .cpuElems = cpu_allocAndInitMatrixWrapper(cpuMem, numRows), // nullptr if failed
         .cpuElemsFlat = cpuMem,
@@ -345,14 +346,14 @@ void markMatrixAsSynced(T matr) {
 
     // indicate that we do not know the revised matrix properties;
     // we defer establishing that until validation needs to check them
-    *(matr.isApproxUnitary)     = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
-    *(matr.isApproxHermitian)   = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
+    util_setFlagToUnknown(matr.isApproxUnitary);
+    util_setFlagToUnknown(matr.isApproxHermitian);
 
     // only diagonal matrices (which can be exponentiated)
     // have these additional fields
     if constexpr (!util_isDenseMatrixType<T>()) {
-        *(matr.isApproxNonZero)       = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
-        *(matr.isStrictlyNonNegative) = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
+        util_setFlagToUnknown(matr.isApproxNonZero);
+        util_setFlagToUnknown(matr.isStrictlyNonNegative);
     }
 }
 

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -401,7 +401,7 @@ extern "C" PauliStrSum createPauliStrSum(PauliStr* strings, qcomp* coeffs, qinde
 
     // otherwise copy given data into new heap structure, and set initial flags
     cpu_copyPauliStrSum(out, strings, coeffs);
-    *(out.isApproxHermitian) = validate_STRUCT_PROPERTY_UNKNOWN_FLAG;
+    util_setFlagToUnknown(out.isApproxHermitian);
 
     return out;
 }

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -315,7 +315,9 @@ int* util_allocEpsilonSensitiveHeapFlag();
 
 void util_deallocEpsilonSensitiveHeapFlag(int* ptr);
 
-void util_setEpsilonSensitiveStructFieldsToUnknown();
+void util_setEpsilonSensitiveHeapFlagsToUnknown();
+
+void util_setFlagToUnknown(int* ptr);
 
 
 

--- a/tests/unit/channels.cpp
+++ b/tests/unit/channels.cpp
@@ -153,11 +153,14 @@ TEST_CASE( "destroyKrausMap", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer interferes with un-initialised struct values
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             KrausMap m;
             REQUIRE_THROWS_WITH( destroyKrausMap(m), ContainsSubstring("Invalid KrausMap") && ContainsSubstring("not created") );
         }
+        #endif
     }
 }
 
@@ -196,13 +199,16 @@ TEST_CASE( "syncKrausMap", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             KrausMap m;
             REQUIRE_THROWS_WITH( syncKrausMap(m), ContainsSubstring("Invalid KrausMap") && ContainsSubstring("not created") );
         }
+        #endif
         #endif
     }
 }
@@ -264,6 +270,15 @@ TEST_CASE( "setKrausMap", TEST_CATEGORY ) {
 
         int err = GENERATE( -1, +1 );
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
+        SECTION( "not created" ) {
+
+            KrausMap bad;
+            REQUIRE_THROWS_WITH( setKrausMap(bad, getRandomKrausMap(numQubits, numOps)), ContainsSubstring("invalid") );
+        }
+        #endif
+
         SECTION( "inconsistent dimensions" ) {
 
             REQUIRE_THROWS_WITH( setKrausMap(map, getRandomKrausMap(numQubits+err, numOps)), ContainsSubstring("dimension") );
@@ -315,6 +330,15 @@ TEST_CASE( "setInlineKrausMap", TEST_CATEGORY ) {
         KrausMap map = createKrausMap(numQubits, numOps);
 
         int err = GENERATE( -1, +1 );
+
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
+        SECTION( "not created" ) {
+
+            KrausMap bad;
+            REQUIRE_THROWS_WITH( setInlineKrausMap(bad, numQubits, numOps, getRandomKrausMap(numQubits, numOps)), ContainsSubstring("invalid") );
+        }
+        #endif
 
         SECTION( "macro parameters" ) {
 
@@ -509,13 +533,16 @@ TEST_CASE( "syncSuperOp", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             SuperOp m;
             REQUIRE_THROWS_WITH( syncSuperOp(m), ContainsSubstring("invalid fields") );
         }
+        #endif
         #endif
     }
 }
@@ -531,11 +558,14 @@ TEST_CASE( "destroySuperOp", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer interferes with un-initialised struct values
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             SuperOp m;
             REQUIRE_THROWS_WITH( destroySuperOp(m), ContainsSubstring("invalid fields") );
         }
+        #endif
     }
 }
 
@@ -590,14 +620,17 @@ TEST_CASE( "setSuperOp", TEST_CATEGORY ) {
 
         SuperOp op = createSuperOp(1);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             SuperOp bad;
             qcomp** dummy;
             REQUIRE_THROWS_WITH( setSuperOp(bad, dummy), ContainsSubstring("invalid fields") );
         }
+        #endif
         #endif
 
         SECTION( "null pointer" ) {
@@ -647,13 +680,16 @@ TEST_CASE( "setInlineSuperOp", TEST_CATEGORY ) {
 
         SuperOp op = createSuperOp(1);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             SuperOp bad;
             REQUIRE_THROWS_WITH( setInlineSuperOp(bad, 1, {{}}), ContainsSubstring("invalid fields") );
         }
+        #endif
         #endif
 
         SECTION( "mismatching dimension" ) {

--- a/tests/unit/channels.cpp
+++ b/tests/unit/channels.cpp
@@ -63,7 +63,7 @@ TEST_CASE( "createKrausMap", TEST_CATEGORY ) {
         REQUIRE( map.superop.numRows == getPow2(2 * numQubits) );
 
         // verify default fields
-        REQUIRE( *(map.isCPTP) == -1 );
+        REQUIRE( *(map.isApproxCPTP) == -1 );
         REQUIRE( *(map.superop.wasGpuSynced) == 0 );
 
         // verify pointers
@@ -172,9 +172,13 @@ TEST_CASE( "syncKrausMap", TEST_CATEGORY ) {
 
         KrausMap map = createKrausMap(numTargs, numMatrs);
         REQUIRE( *(map.superop.wasGpuSynced) == 0 );
+        
+        *(map.isApproxCPTP) = 0;
 
+        // validate the fields are updated
         syncKrausMap(map);
         REQUIRE( *(map.superop.wasGpuSynced) == 1 );
+        REQUIRE( *(map.isApproxCPTP) == -1 );
 
         // validate the superop gets inferred correctly from the kraus map
         auto matrices = getRandomKrausMap(numTargs, numMatrs);

--- a/tests/unit/matrices.cpp
+++ b/tests/unit/matrices.cpp
@@ -780,15 +780,36 @@ TEST_CASE( "syncCompMatr", TEST_CATEGORY ) {
     SECTION( LABEL_CORRECTNESS ) {
 
         CompMatr matr = createCompMatr(5);
+
         REQUIRE( *(matr.wasGpuSynced) == 0 );
 
-        syncCompMatr(matr);
-        REQUIRE( *(matr.wasGpuSynced) == 1 );
+        SECTION( "overwrites GPU elements" ) {
 
-        // to test that the GPU memory was actually overwritten,
-        // we would need a custom accessor of GPU memory, requiring
-        // the tests are CUDA-compiled - no thank you mam! It is
-        // certain this function works from the other GPU tests.
+            // to test that the GPU memory was actually overwritten,
+            // we would need a custom accessor of GPU memory, requiring
+            // the tests are CUDA-compiled - no thank you mam! It is
+            // certain this function works from the other GPU tests.
+
+            SUCCEED( );
+        }
+
+        SECTION( "sets was-synced flag" ) {
+
+            *(matr.wasGpuSynced) = 0;
+
+            syncCompMatr(matr);
+            REQUIRE( *(matr.wasGpuSynced) == 1 );
+        }
+
+        SECTION( "clears numerical flags" ) {
+
+            *(matr).isApproxHermitian = 1;
+            *(matr).isApproxUnitary   = 0;
+
+            syncCompMatr(matr);
+            REQUIRE( *(matr.isApproxHermitian) == -1 );
+            REQUIRE( *(matr.isApproxUnitary)   == -1 );
+        }
 
         destroyCompMatr(matr);
     }
@@ -811,13 +832,37 @@ TEST_CASE( "syncDiagMatr", TEST_CATEGORY ) {
         DiagMatr matr = createDiagMatr(5);
         REQUIRE( *(matr.wasGpuSynced) == 0 );
 
-        syncDiagMatr(matr);
-        REQUIRE( *(matr.wasGpuSynced) == 1 );
+        SECTION( "overwrites GPU elements" ) {
 
-        // to test that the GPU memory was actually overwritten,
-        // we would need a custom accessor of GPU memory, requiring
-        // the tests are CUDA-compiled - no thank you mam! It is
-        // certain this function works from the other GPU tests.
+            // to test that the GPU memory was actually overwritten,
+            // we would need a custom accessor of GPU memory, requiring
+            // the tests are CUDA-compiled - no thank you mam! It is
+            // certain this function works from the other GPU tests.
+
+            SUCCEED( );
+        }
+
+        SECTION( "sets was-synced flag" ) {
+
+            *(matr.wasGpuSynced) = 0;
+
+            syncDiagMatr(matr);
+            REQUIRE( *(matr.wasGpuSynced) == 1 );
+        }
+
+        SECTION( "clears numerical flags" ) {
+
+            *(matr).isApproxHermitian = 1;
+            *(matr).isApproxUnitary   = 0;
+            *(matr).isApproxNonZero   = 1;
+            *(matr).isStrictlyNonNegative = 0;
+
+            syncDiagMatr(matr);
+            REQUIRE( *(matr.isApproxHermitian) == -1 );
+            REQUIRE( *(matr.isApproxUnitary)   == -1 );
+            REQUIRE( *(matr.isApproxNonZero)   == -1 );
+            REQUIRE( *(matr.isStrictlyNonNegative) == -1 );
+        }
 
         destroyDiagMatr(matr);
     }
@@ -842,9 +887,18 @@ TEST_CASE( "syncFullStateDiagMatr", TEST_CATEGORY ) {
             DYNAMIC_SECTION( label ) {
 
                 *(matrix.wasGpuSynced) = 0;
+                *(matrix).isApproxHermitian = 1;
+                *(matrix).isApproxUnitary   = 0;
+                *(matrix).isApproxNonZero   = 1;
+                *(matrix).isStrictlyNonNegative = 0;
 
                 syncFullStateDiagMatr(matrix);
-                REQUIRE( *(matrix.wasGpuSynced) == 1 );
+                REQUIRE( *(matrix.wasGpuSynced)      == 1 );
+                
+                REQUIRE( *(matrix.isApproxHermitian) == -1 );
+                REQUIRE( *(matrix.isApproxUnitary)   == -1 );
+                REQUIRE( *(matrix.isApproxNonZero)   == -1 );
+                REQUIRE( *(matrix.isStrictlyNonNegative) == -1 );
 
                 // to test that the GPU memory was actually overwritten,
                 // we would need a custom accessor of GPU memory, requiring

--- a/tests/unit/matrices.cpp
+++ b/tests/unit/matrices.cpp
@@ -728,11 +728,14 @@ TEST_CASE( "destroyCompMatr", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             CompMatr m;
             REQUIRE_THROWS_WITH( destroyCompMatr(m), ContainsSubstring("Invalid CompMatr") && ContainsSubstring("not created") );
         }
+        #endif
     }
 }
 
@@ -747,11 +750,14 @@ TEST_CASE( "destroyDiagMatr", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             DiagMatr m;
             REQUIRE_THROWS_WITH( destroyDiagMatr(m), ContainsSubstring("Invalid DiagMatr") && ContainsSubstring("not created") );
         }
+        #endif
     }
 }
 
@@ -766,11 +772,14 @@ TEST_CASE( "destroyFullStateDiagMatr", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             FullStateDiagMatr m;
             REQUIRE_THROWS_WITH( destroyFullStateDiagMatr(m), ContainsSubstring("Invalid FullStateDiagMatr") );
         }
+        #endif
     }
 }
 
@@ -816,11 +825,14 @@ TEST_CASE( "syncCompMatr", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             CompMatr m;
             REQUIRE_THROWS_WITH( syncCompMatr(m), ContainsSubstring("Invalid CompMatr") && ContainsSubstring("not created") );
         }
+        #endif
     }
 }
 
@@ -869,11 +881,14 @@ TEST_CASE( "syncDiagMatr", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             DiagMatr m;
             REQUIRE_THROWS_WITH( syncDiagMatr(m), ContainsSubstring("Invalid DiagMatr") && ContainsSubstring("not created") );
         }
+        #endif
     }
 }
 
@@ -910,11 +925,14 @@ TEST_CASE( "syncFullStateDiagMatr", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             FullStateDiagMatr m;
             REQUIRE_THROWS_WITH( syncFullStateDiagMatr(m), ContainsSubstring("Invalid FullStateDiagMatr") );
         }
+        #endif
     }
 }
 
@@ -969,14 +987,17 @@ TEST_CASE( "setCompMatr", TEST_CATEGORY ) {
 
         CompMatr matr = createCompMatr(1);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug!
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             CompMatr bad;
             qcomp** dummy;
             REQUIRE_THROWS_WITH( setCompMatr(bad, dummy), ContainsSubstring("Invalid CompMatr") && ContainsSubstring("not created") );
         }
+        #endif
         #endif
 
         SECTION( "null pointer" ) {
@@ -1044,12 +1065,15 @@ TEST_CASE( "setDiagMatr", TEST_CATEGORY ) {
 
         DiagMatr matr = createDiagMatr(1);
 
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             DiagMatr bad;
             qcomp* dummy;
             REQUIRE_THROWS_WITH( setDiagMatr(bad, dummy), ContainsSubstring("Invalid DiagMatr") && ContainsSubstring("not created") );
         }
+        #endif
 
         SECTION( "null pointer" ) {
 
@@ -1090,13 +1114,16 @@ TEST_CASE( "setInlineCompMatr", TEST_CATEGORY ) {
 
         CompMatr matr = createCompMatr(1);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             CompMatr bad;
             REQUIRE_THROWS_WITH( setInlineCompMatr(bad, 1, {{1,2},{3,4}}), ContainsSubstring("Invalid CompMatr") && ContainsSubstring("not created") );
         }
+        #endif
         #endif
 
         SECTION( "mismatching dimension" ) {
@@ -1140,13 +1167,16 @@ TEST_CASE( "setInlineDiagMatr", TEST_CATEGORY ) {
 
         DiagMatr matr = createDiagMatr(1);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             DiagMatr bad;
             REQUIRE_THROWS_WITH( setInlineDiagMatr(bad, 1, {1,2}), ContainsSubstring("Invalid DiagMatr") && ContainsSubstring("not created") );
         }
+        #endif
         #endif
 
         SECTION( "mismatching dimension" ) {

--- a/tests/unit/paulis.cpp
+++ b/tests/unit/paulis.cpp
@@ -549,8 +549,10 @@ TEST_CASE( "destroyPauliStrSum", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             PauliStrSum sum;
@@ -566,6 +568,7 @@ TEST_CASE( "destroyPauliStrSum", TEST_CATEGORY ) {
                 ContainsSubstring("It is likely the structure was not created by its proper function")
             );
         }
+        #endif
         #endif
     }
 }

--- a/tests/unit/paulis.cpp
+++ b/tests/unit/paulis.cpp
@@ -554,6 +554,12 @@ TEST_CASE( "destroyPauliStrSum", TEST_CATEGORY ) {
         SECTION( "not created" ) {
 
             PauliStrSum sum;
+
+            // uninitialised sum fields can be coincidentally
+            // valid on some platforms (Github Actions linux
+            // gcc), so we force invalidity
+            sum.numTerms = -1;
+
             REQUIRE_THROWS_WITH( destroyPauliStrSum(sum), 
                 ContainsSubstring("invalid fields") || 
                 ContainsSubstring("heap pointers was unexpectedly NULL") ||

--- a/tests/unit/qureg.cpp
+++ b/tests/unit/qureg.cpp
@@ -593,13 +593,16 @@ TEST_CASE( "destroyQureg", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             Qureg qureg;
             REQUIRE_THROWS_WITH( destroyQureg(qureg), ContainsSubstring("invalid Qureg") );
         }
+        #endif
         #endif
     }
 }
@@ -625,13 +628,16 @@ TEST_CASE( "getQuregAmp", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             Qureg qureg;
             REQUIRE_THROWS_WITH( getQuregAmp(qureg,0), ContainsSubstring("invalid Qureg") );
         }
+        #endif
         #endif
 
         SECTION( "invalid index" ) {
@@ -681,13 +687,16 @@ TEST_CASE( "getDensityQuregAmp", TEST_CATEGORY ) {
 
     SECTION( LABEL_VALIDATION ) {
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             Qureg qureg;
             REQUIRE_THROWS_WITH( getDensityQuregAmp(qureg,0,0), ContainsSubstring("invalid Qureg") );
         }
+        #endif
         #endif
 
         SECTION( "invalid indices" ) {
@@ -740,13 +749,16 @@ TEST_CASE( "getQuregAmps", TEST_CATEGORY ) {
 
         Qureg qureg = createQureg(5);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             Qureg bad;
             REQUIRE_THROWS_WITH( getQuregAmps(nullptr,bad,0,0), ContainsSubstring("invalid Qureg") );
         }
+        #endif
         #endif
 
         SECTION( "indices" ) {
@@ -815,13 +827,16 @@ TEST_CASE( "getDensityQuregAmps", TEST_CATEGORY ) {
 
         Qureg qureg = createDensityQureg(5);
 
-        /// @todo this bizarrely fails in MSVC - no time to debug! 
-        #if !defined(_MSC_VER)
+        /// @todo fails in MSVC for unknown reason
+        #ifndef _MSC_VER
+        // sanitizer messes with default initialisation
+        #ifndef SANITIZER_IS_ACTIVE
         SECTION( "not created" ) {
 
             Qureg bad;
             REQUIRE_THROWS_WITH( getDensityQuregAmps(nullptr,bad,0,0,0,0), ContainsSubstring("invalid Qureg") );
         }
+        #endif
         #endif
 
         SECTION( "indices" ) {


### PR DESCRIPTION
- renamed KrausMap.isCPTP to KrausMap.isApproxCPTP to reflect its epsilon-dependence, for consistency with isApproxUnitarity, isApproxHermitian and isApproxNonZero
- defined util_setFlagToUnknown() so that constant validate_STRUCT_PROPERTY_UNKNOWN_FLAG need not be exposed beyond validation.cpp and utilities.cpp
- renamed util_setEpsilonSensitiveStructFieldsToUnknown() to util_setEpsilonSensitiveHeapFlagsToUnknown() to be consistent with related utility functions util_(de)allocEpsilonSensitiveHeapFlag()
- made util_allocEpsilonSensitiveHeapFlag() update the ptr to validate_STRUCT_PROPERTY_UNKNOWN_FLAG by default, in case caller forgets to
- removed redundant logic from validation.cpp which checked whether KrausMap.isCPTP and PauliStrSum.isApproxHermitian were pre-set
- added tests to check that sync() functions (syncKrausMap, syncCompMatr, syncDiagMatr, syncFullStateDiagMatr) clear all property fields (isApproxUnitary, isApproxHermitian, isApproxNonZero, isStrictlyNonNegative)
- added tests to check that validation-changes (setValidationEpsilon, setValidationEpsilonToDefault()) clear all epsilon-dependent struct fields
- hid "struct not initialised" tests from address sanitizer (which erm disliked them)