### PR TITLE
matrix sync tests: correct dereference of wasGpuSynced.

### DIFF
--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -987,7 +987,7 @@ void testOperationValidation(auto operation, bool multiplyOnly) {
 
         // only relevant to variable-size matrix functions
         if constexpr (Targs == any && (Args == compmatr || Args == diagmatr || Args == diagpower))
-            std::get<0>(furtherArgs).wasGpuSynced = 0;
+            *(std::get<0>(furtherArgs).wasGpuSynced) = 0;
         else
             return; // avoid empty test
 


### PR DESCRIPTION
Ayyyyy 😎 

```
QuEST execution environment:
  precision:       2
  multithreaded:   1
  distributed:     1
  GPU-accelerated: 1
  cuQuantum:       0
  num nodes:       4
  num qubits:      6
  num qubit perms: 50

Tested Qureg deployments:
  GPU + OMP + MPI

Randomness seeded to: 3254013672
===============================================================================
All tests passed (75364 assertions in 240 test cases)
```

As discussed in #581.