### PR TITLE
added calcAmpSum backend

### DIFF
--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -134,9 +134,10 @@ qreal calcRealAmpSum(Qureg qureg) {
     validate_quregFields(qureg, __func__);
     validate_quregHasEvenNumQubits(qureg, __func__);
 
-    /// @todo
-    /// implement and call new backend function
-    return -1;
+    // logic is identical for both statevectors and density matrices
+    qcomp value = localiser_statevec_calcAmpSum(qureg);
+
+    return std::real(value);
 }
 
 

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -183,6 +183,20 @@ using std::min;
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp accel_statevec_calcAmpSum(Qureg qureg) {
+
+    return (qureg.isGpuAccelerated)?
+        gpu_statevec_calcAmpSum(qureg):
+        cpu_statevec_calcAmpSum(qureg);
+}
+
+
+
+/*
  * GETTERS 
  */
 

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -148,6 +148,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp accel_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS 
  */
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -462,6 +462,27 @@ void exchangeAmpsToBuffersWhereQubitsAreInStates(Qureg qureg, int pairRank, vect
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp localiser_statevec_calcAmpSum(Qureg qureg) {
+
+    // each node computes the sum of its local amps
+    // in an embarrassingly parallel fashion
+    qcomp out =  accel_statevec_calcAmpSum(qureg);
+
+    // node partial sums are combined, and every
+    // node receives a copy of the full sum (consensus)
+    if (qureg.isDistributed)
+        comm_reduceAmp(&out);
+
+    return out;
+}
+
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -24,6 +24,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp localiser_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -41,6 +41,34 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp cpu_statevec_calcAmpSum(Qureg qureg) {
+
+    // we brazenly perform this all-state reduction without
+    // a single thought to finite precision effects - arrest me! 
+
+    // separately reduce real and imag components to make MSVC happy
+    qreal outRe = 0;
+    qreal outIm = 0;
+
+    // every local amplitude contributes to the sum
+    qindex numIts = qureg.numAmpsPerNode;
+
+    #pragma omp parallel for reduction(+:outRe,outIm) if(qureg.isMultithreaded)
+    for (qindex n=0; n<numIts; n++) {
+        outRe += std::real(qureg.cpuAmps[n]);
+        outIm += std::imag(qureg.cpuAmps[n]);
+    }
+
+    return qcomp(outRe, outIm);
+}
+
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -21,6 +21,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp cpu_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -66,6 +66,32 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp gpu_statevec_calcAmpSum(Qureg qureg) {
+
+#if COMPILE_CUDA || COMPILE_CUQUANTUM
+
+    // there is no cuQuantum function for this facility,
+    // nor is there a need to implement a custom kernel;
+    // we will leverage an exting Thrust facility
+    cu_qcomp out =  thrust_statevec_calcAmpSum(qureg);
+
+    // the GPU backend uses a CUDA-equivalent of 'qcomp'
+    // which we must cast back and forth between (ew!)
+    return toQcomp(out);
+
+#else
+    error_gpuSimButGpuNotCompiled();
+    return -1;
+#endif
+}
+
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -18,6 +18,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp gpu_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -636,6 +636,27 @@ struct functor_setRandomStateVecAmp : public thrust::unary_function<qindex,cu_qc
 
 
 /*
+ * PR DEMOS
+ */
+
+
+cu_qcomp thrust_statevec_calcAmpSum(Qureg qureg) {
+
+    // beware that we must explicitly instantiate a 
+    // qcomp type here, rather than pass reduce() a
+    // literal, which would cause a silent bug (grr)
+    cu_qcomp init = getCuQcomp(0, 0);
+
+    cu_qcomp out = thrust::reduce(
+        getStartPtr(qureg), getEndPtr(qureg), 
+        init, thrust::plus<cu_qcomp>());
+
+    return out;
+}
+
+
+
+/*
  * MATRIX INITIALISATION
  */
 


### PR DESCRIPTION
# Example PR A
## Sub PR 2

This PR implements the backend of the `calcRealAmpSum` function from PR #607, to demonstrate how accelerated functions are structured. 

> Note the backend functions actually implement `calcAmpSum` which returns both the real and imaginary components of the amplitude sum. This will be leveraged by a subsequent `calcAmpSum()` API function.

In general, a function in [`quest/src/api`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/api) calls a
1. [`localiser.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/localiser.cpp) routine which communicates data between distributed nodes as necessary. 
    It does this by invoking one or more routines within...
2. [`comm_routines.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/comm/comm_routines.cpp)
   then proceeds to invoke an
3. [`accelerator.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/core/accelerator.cpp) routine which decides whether to invoke CPU or GPU code.
    This calls either a...
    - [`cpu_subroutines.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/cpu/cpu_subroutines.cpp) routine which may use multithreading, or a...
    - [`gpu_subroutines.cpp`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/gpu/gpu_subroutines.cpp) routine which will invoke either a custom kernel, a [Thrust](https://developer.nvidia.com/thrust) routine, or a [cuStateVec](https://docs.nvidia.com/cuda/cuquantum/latest/custatevec/index.html) routine. These three types of functions are respectively defined in:
      - [`gpu_kernels.cuh`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/gpu/gpu_kernels.cuh)
      - [`gpu_thrust.cuh`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/gpu/gpu_thrust.cuh)
      - [`gpu_cuquantum.cuh`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/gpu/gpu_cuquantum.cuh)

In this PR, the GPU backend for the function `calcAmpSum` was implemented using Thrust since it trivially mapped to an existing Thrust routine.

Note that `calcRealAmpSum` can be called upon both a statevector and density matrix `Qureg`. Since the simulation logic is agnostic to either, both types of `Qureg` were passed to backend functions containing the `_statevector_` infix. If the statevector and density matrix logic had differed, we would additionally define backend functions
```C++
localiser_densmatr_calcAmpSum();
accel_densmatr_calcAmpSum();
cpu_densmatr_calcAmpSum();
gpu_densmatr_calcAmpSum();
thrust_densmatr_calcAmpSum();
```
and invoke the appropriate localiser function at the top-level:
```C++
qreal calcRealAmpSum(Qureg qureg) {
    validate_quregFields(qureg, __func__);
    validate_quregHasEvenNumQubits(qureg, __func__);

    qcomp value = (qureg.isDensityMatrix)?
        localiser_densmatr_calcAmpSum(qureg);
        localiser_statevec_calcAmpSum(qureg);

    return std::real(value);
}
```

With the frontend and backends defined, the next step is to implement the unit tests like demonstrated in #609.