### PR TITLE
example PR A

### DIFF
--- a/quest/include/calculations.h
+++ b/quest/include/calculations.h
@@ -43,6 +43,57 @@ extern "C" {
 
 
 /** 
+ * @defgroup example_prs Example PR functions
+ * @brief Nonsensical functions to demonstrate good PRs.
+ * @{
+ */
+
+
+/** Calculates the real component of the sum of every amplitude in the state,
+ * but only for states which contain an even number of qubits (for no reason :3 ).
+ * 
+ * @formulae
+ * Let @f$ n @f$ qubits be the number of qubits in @p qureg, assumed even.
+ * 
+ * - When @p qureg is a statevector @f$ \svpsi @f$, this function returns
+ *   @f[ 
+    \text{Re}\left( \sum\limits_i^{2^n} \langle i \svpsi \right) \in \mathbb{R}.
+ *   @f]
+ * - When @p qureg is a density matrix @f$ \dmrho @f$, this function returns
+ *   @f[ 
+    \text{Re}\left( \sum\limits_i^{2^n} \sum\limits_j^{2^n} \bra{i} \dmrho \ket{j} \right) \in \mathbb{R}.
+ *   @f]
+ * 
+ * @constraints
+ * - The number of qubits in the register must be even.
+ * 
+ * @myexample
+ * ```
+    Qureg qureg = createQureg(4);
+    initRandomPureState(qureg);
+
+    qreal reAmpSum = calcRealAmpSum(qureg);
+    reportScalar("reAmpSum", reAmpSum);  
+ * ```
+ * 
+ * @see
+ * - calcTotalProb()
+
+ * @param[in] qureg the state with the processed amplitudes.
+ * @returns The real component of the sum of all contained amplitudes.
+ * @throws @validationerror
+ * - if @p qureg is uninitialised.
+ * - if @p qureg contains an odd number of qubits.
+ * @author Tyson Jones
+ */
+qreal calcRealAmpSum(Qureg qureg);
+
+
+/** @} */
+
+
+
+/** 
  * @defgroup calc_expec Expectation values
  * @brief Functions for calculating expected values of Hermitian observables.
  * @{
@@ -289,6 +340,44 @@ Qureg calcReducedDensityMatrix(Qureg qureg, int* retainQubits, int numRetainQubi
  * the user's C binary. We manually add these functions to their
  * respective Doxygen doc groups defined above
  */
+
+
+/** @ingroup example_prs
+ * 
+ * Calculates the sum of every amplitude in the state.
+ * 
+ * @formulae
+ * Let @f$ n @f$ qubits be the number of qubits in @p qureg.
+ * 
+ * - When @p qureg is a statevector @f$ \svpsi @f$, this function returns
+ *   @f[ 
+    \sum\limits_i^{2^n} \langle i \svpsi \in \mathbb{C}.
+ *   @f]
+ * - When @p qureg is a density matrix @f$ \dmrho @f$, this function returns
+ *   @f[ 
+    \sum\limits_i^{2^n} \sum\limits_j^{2^n} \bra{i} \dmrho \ket{j} \in \mathbb{C}.
+ *   @f]
+ *
+ * @myexample
+ * ```
+    Qureg qureg = createQureg(4);
+    initRandomPureState(qureg);
+
+    qcomp ampSum = calcAmpSum(qureg);
+    reportScalar("ampSum", ampSum);  
+ * ```
+ * 
+ * @see
+ * - calcRealAmpSum()
+
+ * @param[in] qureg the state with the processed amplitudes.
+ * @returns The the sum of all contained amplitudes.
+ * @throws @validationerror
+ * - if @p qureg is uninitialised.
+ * - if @p qureg contains an odd number of qubits.
+ * @author Tyson Jones
+ */
+qcomp calcAmpSum(Qureg qureg);
 
 
 /// @ingroup calc_comparisons

--- a/quest/include/wrappers.h
+++ b/quest/include/wrappers.h
@@ -42,6 +42,15 @@
 #ifndef __cplusplus
 
 
+extern void _wrap_calcAmpSum(Qureg qureg, qcomp* out);
+
+qcomp calcAmpSum(Qureg qureg) {
+
+    qcomp out;
+    _wrap_calcAmpSum(qureg, &out);
+    return out;
+}
+
 
 extern void _wrap_calcInnerProduct(Qureg bra, Qureg ket, qcomp* out);
 

--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -46,6 +46,17 @@ extern Qureg validateAndCreateCustomQureg(
  */
 
 
+qcomp calcAmpSum(Qureg qureg) {
+    validate_quregFields(qureg, __func__);
+
+    return localiser_statevec_calcAmpSum(qureg);
+}
+extern "C" void _wrap_calcAmpSum(Qureg qureg, qcomp* out) {
+
+    *out = calcAmpSum(qureg);
+}
+
+
 qcomp calcInnerProduct(Qureg quregA, Qureg quregB) {
     validate_quregFields(quregA, __func__);
     validate_quregFields(quregB, __func__);
@@ -122,6 +133,23 @@ extern "C" void _wrap_calcExpecNonHermitianFullStateDiagMatrPower(qcomp* out, Qu
 
 // enable invocation by both C and C++ binaries
 extern "C" {
+
+
+
+/*
+ * PR DEMOS
+ */
+
+
+qreal calcRealAmpSum(Qureg qureg) {
+    validate_quregFields(qureg, __func__);
+    validate_quregHasEvenNumQubits(qureg, __func__);
+
+    // logic is identical for both statevectors and density matrices
+    qcomp value = localiser_statevec_calcAmpSum(qureg);
+
+    return std::real(value);
+}
 
 
 

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -183,6 +183,20 @@ using std::min;
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp accel_statevec_calcAmpSum(Qureg qureg) {
+
+    return (qureg.isGpuAccelerated)?
+        gpu_statevec_calcAmpSum(qureg):
+        cpu_statevec_calcAmpSum(qureg);
+}
+
+
+
+/*
  * GETTERS 
  */
 

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -148,6 +148,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp accel_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS 
  */
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -462,6 +462,27 @@ void exchangeAmpsToBuffersWhereQubitsAreInStates(Qureg qureg, int pairRank, vect
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp localiser_statevec_calcAmpSum(Qureg qureg) {
+
+    // each node computes the sum of its local amps
+    // in an embarrassingly parallel fashion
+    qcomp out =  accel_statevec_calcAmpSum(qureg);
+
+    // node partial sums are combined, and every
+    // node receives a copy of the full sum (consensus)
+    if (qureg.isDistributed)
+        comm_reduceAmp(&out);
+
+    return out;
+}
+
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -24,6 +24,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp localiser_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -58,6 +58,14 @@ namespace report {
 
 
     /*
+     * NONSENSE VALIDATION FOR DEMO PR
+     */
+
+    string QUREG_HAS_ODD_NUM_QUBITS =
+        "The given Qureg contained ${NUM_QUBITS} qubits, but must contain an even number.";
+
+
+    /*
      *  ENVIRONMENT CREATION
      */
 
@@ -1302,6 +1310,21 @@ bool isIndexListUnique(int* list, int len) {
             mask |= 1ULL << list[i];
 
     return true;
+}
+
+
+
+/*
+ * NONSENSE VALIDATION FOR DEMO PR
+ */
+
+void validate_quregHasEvenNumQubits(Qureg qureg, const char* caller) {
+
+    tokenSubs vars = {
+        {"${NUM_QUBITS}", qureg.numQubits}
+    };
+
+    assertThat(qureg.numQubits % 2 == 0, report::QUREG_HAS_ODD_NUM_QUBITS, vars, caller);
 }
 
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -64,6 +64,14 @@ qreal validateconfig_getEpsilon();
 
 
 /*
+ * NONSENSE VALIDATION FOR DEMO PR
+ */
+
+void validate_quregHasEvenNumQubits(Qureg qureg, const char* caller);
+
+
+
+/*
  * ENVIRONMENT CREATION
  */
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -41,6 +41,34 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp cpu_statevec_calcAmpSum(Qureg qureg) {
+
+    // we brazenly perform this all-state reduction without
+    // a single thought to finite precision effects - arrest me! 
+
+    // separately reduce real and imag components to make MSVC happy
+    qreal outRe = 0;
+    qreal outIm = 0;
+
+    // every local amplitude contributes to the sum
+    qindex numIts = qureg.numAmpsPerNode;
+
+    #pragma omp parallel for reduction(+:outRe,outIm) if(qureg.isMultithreaded)
+    for (qindex n=0; n<numIts; n++) {
+        outRe += std::real(qureg.cpuAmps[n]);
+        outIm += std::imag(qureg.cpuAmps[n]);
+    }
+
+    return qcomp(outRe, outIm);
+}
+
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -21,6 +21,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp cpu_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -66,6 +66,32 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+
+qcomp gpu_statevec_calcAmpSum(Qureg qureg) {
+
+#if COMPILE_CUDA || COMPILE_CUQUANTUM
+
+    // there is no cuQuantum function for this facility,
+    // nor is there a need to implement a custom kernel;
+    // we will leverage an exting Thrust facility
+    cu_qcomp out =  thrust_statevec_calcAmpSum(qureg);
+
+    // the GPU backend uses a CUDA-equivalent of 'qcomp'
+    // which we must cast back and forth between (ew!)
+    return toQcomp(out);
+
+#else
+    error_gpuSimButGpuNotCompiled();
+    return -1;
+#endif
+}
+
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -18,6 +18,13 @@ using std::vector;
 
 
 /*
+ * PR DEMOS
+ */
+
+qcomp gpu_statevec_calcAmpSum(Qureg qureg);
+
+
+/*
  * GETTERS
  */
 

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -636,6 +636,27 @@ struct functor_setRandomStateVecAmp : public thrust::unary_function<qindex,cu_qc
 
 
 /*
+ * PR DEMOS
+ */
+
+
+cu_qcomp thrust_statevec_calcAmpSum(Qureg qureg) {
+
+    // beware that we must explicitly instantiate a 
+    // qcomp type here, rather than pass reduce() a
+    // literal, which would cause a silent bug (grr)
+    cu_qcomp init = getCuQcomp(0, 0);
+
+    cu_qcomp out = thrust::reduce(
+        getStartPtr(qureg), getEndPtr(qureg), 
+        init, thrust::plus<cu_qcomp>());
+
+    return out;
+}
+
+
+
+/*
  * MATRIX INITIALISATION
  */
 

--- a/tests/unit/calculations.cpp
+++ b/tests/unit/calculations.cpp
@@ -11,6 +11,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "tests/utils/qvector.hpp"
@@ -31,6 +32,7 @@
 
 using std::vector;
 using namespace Catch::Matchers;
+using Catch::Matchers::ContainsSubstring;
 
 
 
@@ -153,6 +155,71 @@ void TEST_ON_CACHED_QUREG_AND_MATRIX(quregCache quregs, matrixCache matrices, au
  * @ingroup unitcalcs
  * @{
  */
+
+
+
+TEST_CASE( "calcRealAmpSum", TEST_CATEGORY ) {
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        // The boilerplate for testing a function differs
+        // greatly depending on what the function does;
+        // this function is trivial so has a simple test,
+        // re-using the existing TEST_ALL_QUREGS() macro.
+        // This macro invokes the below RHS expressions
+        // passing substitutions of the LHS expressions
+        // with Quregs (statevector or density matrix)
+        // and reference objects (qvector or qmatrix), for
+        // every possible deployment (i.e. multithreading,
+        // GPU-acceleration, distribution, hybrids, etc).
+
+        TEST_ALL_QUREGS(
+            qureg, calcRealAmpSum(qureg),
+            refer, std::real(getTotal(refer))
+        );
+    }
+
+    SECTION( LABEL_VALIDATION ) {
+
+        SECTION( "qureg uninitialised" ) {
+
+            // prepare an un-initialised qureg
+            Qureg qureg;
+
+            // manually mangle the fields for validation
+            // to detect, since the default values are
+            // undefined behaviour and might not trigger
+            // (e.g. compiler could re-use a valid Qureg)
+            qureg.numQubits = -123;
+
+            REQUIRE_THROWS_WITH( calcRealAmpSum(qureg), ContainsSubstring("invalid Qureg") );
+        }
+    }
+}
+
+
+
+TEST_CASE( "calcAmpSum", TEST_CATEGORY ) {
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        TEST_ALL_QUREGS(
+            qureg, calcAmpSum(qureg),
+            refer, getTotal(refer)
+        );
+    }
+
+    SECTION( LABEL_VALIDATION ) {
+
+        SECTION( "qureg uninitialised" ) {
+
+            Qureg qureg;
+            qureg.numQubits = -123;
+
+            REQUIRE_THROWS_WITH( calcRealAmpSum(qureg), ContainsSubstring("invalid Qureg") );
+        }
+    }
+}
 
 
 

--- a/tests/utils/linalg.cpp
+++ b/tests/utils/linalg.cpp
@@ -108,6 +108,37 @@ int getNumPermutations(int n, int k) {
 
 
 /*
+ * NONSENSE PR OPERATIONS
+ */
+
+
+qcomp getTotal(qvector in) {
+
+    qcomp out = 0;
+
+    // no compensated summation
+    for (auto& elem : in)
+        out += elem;
+
+    return out;
+}
+
+
+qcomp getTotal(qmatrix in) {
+
+    qcomp out = 0;
+
+    // no compensated summation
+    for (auto& row : in)
+        for (auto& elem : row)
+            out += elem;
+
+    return out;
+}
+
+
+
+/*
  * VECTOR OPERATIONS
  */
 

--- a/tests/utils/linalg.hpp
+++ b/tests/utils/linalg.hpp
@@ -29,6 +29,9 @@ qindex setBitAt(qindex num, int ind, int bit);
 qindex setBitsAt(qindex num, vector<int> inds, qindex bits);
 qindex getPow2(int);
 
+qcomp getTotal(qvector);
+qcomp getTotal(qmatrix);
+
 qreal getSum(vector<qreal> vec);
 qcomp getSum(qvector);
 qvector getNormalised(qvector);


### PR DESCRIPTION
# Example PR A

This example PR demonstrates how to add a new, standard QuEST function. As an illustration, it implements `calcAmpSum()` (and `calcRealAmpSum()`) which returns the sum of all amplitudes in a `Qureg` (or just its real component).

The PR combines the changes of the four PRs below which each illustrate an isolated "step" of implementing a new feature.

1. ([#607](https://github.com/QuEST-Kit/QuEST/pull/607)) `calcRealAmpSum()` frontend
2. ([#608](https://github.com/QuEST-Kit/QuEST/pull/608)) `calc(Real)AmpSum()` backend
3. ([#609](https://github.com/QuEST-Kit/QuEST/pull/609)) `calcRealAmpSum()` unit tests
4. ([#610](https://github.com/QuEST-Kit/QuEST/pull/610)) `calcAmpSum()` frontend

These individual PRs document how to expose and document the new function, validate its user inputs, implement its accelerated backends (distributed, multithreaded and GPU-accelerated) and its unit tests. It also demonstrates some extra steps needed to maintain `C` and `C++` agnosticism when the new function returns a `qcomp` directly, as `calcAmpSum()` does.