### PR TITLE
added calcRealAmpSum frontend

### DIFF
--- a/quest/include/calculations.h
+++ b/quest/include/calculations.h
@@ -43,6 +43,57 @@ extern "C" {
 
 
 /** 
+ * @defgroup example_prs Example PR functions
+ * @brief Nonsensical functions to demonstrate good PRs.
+ * @{
+ */
+
+
+/** Calculates the real component of the sum of every amplitude in the state,
+ * but only for states which contain an even number of qubits (for no reason :3 ).
+ * 
+ * @formulae
+ * Let @f$ n @f$ qubits be the number of qubits in @p qureg, assumed even.
+ * 
+ * - When @p qureg is a statevector @f$ \svpsi @f$, this function returns
+ *   @f[ 
+    \text{Re}\left( \sum\limits_i^{2^n} \langle i \svpsi \right) \in \mathbb{R}.
+ *   @f]
+ * - When @p qureg is a density matrix @f$ \dmrho @f$, this function returns
+ *   @f[ 
+    \text{Re}\left( \sum\limits_i^{2^n} \sum\limits_j^{2^n} \bra{i} \dmrho \ket{j} \right) \in \mathbb{R}.
+ *   @f]
+ * 
+ * @constraints
+ * - The number of qubits in the register must be even.
+ * 
+ * @myexample
+ * ```
+    Qureg qureg = createQureg(4);
+    initRandomPureState(qureg);
+
+    qreal reAmpSum = calcRealAmpSum(qureg);
+    reportScalar("reAmpSum", reAmpSum);  
+ * ```
+ * 
+ * @see
+ * - calcTotalProb()
+
+ * @param[in] qureg the state with the processed amplitudes.
+ * @returns The real component of the sum of all contained amplitudes.
+ * @throws @validationerror
+ * - if @p qureg is uninitialised.
+ * - if @p qureg contains an odd number of qubits.
+ * @author Tyson Jones
+ */
+qreal calcRealAmpSum(Qureg qureg);
+
+
+/** @} */
+
+
+
+/** 
  * @defgroup calc_expec Expectation values
  * @brief Functions for calculating expected values of Hermitian observables.
  * @{

--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -126,6 +126,22 @@ extern "C" {
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qreal calcRealAmpSum(Qureg qureg) {
+    validate_quregFields(qureg, __func__);
+    validate_quregHasEvenNumQubits(qureg, __func__);
+
+    /// @todo
+    /// implement and call new backend function
+    return -1;
+}
+
+
+
+/*
  * EXPECTED VALUES
  */
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -58,6 +58,14 @@ namespace report {
 
 
     /*
+     * NONSENSE VALIDATION FOR DEMO PR
+     */
+
+    string QUREG_HAS_ODD_NUM_QUBITS =
+        "The given Qureg contained ${NUM_QUBITS} qubits, but must contain an even number.";
+
+
+    /*
      *  ENVIRONMENT CREATION
      */
 
@@ -1302,6 +1310,21 @@ bool isIndexListUnique(int* list, int len) {
             mask |= 1ULL << list[i];
 
     return true;
+}
+
+
+
+/*
+ * NONSENSE VALIDATION FOR DEMO PR
+ */
+
+void validate_quregHasEvenNumQubits(Qureg qureg, const char* caller) {
+
+    tokenSubs vars = {
+        {"${NUM_QUBITS}", qureg.numQubits}
+    };
+
+    assertThat(qureg.numQubits % 2 == 0, report::QUREG_HAS_ODD_NUM_QUBITS, vars, caller);
 }
 
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -64,6 +64,14 @@ qreal validateconfig_getEpsilon();
 
 
 /*
+ * NONSENSE VALIDATION FOR DEMO PR
+ */
+
+void validate_quregHasEvenNumQubits(Qureg qureg, const char* caller);
+
+
+
+/*
  * ENVIRONMENT CREATION
  */
 


### PR DESCRIPTION
# Example PR A
## Sub PR 1

This PR demonstrates how to add the user-facing _frontend_ of a new function to the QuEST API. To do so:
1. declare the function in a [`quest/include/`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/include) header file.
2. write the function doc above that declaration.
3. define the function in a corresponding [`quest/src/api/`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/api) file.
4. define new [validation](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/validation.cpp) functions as necessary.

This API function should contain only simple logic, and call other internal functions defined in [`quest/src/core/`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core) files as necessary. It typically resembles
```C++
void myFunction(int a, int b) {
     validate_userInput(a, __func__);
     validate_userInput(b, __func__);

    localiser_myFunction(a, b);
}
```
where `validate_userInput()` is a function declared in [`validation.hpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/validation.hpp) which verifies the user's input satisfies necessary preconditions. The so-far undefined function `localiser_myFunction()` is the entry-point to the _backend_ of the new function, as explained in the next PR ([#608](https://github.com/QuEST-Kit/QuEST/pull/608)).

It is sometimes necessary to define new internal functions needed by the new API function. These will typically be added to
- [`validation.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/validation.cpp)
- [`utilities.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/utilities.cpp)
- [`parser.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/parser.cpp)
- [`printer.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/printer.cpp)
- [`randomiser.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/randomiser.cpp)
- [`memory.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/memory.cpp)

In this PR, it was necessary to define a new validation function in [`validation.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/validation.cpp), and declare it in [`validation.hpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/validation.hpp)