### PR TITLE
added MPI tags to support AR

### DIFF
--- a/quest/src/comm/comm_routines.cpp
+++ b/quest/src/comm/comm_routines.cpp
@@ -169,6 +169,7 @@ int getMaxNumMessages() {
 
 #else
     error_commButEnvNotDistributed();
+    return -1;
 #endif
 }
 

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -145,6 +145,16 @@ void error_commGivenInconsistentNumSubArraysANodes() {
     raiseInternalError("A distributed function was given a different number of per-node subarray lengths than exist nodes.");
 }
 
+void error_commTagUpperBoundNotSet() {
+
+    raiseInternalError("The MPI attribute MPI_TAG_UB was not set for communicator MPI_COMM_WORLD, such that the maximum number of messages per communication-round could not be determined.");
+}
+
+void error_commNumMessagesExceedTagMax() {
+
+    raiseInternalError("A function attempted to communicate via more messages than permitted (since there would be more uniquely-tagged messages than the tag upperbound).");
+}
+
 void assert_commBoundsAreValid(Qureg qureg, qindex sendInd, qindex recvInd, qindex numAmps) {
 
     bool valid = (

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -70,6 +70,10 @@ void error_commWithSameRank();
 
 void error_commGivenInconsistentNumSubArraysANodes();
 
+void error_commTagUpperBoundNotSet();
+
+void error_commNumMessagesExceedTagMax();
+
 void assert_commBoundsAreValid(Qureg qureg, qindex sendInd, qindex recvInd, qindex numAmps);
 
 void assert_commPayloadIsPowerOf2(qindex numAmps);


### PR DESCRIPTION
By giving each send-recv pair a unique tag, we no longer require message orderedness and can ergo support adaptive routing (AR)