### PR TITLE
V4 header install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,7 +525,7 @@ set(QuEST_INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/QuEST")
 
 # Write QuESTConfigVersion.cmake
 write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake"
         VERSION ${PROJECT_VERSION}
         COMPATIBILITY AnyNewerVersion
 )
@@ -533,14 +533,14 @@ write_basic_package_version_file(
 # Configure QuESTConfig.cmake (from template)
 configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/QuESTConfig.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake"
         INSTALL_DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )
 
 # Install them
 install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfig.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake"
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )
 
@@ -554,7 +554,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/quest/include/"
 )
 
 install(EXPORT QuESTTargets
-        FILE QuESTTargets.cmake
+        FILE "${LIB_NAME}Targets.cmake"
         NAMESPACE QuEST::
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,22 @@ message(STATUS "Library will be named lib${LIB_NAME}. Set LIB_NAME to modify.")
 option(VERBOSE_LIB_NAME "Modify library name based on compilation configuration. Turned OFF by default." OFF)
 message(STATUS "Verbose library naming is turned ${VERBOSE_LIB_NAME}. Set VERBOSE_LIB_NAME to modify.")
 
+if (VERBOSE_LIB_NAME)
+  # Same headers will be used for several verbosely-named libraries
+  set(MULTI_LIB_HEADERS 1)
+  function(compile_option VAR VALUE)
+    target_compile_definitions(QuEST PUBLIC ${VAR}=${VALUE})
+  endfunction()
+else()
+  # Headers will be used for a single library with a single valid configuration
+  set(MULTI_LIB_HEADERS 0)
+  function(compile_option VAR VALUE)
+    target_compile_definitions(QuEST PRIVATE ${VAR}=${VALUE})
+    set(${VAR} ${VALUE})
+  endfunction()
+endif()
+
+
 # Precision
 set(FLOAT_PRECISION 2 
   CACHE 
@@ -251,10 +267,9 @@ add_library(QuEST::QuEST ALIAS QuEST)
 # Set include directories
 target_include_directories(QuEST
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/quest/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:../quest/include>
-  $<INSTALL_INTERFACE:..>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 # Add required C and C++ standards
@@ -279,7 +294,7 @@ target_compile_options(QuEST
 
 
 # Set user options
-target_compile_definitions(QuEST PUBLIC FLOAT_PRECISION=${FLOAT_PRECISION})
+compile_option(FLOAT_PRECISION ${FLOAT_PRECISION})
 
 if (ENABLE_MULTITHREADING)
 
@@ -295,7 +310,7 @@ if (ENABLE_MULTITHREADING)
     message(FATAL_ERROR ${ErrorMsg})
   endif()
 
-  target_compile_definitions(QuEST PUBLIC COMPILE_OPENMP=1)
+  compile_option(COMPILE_OPENMP 1)
   target_link_libraries(QuEST
     PRIVATE
     OpenMP::OpenMP_CXX
@@ -313,14 +328,14 @@ else()
     target_compile_options(QuEST PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>)
   endif()
   
-  target_compile_definitions(QuEST PUBLIC COMPILE_OPENMP=0)
+  compile_option(COMPILE_OPENMP 0)
 endif()
 
 if (ENABLE_DISTRIBUTION)
   find_package(MPI REQUIRED
     COMPONENTS CXX
   )
-  target_compile_definitions(QuEST PUBLIC COMPILE_MPI=1)
+  compile_option(COMPILE_MPI 1)
   target_link_libraries(QuEST
     PRIVATE
     MPI::MPI_CXX
@@ -329,7 +344,7 @@ if (ENABLE_DISTRIBUTION)
     string(CONCAT LIB_NAME ${LIB_NAME} "+mpi")
   endif()
 else()
-  target_compile_definitions(QuEST PUBLIC COMPILE_MPI=0)
+  compile_option(COMPILE_MPI 0)
 endif()
 
 if (ENABLE_CUDA)
@@ -353,14 +368,14 @@ endif()
 
 if (ENABLE_CUQUANTUM)
   find_package(CUQUANTUM REQUIRED)
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=1)
+  compile_option(COMPILE_CUQUANTUM 1)
   target_link_libraries(QuEST PRIVATE CUQUANTUM::cuStateVec)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
   if (VERBOSE_LIB_NAME)
     string(CONCAT LIB_NAME ${LIB_NAME} "+cuquantum")
   endif()
 else()
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=0)
+  compile_option(COMPILE_CUQUANTUM 0)
 endif()
 
 if (ENABLE_HIP)
@@ -380,7 +395,7 @@ if (ENABLE_HIP)
   find_package(HIP REQUIRED)
   message(STATUS "Found HIP: " ${HIP_VERSION})
 
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=0)
+  compile_option(COMPILE_CUQUANTUM 0)
   target_link_libraries(QuEST PRIVATE hip::host)
 
   if (VERBOSE_LIB_NAME)
@@ -389,9 +404,9 @@ if (ENABLE_HIP)
 endif()
 
 if (ENABLE_CUDA OR ENABLE_HIP)
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUDA=1)
+  compile_option(COMPILE_CUDA 1)
 else()
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUDA=0)
+  compile_option(COMPILE_CUDA 0)
 endif()
 
 if (ENABLE_DEPRECATED_API)
@@ -423,7 +438,8 @@ endif()
 set_target_properties(QuEST PROPERTIES OUTPUT_NAME ${LIB_NAME})
 
 # Add source files
-add_subdirectory(quest)
+add_subdirectory(quest/src)
+add_subdirectory(quest/include include/quest)
 
 ## Examples
 
@@ -526,6 +542,15 @@ install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfigVersion.cmake"
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/quest.h"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/quest/include/"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        FILES_MATCHING PATTERN "*.h"
 )
 
 install(EXPORT QuESTTargets

--- a/cmake/QuESTConfig.cmake.in
+++ b/cmake/QuESTConfig.cmake.in
@@ -1,4 +1,4 @@
 # @author Erich Essmann
 
 @PACKAGE_INIT@
-include("${CMAKE_CURRENT_LIST_DIR}/QuESTTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@LIB_NAME@Targets.cmake")

--- a/quest/CMakeLists.txt
+++ b/quest/CMakeLists.txt
@@ -1,4 +1,0 @@
-# @author Oliver Thomson Brown
-
-add_subdirectory(src)
-add_subdirectory(include)

--- a/quest/include/CMakeLists.txt
+++ b/quest/include/CMakeLists.txt
@@ -1,7 +1,9 @@
 # @author Oliver Thomson Brown
 # @author Erich Essmann
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DESTINATION "${CMAKE_INSTALL_PREFIX}"
-        FILES_MATCHING PATTERN "*.h" 
-)
+configure_file(quest.h.in ../quest.h @ONLY)
+
+file(GLOB HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" CONFIGURE_DEPENDS "*.h")
+foreach(FILE IN LISTS HEADER_FILES)
+	file(GENERATE OUTPUT ${FILE} INPUT ${FILE})
+endforeach()

--- a/quest/include/calculations.h
+++ b/quest/include/calculations.h
@@ -13,10 +13,10 @@
 #ifndef CALCULATIONS_H
 #define CALCULATIONS_H
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 
 

--- a/quest/include/channels.h
+++ b/quest/include/channels.h
@@ -47,7 +47,7 @@
 #ifndef CHANNELS_H
 #define CHANNELS_H
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 // C++ gets vector initialiser overloads, whereas C gets a macro
 #ifdef __cplusplus

--- a/quest/include/debug.h
+++ b/quest/include/debug.h
@@ -14,7 +14,7 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 
 

--- a/quest/include/decoherence.h
+++ b/quest/include/decoherence.h
@@ -13,9 +13,9 @@
 #ifndef DECOHERENCE_H
 #define DECOHERENCE_H
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/channels.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/channels.h"
 
 
 

--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -18,7 +18,7 @@
 #ifndef DEPRECATED_H
 #define DEPRECATED_H
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "stdlib.h"
 

--- a/quest/include/initialisations.h
+++ b/quest/include/initialisations.h
@@ -15,9 +15,9 @@
 #ifndef INITIALISATIONS_H
 #define INITIALISATIONS_H
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
 
 
 

--- a/quest/include/matrices.h
+++ b/quest/include/matrices.h
@@ -22,8 +22,8 @@
 #ifndef MATRICES_H
 #define MATRICES_H
 
-#include "quest/include/types.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/paulis.h"
 
 // C++ gets vector initialiser overloads, whereas C gets a macro
 #ifdef __cplusplus

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -15,10 +15,10 @@
 #ifndef OPERATIONS_H
 #define OPERATIONS_H
 
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
 
 #ifdef __cplusplus
     #include <vector>

--- a/quest/include/paulis.h
+++ b/quest/include/paulis.h
@@ -13,8 +13,8 @@
 #ifndef PAULIS_H
 #define PAULIS_H
 
-#include "quest/include/precision.h"
-#include "quest/include/types.h"
+#include "quest/precision.h"
+#include "quest/types.h"
 
 // C++ gets string and vector initialiser overloads
 #ifdef __cplusplus

--- a/quest/include/precision.h
+++ b/quest/include/precision.h
@@ -14,7 +14,7 @@
 #ifndef PRECISION_H
 #define PRECISION_H
 
-#include "quest/include/modes.h"
+#include "quest/modes.h"
 
 
 

--- a/quest/include/quest.h
+++ b/quest/include/quest.h
@@ -32,30 +32,30 @@
 
 // include version first so it is accessible to 
 // debuggers in case a subsequent include fails
-#include "quest/include/version.h"
+#include "quest/version.h"
 
 // include before API headers since it validates
 // preprocessor configuration, and affirms macro
 // preconditions assumed by subsequent header
-#include "quest/include/modes.h"
+#include "quest/modes.h"
 
-#include "quest/include/precision.h"
-#include "quest/include/types.h"
-#include "quest/include/calculations.h"
-#include "quest/include/debug.h"
-#include "quest/include/decoherence.h"
-#include "quest/include/environment.h"
-#include "quest/include/initialisations.h"
-#include "quest/include/channels.h"
-#include "quest/include/operations.h"
-#include "quest/include/paulis.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
-#include "quest/include/wrappers.h"
+#include "quest/precision.h"
+#include "quest/types.h"
+#include "quest/calculations.h"
+#include "quest/debug.h"
+#include "quest/decoherence.h"
+#include "quest/environment.h"
+#include "quest/initialisations.h"
+#include "quest/channels.h"
+#include "quest/operations.h"
+#include "quest/paulis.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
+#include "quest/wrappers.h"
 
 
 #if INCLUDE_DEPRECATED_FUNCTIONS
-    #include "quest/include/deprecated.h"
+    #include "quest/deprecated.h"
 #endif
 
 

--- a/quest/include/quest.h.in
+++ b/quest/include/quest.h.in
@@ -30,6 +30,15 @@
 #define QUEST_H
 
 
+#if !@MULTI_LIB_HEADERS@
+#cmakedefine FLOAT_PRECISION @FLOAT_PRECISION@
+#cmakedefine01 COMPILE_MPI
+#cmakedefine01 COMPILE_OPENMP
+#cmakedefine01 COMPILE_CUDA
+#cmakedefine01 COMPILE_CUQUANTUM
+#endif
+
+
 // include version first so it is accessible to 
 // debuggers in case a subsequent include fails
 #include "quest/version.h"

--- a/quest/include/qureg.h
+++ b/quest/include/qureg.h
@@ -12,7 +12,7 @@
 #ifndef QUREG_H
 #define QUREG_H
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 
 

--- a/quest/include/types.h
+++ b/quest/include/types.h
@@ -19,8 +19,8 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-#include "quest/include/modes.h"
-#include "quest/include/precision.h"
+#include "quest/modes.h"
+#include "quest/precision.h"
 
 
 

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -30,10 +30,10 @@
 #ifndef WRAPPERS_H
 #define WRAPPERS_H
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 /// @cond EXCLUDE_FROM_DOXYGEN
 

--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -6,10 +6,10 @@
  * @author Balint Koczor (prototyped v3 calcHilbertSchmidtDistance and calcDensityInnerProduct)
  */
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/calculations.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/calculations.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/utilities.hpp"

--- a/quest/src/api/channels.cpp
+++ b/quest/src/api/channels.cpp
@@ -7,8 +7,8 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/channels.h"
-#include "quest/include/types.h"
+#include "quest/channels.h"
+#include "quest/types.h"
 
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/memory.hpp"

--- a/quest/src/api/debug.cpp
+++ b/quest/src/api/debug.cpp
@@ -6,7 +6,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/printer.hpp"

--- a/quest/src/api/decoherence.cpp
+++ b/quest/src/api/decoherence.cpp
@@ -7,9 +7,9 @@
  * @author Nicolas Vogt (prototyped v3 mixDamping)
  */
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/channels.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/channels.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/localiser.hpp"

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -5,9 +5,9 @@
  * @author Tyson Jones 
  */
 
-#include "quest/include/environment.h"
-#include "quest/include/precision.h"
-#include "quest/include/modes.h"
+#include "quest/environment.h"
+#include "quest/precision.h"
+#include "quest/modes.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/memory.hpp"

--- a/quest/src/api/initialisations.cpp
+++ b/quest/src/api/initialisations.cpp
@@ -7,9 +7,9 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/qureg.h"
-#include "quest/include/calculations.h"
-#include "quest/include/initialisations.h"
+#include "quest/qureg.h"
+#include "quest/calculations.h"
+#include "quest/initialisations.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/localiser.hpp"

--- a/quest/src/api/matrices.cpp
+++ b/quest/src/api/matrices.cpp
@@ -8,9 +8,9 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/matrices.h"
-#include "quest/include/environment.h"
-#include "quest/include/types.h"
+#include "quest/matrices.h"
+#include "quest/environment.h"
+#include "quest/types.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/autodeployer.hpp"

--- a/quest/src/api/modes.cpp
+++ b/quest/src/api/modes.cpp
@@ -4,7 +4,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/modes.h"
+#include "quest/modes.h"
 
 
 int modeflag::USE_AUTO = -1;

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -7,10 +7,10 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
-#include "quest/include/operations.h"
-#include "quest/include/calculations.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
+#include "quest/operations.h"
+#include "quest/calculations.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/utilities.hpp"

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -5,8 +5,8 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/precision.h"
-#include "quest/include/paulis.h"
+#include "quest/precision.h"
+#include "quest/paulis.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/printer.hpp"

--- a/quest/src/api/qureg.cpp
+++ b/quest/src/api/qureg.cpp
@@ -5,9 +5,9 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/qureg.h"
-#include "quest/include/environment.h"
-#include "quest/include/initialisations.h"
+#include "quest/qureg.h"
+#include "quest/environment.h"
+#include "quest/initialisations.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/autodeployer.hpp"

--- a/quest/src/api/types.cpp
+++ b/quest/src/api/types.cpp
@@ -4,7 +4,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 #include "quest/src/core/printer.hpp"
 #include "quest/src/core/validation.hpp"

--- a/quest/src/comm/comm_config.cpp
+++ b/quest/src/comm/comm_config.cpp
@@ -12,8 +12,8 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
+#include "quest/modes.h"
+#include "quest/types.h"
 
 #include "quest/src/comm/comm_config.hpp"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/comm/comm_indices.hpp
+++ b/quest/src/comm/comm_indices.hpp
@@ -12,8 +12,8 @@
 #ifndef COMM_INDICES_HPP
 #define COMM_INDICES_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
 
 #include <utility>
 

--- a/quest/src/comm/comm_routines.cpp
+++ b/quest/src/comm/comm_routines.cpp
@@ -10,9 +10,9 @@
  * @author Ania (Anna) Brown (developed QuEST v1 logic)
  */
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/comm/comm_routines.hpp
+++ b/quest/src/comm/comm_routines.hpp
@@ -10,9 +10,9 @@
 #ifndef COMM_ROUTINES_HPP
 #define COMM_ROUTINES_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
 
 #include <vector>
 #include <string>

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -14,10 +14,10 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 #include "quest/src/core/accelerator.hpp"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -21,8 +21,8 @@
 #ifndef ACCELERATOR_HPP
 #define ACCELERATOR_HPP
 
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
 
 #include <vector>
 

--- a/quest/src/core/autodeployer.cpp
+++ b/quest/src/core/autodeployer.cpp
@@ -8,8 +8,8 @@
  * @author Richard Meister (aided in design)
  */
 
-#include "quest/include/modes.h"
-#include "quest/include/environment.h"
+#include "quest/modes.h"
+#include "quest/environment.h"
 
 #include "quest/src/core/memory.hpp"
 #include "quest/src/core/autodeployer.hpp"

--- a/quest/src/core/autodeployer.hpp
+++ b/quest/src/core/autodeployer.hpp
@@ -10,7 +10,7 @@
 #ifndef AUTODEPLOYER_HPP
 #define AUTODEPLOYER_HPP
 
-#include "quest/include/environment.h"
+#include "quest/environment.h"
 
 
 

--- a/quest/src/core/bitwise.hpp
+++ b/quest/src/core/bitwise.hpp
@@ -13,7 +13,7 @@
   #include <intrin.h>
 #endif
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 #include "quest/src/core/inliner.hpp"
 

--- a/quest/src/core/constants.hpp
+++ b/quest/src/core/constants.hpp
@@ -9,7 +9,7 @@
 #ifndef CONSTANTS_HPP
 #define CONSTANTS_HPP
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 
 inline constexpr qreal const_PI = 3.14159265358979323846;

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -7,9 +7,9 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
 
 #include "quest/src/core/printer.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -10,9 +10,9 @@
 #ifndef ERRORS_HPP
 #define ERRORS_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
 
 #include <string>
 

--- a/quest/src/core/fastmath.hpp
+++ b/quest/src/core/fastmath.hpp
@@ -9,9 +9,9 @@
 #ifndef FASTMATH_HPP
 #define FASTMATH_HPP
 
-#include "quest/include/precision.h"
-#include "quest/include/types.h"
-#include "quest/include/paulis.h"
+#include "quest/precision.h"
+#include "quest/types.h"
+#include "quest/paulis.h"
 
 #include "quest/src/core/inliner.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -11,10 +11,10 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
-#include "quest/include/initialisations.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
+#include "quest/initialisations.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -13,10 +13,10 @@
 #ifndef LOCALISER_HPP
 #define LOCALISER_HPP
 
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
 
 #include <vector>
 

--- a/quest/src/core/memory.cpp
+++ b/quest/src/core/memory.cpp
@@ -12,8 +12,8 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/paulis.h"
 
 #include "quest/src/core/memory.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/core/memory.hpp
+++ b/quest/src/core/memory.hpp
@@ -15,9 +15,9 @@
 #ifndef MEMORY_HPP
 #define MEMORY_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
 
 
 

--- a/quest/src/core/parser.cpp
+++ b/quest/src/core/parser.cpp
@@ -10,8 +10,8 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/paulis.h"
 
 #include "quest/src/core/parser.hpp"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/core/parser.hpp
+++ b/quest/src/core/parser.hpp
@@ -7,7 +7,7 @@
 #ifndef PARSER_HPP
 #define PARSER_HPP
 
-#include "quest/include/paulis.h"
+#include "quest/paulis.h"
 
 #include <string>
 

--- a/quest/src/core/printer.cpp
+++ b/quest/src/core/printer.cpp
@@ -9,11 +9,11 @@
  * @author Erich Essmann (improved OS agnosticism, patched mem-leak)
  */
 
-#include "quest/include/qureg.h"
-#include "quest/include/types.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
-#include "quest/include/paulis.h"
+#include "quest/qureg.h"
+#include "quest/types.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
+#include "quest/paulis.h"
 
 #include "quest/src/core/printer.hpp"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/core/printer.hpp
+++ b/quest/src/core/printer.hpp
@@ -8,11 +8,11 @@
 #ifndef PRINTER_HPP
 #define PRINTER_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
+#include "quest/paulis.h"
 
 #include <tuple>
 #include <vector>

--- a/quest/src/core/randomiser.cpp
+++ b/quest/src/core/randomiser.cpp
@@ -7,7 +7,7 @@
  * @author Balint Koczor (patched v3 MSVC seeding)
  */
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/core/randomiser.hpp
+++ b/quest/src/core/randomiser.hpp
@@ -9,7 +9,7 @@
 #ifndef RANDOMISER_HPP
 #define RANDOMISER_HPP
 
-#include "quest/include/types.h"
+#include "quest/types.h"
 
 #include <vector>
 #include <random>

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -7,12 +7,12 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
-#include "quest/include/precision.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
+#include "quest/precision.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -12,12 +12,12 @@
 #ifndef UTILITIES_HPP
 #define UTILITIES_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
-#include "quest/include/environment.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
+#include "quest/environment.h"
 
 #include <type_traits>
 #include <functional>

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -7,14 +7,14 @@
  * @author Kshitij Chhabra (patched v3 overflow bug)
  */
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/precision.h"
-#include "quest/include/environment.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
-#include "quest/include/paulis.h"
-#include "quest/include/channels.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/precision.h"
+#include "quest/environment.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
+#include "quest/paulis.h"
+#include "quest/channels.h"
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -8,12 +8,12 @@
 #ifndef VALIDATION_HPP
 #define VALIDATION_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/environment.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
+#include "quest/types.h"
+#include "quest/environment.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
 
 #include <vector>
 #include <string>

--- a/quest/src/cpu/cpu_config.cpp
+++ b/quest/src/cpu/cpu_config.cpp
@@ -5,9 +5,9 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/paulis.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/paulis.h"
 
 #include "quest/src/core/errors.hpp"
 

--- a/quest/src/cpu/cpu_config.hpp
+++ b/quest/src/cpu/cpu_config.hpp
@@ -8,8 +8,8 @@
 #ifndef CPU_CONFIG_HPP
 #define CPU_CONFIG_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/paulis.h"
+#include "quest/types.h"
+#include "quest/paulis.h"
 
 #include <vector>
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -14,11 +14,11 @@
  * @author Ania (Anna) Brown (developed QuEST v1 logic)
  */
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/inliner.hpp"

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -8,10 +8,10 @@
 #ifndef CPU_SUBROUTINES_HPP
 #define CPU_SUBROUTINES_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 #include "quest/src/core/utilities.hpp"
 

--- a/quest/src/gpu/gpu_config.cpp
+++ b/quest/src/gpu/gpu_config.cpp
@@ -5,12 +5,12 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
-#include "quest/include/environment.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
+#include "quest/environment.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/memory.hpp"

--- a/quest/src/gpu/gpu_config.hpp
+++ b/quest/src/gpu/gpu_config.hpp
@@ -12,10 +12,10 @@
 #ifndef GPU_CONFIG_HPP
 #define GPU_CONFIG_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/matrices.h"
-#include "quest/include/channels.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/matrices.h"
+#include "quest/channels.h"
 
 
 

--- a/quest/src/gpu/gpu_cuquantum.cuh
+++ b/quest/src/gpu/gpu_cuquantum.cuh
@@ -40,7 +40,7 @@
 #endif
 
 
-#include "quest/include/precision.h"
+#include "quest/precision.h"
 
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/gpu/gpu_config.hpp"

--- a/quest/src/gpu/gpu_kernels.cuh
+++ b/quest/src/gpu/gpu_kernels.cuh
@@ -18,8 +18,8 @@
 #ifndef GPU_KERNELS_HPP
 #define GPU_KERNELS_HPP
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
+#include "quest/modes.h"
+#include "quest/types.h"
 
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/gpu/gpu_types.cuh"

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -36,11 +36,11 @@
     #error "Cannot define COMPILE_CUQUANTUM=1 without simultaneously defining COMPILE_CUDA=1"
 #endif
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -7,10 +7,10 @@
 #ifndef GPU_SUBROUTINES_HPP
 #define GPU_SUBROUTINES_HPP
 
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 #include <vector>
 

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -25,11 +25,11 @@
     #error "A file being compiled somehow included gpu_thrust.hpp despite QuEST not being compiled in GPU-accelerated mode."
 #endif
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/qureg.h"
-#include "quest/include/paulis.h"
-#include "quest/include/matrices.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/qureg.h"
+#include "quest/paulis.h"
+#include "quest/matrices.h"
 
 #include "quest/src/gpu/gpu_types.cuh"
 #include "quest/src/core/errors.hpp"

--- a/quest/src/gpu/gpu_types.cuh
+++ b/quest/src/gpu/gpu_types.cuh
@@ -14,9 +14,9 @@
 #ifndef GPU_TYPES_HPP
 #define GPU_TYPES_HPP
 
-#include "quest/include/modes.h"
-#include "quest/include/types.h"
-#include "quest/include/precision.h"
+#include "quest/modes.h"
+#include "quest/types.h"
+#include "quest/precision.h"
 
 #include "quest/src/core/inliner.hpp"
 

--- a/tests/deprecated/test_calculations.cpp
+++ b/tests/deprecated/test_calculations.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_data_structures.cpp
+++ b/tests/deprecated/test_data_structures.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_gates.cpp
+++ b/tests/deprecated/test_gates.cpp
@@ -23,7 +23,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_main.cpp
+++ b/tests/deprecated/test_main.cpp
@@ -21,7 +21,7 @@
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "test_utilities.hpp"
 
 #include <stdexcept>

--- a/tests/deprecated/test_operators.cpp
+++ b/tests/deprecated/test_operators.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_state_initialisations.cpp
+++ b/tests/deprecated/test_state_initialisations.cpp
@@ -16,7 +16,7 @@
 
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
     

--- a/tests/deprecated/test_unitaries.cpp
+++ b/tests/deprecated/test_unitaries.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_utilities.cpp
+++ b/tests/deprecated/test_utilities.cpp
@@ -11,7 +11,7 @@
 
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_utilities.hpp
+++ b/tests/deprecated/test_utilities.hpp
@@ -9,7 +9,7 @@
 #ifndef QUEST_TEST_UTILS_H
 #define QUEST_TEST_UTILS_H
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/generators/catch_generators.hpp>
 

--- a/tests/integration/densitymatrix.cpp
+++ b/tests/integration/densitymatrix.cpp
@@ -7,7 +7,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -49,7 +49,7 @@
 #include <iostream>
 #include <string>
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "tests/utils/cache.hpp"
 #include "tests/utils/macros.hpp"
 #include "tests/utils/random.hpp"

--- a/tests/unit/calculations.cpp
+++ b/tests/unit/calculations.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_range.hpp>

--- a/tests/unit/channels.cpp
+++ b/tests/unit/channels.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/debug.cpp
+++ b/tests/unit/debug.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/decoherence.cpp
+++ b/tests/unit/decoherence.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_range.hpp>

--- a/tests/unit/environment.cpp
+++ b/tests/unit/environment.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/initialisations.cpp
+++ b/tests/unit/initialisations.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_range.hpp>

--- a/tests/unit/matrices.cpp
+++ b/tests/unit/matrices.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -15,7 +15,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>

--- a/tests/unit/paulis.cpp
+++ b/tests/unit/paulis.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/qureg.cpp
+++ b/tests/unit/qureg.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/types.cpp
+++ b/tests/unit/types.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/tests/utils/cache.cpp
+++ b/tests/utils/cache.cpp
@@ -5,7 +5,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "macros.hpp"
 #include "qvector.hpp"

--- a/tests/utils/cache.hpp
+++ b/tests/utils/cache.hpp
@@ -12,7 +12,7 @@
 #ifndef CACHE_HPP
 #define CACHE_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "qvector.hpp"
 #include "qmatrix.hpp"

--- a/tests/utils/compare.cpp
+++ b/tests/utils/compare.cpp
@@ -12,7 +12,7 @@
 #include "linalg.hpp"
 #include "macros.hpp"
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/tests/utils/compare.hpp
+++ b/tests/utils/compare.hpp
@@ -13,7 +13,7 @@
 #ifndef COMPARE_HPP
 #define COMPARE_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "qvector.hpp"
 #include "qmatrix.hpp"
 

--- a/tests/utils/convert.cpp
+++ b/tests/utils/convert.cpp
@@ -12,7 +12,7 @@
 #include "macros.hpp"
 #include "lists.hpp"
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <type_traits>
 using std::is_same_v;

--- a/tests/utils/convert.hpp
+++ b/tests/utils/convert.hpp
@@ -13,7 +13,7 @@
 #ifndef CONVERT_HPP
 #define CONVERT_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "qvector.hpp"
 #include "qmatrix.hpp"
 

--- a/tests/utils/lists.cpp
+++ b/tests/utils/lists.cpp
@@ -8,7 +8,7 @@
 #include <catch2/generators/catch_generators_range.hpp>
 #include <catch2/generators/catch_generators_adapters.hpp>
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "lists.hpp"
 #include "macros.hpp"

--- a/tests/utils/lists.hpp
+++ b/tests/utils/lists.hpp
@@ -13,7 +13,7 @@
 
 #include <catch2/generators/catch_generators_adapters.hpp>
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <vector>
 #include <tuple>

--- a/tests/utils/measure.cpp
+++ b/tests/utils/measure.cpp
@@ -6,7 +6,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "qvector.hpp"
 #include "qmatrix.hpp"

--- a/tests/utils/measure.hpp
+++ b/tests/utils/measure.hpp
@@ -13,7 +13,7 @@
 #ifndef MEASURE_HPP
 #define MEASURE_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "qvector.hpp"
 #include "qmatrix.hpp"

--- a/tests/utils/qmatrix.hpp
+++ b/tests/utils/qmatrix.hpp
@@ -13,7 +13,7 @@
 #ifndef QMATRIX_HPP
 #define QMATRIX_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "qvector.hpp"
 
 #include <vector>

--- a/tests/utils/qvector.hpp
+++ b/tests/utils/qvector.hpp
@@ -12,7 +12,7 @@
 #ifndef QVECTOR_HPP
 #define QVECTOR_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "macros.hpp"
 #include <vector>
 

--- a/tests/utils/random.cpp
+++ b/tests/utils/random.cpp
@@ -15,7 +15,7 @@
 #include "linalg.hpp"
 #include "lists.hpp"
 #include "random.hpp"
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <cmath>
 #include <vector>

--- a/tests/utils/random.hpp
+++ b/tests/utils/random.hpp
@@ -17,7 +17,7 @@
 #include "macros.hpp"
 #include "linalg.hpp"
 #include "lists.hpp"
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <vector>
 using std::vector;


### PR DESCRIPTION
Fixes #611 header issues:
- Moves the install directive for headers into main CMakeLists to make it recognize the install prefixes correctly
- Create  a more standard layout with `quest.h` and other headers under `quest/` subdirectory all in the usual include path.
- Use the build directories to create a structure similar to the desired install directories so that include paths are unique.
- Make `quest.h` configured so it contains the pre-processor defines if `VERBOSE_LIB_NAME` is false, and make those target defines private so they don’t appear in exported cmake files.
- Do not set the defines in `quest.h` and keep them in the exported cmake if `VERBOSE_LIB_NAME` is true.
- Differentiate exported cmake files using `$LIB_NAME` as well, so the matching cmake files link to the right verbosely-named libraries and provide the right compile-time flags, with a single set of header files.

I think all of the CMakeFiles machinery (in particular `foreach()` which seems to be discouraged) can be simplified at the cost of having all the files already in the final layout in the source directory. So all headers at `quest/include/quest.h.in` and `quest/include/quest/*.h` respectively. I can update the PR that way if that’s preferred.