### PR TITLE
added calcAmpSum frontend

### DIFF
--- a/quest/include/calculations.h
+++ b/quest/include/calculations.h
@@ -342,6 +342,44 @@ Qureg calcReducedDensityMatrix(Qureg qureg, int* retainQubits, int numRetainQubi
  */
 
 
+/** @ingroup example_prs
+ * 
+ * Calculates the sum of every amplitude in the state.
+ * 
+ * @formulae
+ * Let @f$ n @f$ qubits be the number of qubits in @p qureg.
+ * 
+ * - When @p qureg is a statevector @f$ \svpsi @f$, this function returns
+ *   @f[ 
+    \sum\limits_i^{2^n} \langle i \svpsi \in \mathbb{C}.
+ *   @f]
+ * - When @p qureg is a density matrix @f$ \dmrho @f$, this function returns
+ *   @f[ 
+    \sum\limits_i^{2^n} \sum\limits_j^{2^n} \bra{i} \dmrho \ket{j} \in \mathbb{C}.
+ *   @f]
+ *
+ * @myexample
+ * ```
+    Qureg qureg = createQureg(4);
+    initRandomPureState(qureg);
+
+    qcomp ampSum = calcAmpSum(qureg);
+    reportScalar("ampSum", ampSum);  
+ * ```
+ * 
+ * @see
+ * - calcRealAmpSum()
+
+ * @param[in] qureg the state with the processed amplitudes.
+ * @returns The the sum of all contained amplitudes.
+ * @throws @validationerror
+ * - if @p qureg is uninitialised.
+ * - if @p qureg contains an odd number of qubits.
+ * @author Tyson Jones
+ */
+qcomp calcAmpSum(Qureg qureg);
+
+
 /// @ingroup calc_comparisons
 /// @notdoced
 /// @notvalidated

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -42,6 +42,15 @@
 #ifndef __cplusplus
 
 
+extern void _wrap_calcAmpSum(Qureg qureg, qcomp* out);
+
+qcomp calcAmpSum(Qureg qureg) {
+
+    qcomp out;
+    _wrap_calcAmpSum(qureg, &out);
+    return out;
+}
+
 
 extern void _wrap_calcInnerProduct(Qureg bra, Qureg ket, qcomp* out);
 

--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -46,6 +46,17 @@ extern Qureg validateAndCreateCustomQureg(
  */
 
 
+qcomp calcAmpSum(Qureg qureg) {
+    validate_quregFields(qureg, __func__);
+
+    return localiser_statevec_calcAmpSum(qureg);
+}
+extern "C" void _wrap_calcAmpSum(Qureg qureg, qcomp* out) {
+
+    *out = calcAmpSum(qureg);
+}
+
+
 qcomp calcInnerProduct(Qureg quregA, Qureg quregB) {
     validate_quregFields(quregA, __func__);
     validate_quregFields(quregB, __func__);

--- a/tests/unit/calculations.cpp
+++ b/tests/unit/calculations.cpp
@@ -197,6 +197,30 @@ TEST_CASE( "calcRealAmpSum", TEST_CATEGORY ) {
 
 
 
+TEST_CASE( "calcAmpSum", TEST_CATEGORY ) {
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        TEST_ALL_QUREGS(
+            qureg, calcAmpSum(qureg),
+            refer, getTotal(refer)
+        );
+    }
+
+    SECTION( LABEL_VALIDATION ) {
+
+        SECTION( "qureg uninitialised" ) {
+
+            Qureg qureg;
+            qureg.numQubits = -123;
+
+            REQUIRE_THROWS_WITH( calcRealAmpSum(qureg), ContainsSubstring("invalid Qureg") );
+        }
+    }
+}
+
+
+
 TEST_CASE( "calcExpecPauliStr", TEST_CATEGORY ) {
 
     SECTION( LABEL_CORRECTNESS ) {


### PR DESCRIPTION
# Example PR A
## Sub PR 4

This PR demonstrates how to add new QuEST API functions which **_directly return_** a `qcomp`.
```C++
extern "C" {

    // here be dragons
    qcomp calcAmpSum(Qureg qureg) {
        qcomp value = internalFunc(qureg);
        return value;
    }

}
```

## The problem

QuEST is agnostic to `C` and `C++` using a myriad of tricks. This includes [resolving](https://github.com/QuEST-Kit/QuEST/blob/53f8f3ad60e5b0171646ee8250c0e6ea65878b44/quest/include/types.h#L36) the `qcomp` type to the natural, respective `C` and `C++` complex types. While a `C` user may believe the `qcomp` is defined as
```C
#include <complex.h>
typedef double _Complex qcomp;
```
a `C++` user (_and_ the internal QuEST library) may meanwhile believe it to be
```C++
#include <complex>
typedef std::complex<double> qcomp;
```

As such, a `C` user might pass a `_Complex` to a `C++` function expecting a `std::complex<double>`. Alas, this is [undefined behaviour](https://en.wikipedia.org/wiki/Undefined_behavior)! For historical reasons, complex primitives were never integrated into the [ABI](https://en.wikipedia.org/wiki/Application_binary_interface). It is ergo illegal for a `C` user to directly pass a `qcomp` to its internal `C++` functions.


## The solution

While the type `qcomp` differs between `C` and `C++`, they do have the same _memory layout_. This is guaranteed by the `C99` and `C++11` standards as indicated [here](https://stackoverflow.com/a/14569958/848292), and means it is okay to pass _pointers_ to `qcomp` over the ABI. Ergo, QuEST's `C++` functions can safely accept and return `qcomp*` and be directly invoked by `C` code.

Passing superfluous pointers is gross though, and we still wish for the `C` and `C++` interfaces to be identical. So, to define a new API function which returns a `qcomp`, we...
1. Declare the function in the user-facing header (e.g. `quest/include/calculations.h`) **_without_** `extern "C"`.
   ```C++
   qcomp calcAmpSum(Qureg qureg);
   ```
   > Both the user's `C` compiler and the backend's `C++` compiler will interpret `qcomp` as their native types.
2. Define the function's `C++`-only version in the corresponding source file (e.g. `quest/src/api/calculatons.cpp`), also **_without_** `extern "C"`.
    ```C++
    qcomp calcAmpSum(Qureg qureg) {
        qcomp value = internalFunc(qureg);
        return value;
    }
    ```
    > The `C++` compiler will name-mangle this definition, ensuring it is never directly invoked from `C`. So far, `C++` users can call this function - we now need to spoof it for `C` users.
3. Define a de-mangled `C`-compatible version of the function just under the above function, which calls the above function, but safely "returns" the `qcomp` by overwriting a pointer.
    ```C++
    extern "C" void _wrap_calcAmpSum(Qureg qureg, qcomp* out) {
        *out = calcAmpSum(qureg);
    }
    ```
    > This _could_ be directly called by a `C` user, but it's ugly and has a differing signature to the `C++` version! To address this...
4. Define a `C`-only version of the function in [`quest/include/wrappers.h`](https://github.com/QuEST-Kit/QuEST/blob/main/quest/include/wrappers.h) with an identical signature to the `C++` definition but which invokes `_wrap_calcAmpSum` above.
    ```C
    #ifndef __cplusplus

    extern void _wrap_calcAmpSum(Qureg qureg, qcomp* out);

    qcomp calcAmpSum(Qureg qureg) {

        qcomp out;
        _wrap_calcAmpSum(qureg, &out);
        return out;
    }

    #endif
    ```
    > Since only `C` parses this header-only definition, only `C` user's will invoke it! `C++` users will invoke the original `calcAmpSum` definition.

A regrettable side-effect of this trick is that the intendedly private function `_wrap_calcAmpSum` is declared (as `extern`) in the header. This is necessary to prevent the the `C` compiler parsing `wrappers.h` from panicking about the missing symbol, but means `C` users can see and call `_wrap_calcAmpSum`. Although calling it is harmless, hopefully the ugly prefix dissuades IDEs from listing the routine!

## This PR

We generalise the existing `calcRealAmpSum` (which returned a real-valued primitive without problem) to return `qcomp`, retaining a `C` and `C++` agnostic API via the above process. We also define its unit test for completeness.

The combined changes of this and the previous example PRs can be seen in #615.