### PR TITLE
added calcRealAmpSum tests

### DIFF
--- a/tests/unit/calculations.cpp
+++ b/tests/unit/calculations.cpp
@@ -156,6 +156,47 @@ void TEST_ON_CACHED_QUREG_AND_MATRIX(quregCache quregs, matrixCache matrices, au
 
 
 
+TEST_CASE( "calcRealAmpSum", TEST_CATEGORY ) {
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        // The boilerplate for testing a function differs
+        // greatly depending on what the function does;
+        // this function is trivial so has a simple test,
+        // re-using the existing TEST_ALL_QUREGS() macro.
+        // This macro invokes the below RHS expressions
+        // passing substitutions of the LHS expressions
+        // with Quregs (statevector or density matrix)
+        // and reference objects (qvector or qmatrix), for
+        // every possible deployment (i.e. multithreading,
+        // GPU-acceleration, distribution, hybrids, etc).
+
+        TEST_ALL_QUREGS(
+            qureg, calcRealAmpSum(qureg),
+            refer, std::real(getTotal(refer))
+        );
+    }
+
+    SECTION( LABEL_VALIDATION ) {
+
+        SECTION( "qureg uninitialised" ) {
+
+            // prepare an un-initialised qureg
+            Qureg qureg;
+
+            // manually mangle the fields for validation
+            // to detect, since the default values are
+            // undefined behaviour and might not trigger
+            // (e.g. compiler could re-use a valid Qureg)
+            qureg.numQubits = -123;
+
+            REQUIRE_THROWS_WITH( calcRealAmpSum(qureg), ContainsSubstring("invalid Qureg") );
+        }
+    }
+}
+
+
+
 TEST_CASE( "calcExpecPauliStr", TEST_CATEGORY ) {
 
     SECTION( LABEL_CORRECTNESS ) {

--- a/tests/utils/linalg.cpp
+++ b/tests/utils/linalg.cpp
@@ -108,6 +108,37 @@ int getNumPermutations(int n, int k) {
 
 
 /*
+ * NONSENSE PR OPERATIONS
+ */
+
+
+qcomp getTotal(qvector in) {
+
+    qcomp out = 0;
+
+    // no compensated summation
+    for (auto& elem : in)
+        out += elem;
+
+    return out;
+}
+
+
+qcomp getTotal(qmatrix in) {
+
+    qcomp out = 0;
+
+    // no compensated summation
+    for (auto& row : in)
+        for (auto& elem : row)
+            out += elem;
+
+    return out;
+}
+
+
+
+/*
  * VECTOR OPERATIONS
  */
 

--- a/tests/utils/linalg.hpp
+++ b/tests/utils/linalg.hpp
@@ -29,6 +29,9 @@ qindex setBitAt(qindex num, int ind, int bit);
 qindex setBitsAt(qindex num, vector<int> inds, qindex bits);
 qindex getPow2(int);
 
+qcomp getTotal(qvector);
+qcomp getTotal(qmatrix);
+
 qreal getSum(vector<qreal> vec);
 qcomp getSum(qvector);
 qvector getNormalised(qvector);


### PR DESCRIPTION
# Example PR A
## Sub PR 3

This PR demonstrates how to define unit tests for a new API function. Here, we test `calcRealAmpSum` as implemented in #607 and #608.

It is essential to rigorously unit test every new QuEST function. Each function corresponds to a single Catch2 [`TEST_CASE`](https://github.com/catchorg/catch2/blob/devel/docs/tutorial.md#writing-tests), defined in a file in [`tests/unit/`](https://github.com/QuEST-Kit/QuEST/tree/main/tests/unit). The test filename is identical to the filename in [`quest/src/api/`](https://github.com/QuEST-Kit/QuEST/tree/main/quest/src/api) containing the API function. 

The unit tests re-create the behaviour of a QuEST function through direct, non-accelerated, naive linear algebra. They are ergo exceptionally slow, but perform precisely what the test operations are defined to do. For example, a Hadamard gate is tensored into a full-state matrix (with dimension `2^qubits`) and is multiplied onto a vector via matrix-vector multiplication. This is performed using the myriad of utility functions in [`tests/utils/`](https://github.com/QuEST-Kit/QuEST/tree/main/tests/utils). It is sometimes necessary, like in this PR, to define new utility functions.

Beware that some unit tests are _filled_ with [boilerplate](https://en.wikipedia.org/wiki/Boilerplate_code) and complicated usages of macros and generic programming. This is to avoid code duplication between the tests of similar functions, while rigorously testing every aspect of QuEST's varied API functionality. The structure of the unit tests differ between the major groups of API functions. In order of increasing complexity, they are
- (_trivial_) [`types.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/types.cpp)
- (_trivial_) [`environment.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/environment.cpp)
- (_trivial_) [`paulis.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/paulis.cpp)
- (_trivial_) [`qureg.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/qureg.cpp)
- (_trivial_) [`channels.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/channels.cpp)
- (_simple_) [`initialisations.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/initialisations.cpp)
- (_simple_) [`debug.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/debug.cpp)
- (_simple_) [`matrices.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/matrices.cpp)
- (_moderate_) [`decoherence.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/decoherence.cpp)
- (_complicated_) [`calculations.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/calculations.cpp)
- (_nightmarish_) [`operations.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/operations.cpp)

This PR added a test to [`calculations.cpp`](https://github.com/QuEST-Kit/QuEST/blob/main/tests/unit/calculations.cpp) which expands the [`TEST_ALL_QUREGS()`](https://github.com/QuEST-Kit/QuEST/blob/53f8f3ad60e5b0171646ee8250c0e6ea65878b44/tests/unit/calculations.cpp#L79) macro defined therein.

These example PRs have so far implemented `calcRealAmpSum()`, returning a real number (`qreal`). The natural companion function `calcAmpSum()`, which returns a complex number (`qcomp`), requires some additional steps as explained in #610.