### PR TITLE
V4 header install devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,22 @@ message(STATUS "Library will be named lib${LIB_NAME}. Set LIB_NAME to modify.")
 option(VERBOSE_LIB_NAME "Modify library name based on compilation configuration. Turned OFF by default." OFF)
 message(STATUS "Verbose library naming is turned ${VERBOSE_LIB_NAME}. Set VERBOSE_LIB_NAME to modify.")
 
+if (VERBOSE_LIB_NAME)
+  # Same headers will be used for several verbosely-named libraries
+  set(MULTI_LIB_HEADERS 1)
+  function(compile_option VAR VALUE)
+    target_compile_definitions(QuEST PUBLIC ${VAR}=${VALUE})
+  endfunction()
+else()
+  # Headers will be used for a single library with a single valid configuration
+  set(MULTI_LIB_HEADERS 0)
+  function(compile_option VAR VALUE)
+    target_compile_definitions(QuEST PRIVATE ${VAR}=${VALUE})
+    set(${VAR} ${VALUE})
+  endfunction()
+endif()
+
+
 # Precision
 set(FLOAT_PRECISION 2 
   CACHE 
@@ -253,8 +269,8 @@ target_include_directories(QuEST
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/quest/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<INSTALL_INTERFACE:${ORG_INSTALL_PATH}>
 )
 set_target_properties(QuEST PROPERTIES
         VERSION     ${PROJECT_VERSION}
@@ -283,7 +299,7 @@ target_compile_options(QuEST
 
 
 # Set user options
-target_compile_definitions(QuEST PUBLIC FLOAT_PRECISION=${FLOAT_PRECISION})
+compile_option(FLOAT_PRECISION ${FLOAT_PRECISION})
 
 if (ENABLE_MULTITHREADING)
 
@@ -299,7 +315,7 @@ if (ENABLE_MULTITHREADING)
     message(FATAL_ERROR ${ErrorMsg})
   endif()
 
-  target_compile_definitions(QuEST PUBLIC COMPILE_OPENMP=1)
+  compile_option(COMPILE_OPENMP 1)
   target_link_libraries(QuEST
     PRIVATE
     OpenMP::OpenMP_CXX
@@ -317,14 +333,14 @@ else()
     target_compile_options(QuEST PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>)
   endif()
   
-  target_compile_definitions(QuEST PUBLIC COMPILE_OPENMP=0)
+  compile_option(COMPILE_OPENMP 0)
 endif()
 
 if (ENABLE_DISTRIBUTION)
   find_package(MPI REQUIRED
     COMPONENTS CXX
   )
-  target_compile_definitions(QuEST PUBLIC COMPILE_MPI=1)
+  compile_option(COMPILE_MPI 1)
   target_link_libraries(QuEST
     PRIVATE
     MPI::MPI_CXX
@@ -333,7 +349,7 @@ if (ENABLE_DISTRIBUTION)
     string(CONCAT LIB_NAME ${LIB_NAME} "+mpi")
   endif()
 else()
-  target_compile_definitions(QuEST PUBLIC COMPILE_MPI=0)
+  compile_option(COMPILE_MPI 0)
 endif()
 
 if (ENABLE_CUDA)
@@ -357,14 +373,14 @@ endif()
 
 if (ENABLE_CUQUANTUM)
   find_package(CUQUANTUM REQUIRED)
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=1)
+  compile_option(COMPILE_CUQUANTUM 1)
   target_link_libraries(QuEST PRIVATE CUQUANTUM::cuStateVec)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
   if (VERBOSE_LIB_NAME)
     string(CONCAT LIB_NAME ${LIB_NAME} "+cuquantum")
   endif()
 else()
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=0)
+  compile_option(COMPILE_CUQUANTUM 0)
 endif()
 
 if (ENABLE_HIP)
@@ -384,7 +400,7 @@ if (ENABLE_HIP)
   find_package(HIP REQUIRED)
   message(STATUS "Found HIP: " ${HIP_VERSION})
 
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUQUANTUM=0)
+  compile_option(COMPILE_CUQUANTUM 0)
   target_link_libraries(QuEST PRIVATE hip::host)
 
   if (VERBOSE_LIB_NAME)
@@ -393,9 +409,9 @@ if (ENABLE_HIP)
 endif()
 
 if (ENABLE_CUDA OR ENABLE_HIP)
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUDA=1)
+  compile_option(COMPILE_CUDA 1)
 else()
-  target_compile_definitions(QuEST PUBLIC COMPILE_CUDA=0)
+  compile_option(COMPILE_CUDA 0)
 endif()
 
 if (ENABLE_DEPRECATED_API)
@@ -550,6 +566,15 @@ install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfigVersion.cmake"
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/quest.h"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/quest/include"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/quest"
+        FILES_MATCHING PATTERN "*.h"
 )
 
 install(EXPORT QuESTTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,7 +549,7 @@ set(QuEST_INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/QuEST")
 
 # Write QuESTConfigVersion.cmake
 write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake"
         VERSION ${PROJECT_VERSION}
         COMPATIBILITY AnyNewerVersion
 )
@@ -557,14 +557,14 @@ write_basic_package_version_file(
 # Configure QuESTConfig.cmake (from template)
 configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/QuESTConfig.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake"
         INSTALL_DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )
 
 # Install them
 install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfig.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/QuESTConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake"
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )
 
@@ -578,7 +578,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/quest/include"
 )
 
 install(EXPORT QuESTTargets
-        FILE QuESTTargets.cmake
+        FILE "${LIB_NAME}Targets.cmake"
         NAMESPACE QuEST::
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )

--- a/cmake/QuESTConfig.cmake.in
+++ b/cmake/QuESTConfig.cmake.in
@@ -1,4 +1,4 @@
 # @author Erich Essmann
 
 @PACKAGE_INIT@
-include("${CMAKE_CURRENT_LIST_DIR}/QuESTTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@LIB_NAME@Targets.cmake")

--- a/quest/include/CMakeLists.txt
+++ b/quest/include/CMakeLists.txt
@@ -1,7 +1,4 @@
 # @author Oliver Thomson Brown
 # @author Erich Essmann
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DESTINATION "${CMAKE_INSTALL_PREFIX}"
-        FILES_MATCHING PATTERN "*.h" 
-)
+configure_file(quest.h.in "${CMAKE_BINARY_DIR}/include/quest.h" @ONLY)

--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -18,7 +18,7 @@
 #ifndef DEPRECATED_H
 #define DEPRECATED_H
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "stdlib.h"
 

--- a/quest/include/quest.h.in
+++ b/quest/include/quest.h.in
@@ -30,6 +30,15 @@
 #define QUEST_H
 
 
+#if !@MULTI_LIB_HEADERS@
+#cmakedefine FLOAT_PRECISION @FLOAT_PRECISION@
+#cmakedefine01 COMPILE_MPI
+#cmakedefine01 COMPILE_OPENMP
+#cmakedefine01 COMPILE_CUDA
+#cmakedefine01 COMPILE_CUQUANTUM
+#endif
+
+
 // include version first so it is accessible to 
 // debuggers in case a subsequent include fails
 #include "quest/include/version.h"

--- a/tests/deprecated/test_calculations.cpp
+++ b/tests/deprecated/test_calculations.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_data_structures.cpp
+++ b/tests/deprecated/test_data_structures.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_gates.cpp
+++ b/tests/deprecated/test_gates.cpp
@@ -23,7 +23,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_main.cpp
+++ b/tests/deprecated/test_main.cpp
@@ -21,7 +21,7 @@
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "test_utilities.hpp"
 
 #include <stdexcept>

--- a/tests/deprecated/test_operators.cpp
+++ b/tests/deprecated/test_operators.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_state_initialisations.cpp
+++ b/tests/deprecated/test_state_initialisations.cpp
@@ -16,7 +16,7 @@
 
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
     

--- a/tests/deprecated/test_unitaries.cpp
+++ b/tests/deprecated/test_unitaries.cpp
@@ -20,7 +20,7 @@
 // warnings issued by its compilation
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_utilities.cpp
+++ b/tests/deprecated/test_utilities.cpp
@@ -11,7 +11,7 @@
 
 #define INCLUDE_DEPRECATED_FUNCTIONS 1
 #define DISABLE_DEPRECATION_WARNINGS 1
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "test_utilities.hpp"
 

--- a/tests/deprecated/test_utilities.hpp
+++ b/tests/deprecated/test_utilities.hpp
@@ -9,7 +9,7 @@
 #ifndef QUEST_TEST_UTILS_H
 #define QUEST_TEST_UTILS_H
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/generators/catch_generators.hpp>
 

--- a/tests/integration/densitymatrix.cpp
+++ b/tests/integration/densitymatrix.cpp
@@ -7,7 +7,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -49,7 +49,7 @@
 #include <iostream>
 #include <string>
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "tests/utils/cache.hpp"
 #include "tests/utils/macros.hpp"
 #include "tests/utils/random.hpp"

--- a/tests/unit/calculations.cpp
+++ b/tests/unit/calculations.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_range.hpp>

--- a/tests/unit/channels.cpp
+++ b/tests/unit/channels.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/debug.cpp
+++ b/tests/unit/debug.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/decoherence.cpp
+++ b/tests/unit/decoherence.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/environment.cpp
+++ b/tests/unit/environment.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/initialisations.cpp
+++ b/tests/unit/initialisations.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/matrices.cpp
+++ b/tests/unit/matrices.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -15,7 +15,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>

--- a/tests/unit/paulis.cpp
+++ b/tests/unit/paulis.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/qureg.cpp
+++ b/tests/unit/qureg.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/unit/types.cpp
+++ b/tests/unit/types.cpp
@@ -7,7 +7,7 @@
  * @ingroup unittests
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/utils/cache.cpp
+++ b/tests/utils/cache.cpp
@@ -5,7 +5,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "macros.hpp"
 #include "qvector.hpp"

--- a/tests/utils/cache.hpp
+++ b/tests/utils/cache.hpp
@@ -12,7 +12,7 @@
 #ifndef CACHE_HPP
 #define CACHE_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "qvector.hpp"
 #include "qmatrix.hpp"

--- a/tests/utils/compare.cpp
+++ b/tests/utils/compare.cpp
@@ -12,7 +12,7 @@
 #include "linalg.hpp"
 #include "macros.hpp"
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/tests/utils/compare.hpp
+++ b/tests/utils/compare.hpp
@@ -13,7 +13,7 @@
 #ifndef COMPARE_HPP
 #define COMPARE_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "qvector.hpp"
 #include "qmatrix.hpp"
 

--- a/tests/utils/convert.cpp
+++ b/tests/utils/convert.cpp
@@ -12,7 +12,7 @@
 #include "macros.hpp"
 #include "lists.hpp"
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <type_traits>
 using std::is_same_v;

--- a/tests/utils/convert.hpp
+++ b/tests/utils/convert.hpp
@@ -13,7 +13,7 @@
 #ifndef CONVERT_HPP
 #define CONVERT_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "qvector.hpp"
 #include "qmatrix.hpp"
 

--- a/tests/utils/lists.cpp
+++ b/tests/utils/lists.cpp
@@ -8,7 +8,7 @@
 #include <catch2/generators/catch_generators_range.hpp>
 #include <catch2/generators/catch_generators_adapters.hpp>
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "lists.hpp"
 #include "macros.hpp"

--- a/tests/utils/lists.hpp
+++ b/tests/utils/lists.hpp
@@ -13,7 +13,7 @@
 
 #include <catch2/generators/catch_generators_adapters.hpp>
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <vector>
 #include <tuple>

--- a/tests/utils/measure.cpp
+++ b/tests/utils/measure.cpp
@@ -6,7 +6,7 @@
  * @author Tyson Jones
  */
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "qvector.hpp"
 #include "qmatrix.hpp"

--- a/tests/utils/measure.hpp
+++ b/tests/utils/measure.hpp
@@ -13,7 +13,7 @@
 #ifndef MEASURE_HPP
 #define MEASURE_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include "qvector.hpp"
 #include "qmatrix.hpp"

--- a/tests/utils/qmatrix.hpp
+++ b/tests/utils/qmatrix.hpp
@@ -13,7 +13,7 @@
 #ifndef QMATRIX_HPP
 #define QMATRIX_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "qvector.hpp"
 
 #include <vector>

--- a/tests/utils/qvector.hpp
+++ b/tests/utils/qvector.hpp
@@ -12,7 +12,7 @@
 #ifndef QVECTOR_HPP
 #define QVECTOR_HPP
 
-#include "quest/include/quest.h"
+#include "quest.h"
 #include "macros.hpp"
 #include <vector>
 

--- a/tests/utils/random.cpp
+++ b/tests/utils/random.cpp
@@ -15,7 +15,7 @@
 #include "linalg.hpp"
 #include "lists.hpp"
 #include "random.hpp"
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <cmath>
 #include <vector>

--- a/tests/utils/random.hpp
+++ b/tests/utils/random.hpp
@@ -17,7 +17,7 @@
 #include "macros.hpp"
 #include "linalg.hpp"
 #include "lists.hpp"
-#include "quest/include/quest.h"
+#include "quest.h"
 
 #include <vector>
 using std::vector;


### PR DESCRIPTION
#614 fixing #611 rebased on devel, and without changing include paths. (Does not require foreach anymore).

Creates some quirky layout of files but all headers are under `$prefix/include` and `quest.h` can be included as `#include "quest.h"` (which required updating some of the deprecated test paths which were trying to include `quest/include/quest.h`).

Example with verbose installing to `/tmp/cmake`:
```
-- Install configuration: "Debug"
-- Installing: /tmp/quest/bin/min_example
-- Set non-toolchain portion of runtime path of "/tmp/quest/bin/min_example" to "$ORIGIN/../lib64"
-- Installing: /tmp/quest/lib64/libQuEST-fp1+mt.so.4.0.0
-- Installing: /tmp/quest/lib64/libQuEST-fp1+mt.so.4
-- Set non-toolchain portion of runtime path of "/tmp/quest/lib64/libQuEST-fp1+mt.so.4.0.0" to "$ORIGIN/../lib64"
-- Installing: /tmp/quest/lib64/libQuEST-fp1+mt.so
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuEST-fp1+mtConfig.cmake
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuEST-fp1+mtConfigVersion.cmake
-- Installing: /tmp/quest/include/quest.h
-- Up-to-date: /tmp/quest/include/quest/include
-- Up-to-date: /tmp/quest/include/quest/include/calculations.h
-- Up-to-date: /tmp/quest/include/quest/include/channels.h
-- Up-to-date: /tmp/quest/include/quest/include/decoherence.h
-- Up-to-date: /tmp/quest/include/quest/include/environment.h
-- Up-to-date: /tmp/quest/include/quest/include/initialisations.h
-- Up-to-date: /tmp/quest/include/quest/include/matrices.h
-- Up-to-date: /tmp/quest/include/quest/include/modes.h
-- Up-to-date: /tmp/quest/include/quest/include/operations.h
-- Up-to-date: /tmp/quest/include/quest/include/paulis.h
-- Up-to-date: /tmp/quest/include/quest/include/precision.h
-- Up-to-date: /tmp/quest/include/quest/include/qureg.h
-- Up-to-date: /tmp/quest/include/quest/include/types.h
-- Up-to-date: /tmp/quest/include/quest/include/version.h
-- Up-to-date: /tmp/quest/include/quest/include/wrappers.h
-- Installing: /tmp/quest/include/quest/include/debug.h
-- Installing: /tmp/quest/include/quest/include/deprecated.h
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuEST-fp1+mtTargets.cmake
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuEST-fp1+mtTargets-debug.cmake
```

And without verbose naming, defines aren’t set in cmake files anymore but in `quest.h` directly:
```
-- Install configuration: "Debug"
-- Installing: /tmp/quest/bin/min_example
-- Set non-toolchain portion of runtime path of "/tmp/quest/bin/min_example" to "$ORIGIN/../lib64"
-- Installing: /tmp/quest/lib64/libQuEST.so.4.0.0
-- Installing: /tmp/quest/lib64/libQuEST.so.4
-- Set non-toolchain portion of runtime path of "/tmp/quest/lib64/libQuEST.so.4.0.0" to "$ORIGIN/../lib64"
-- Installing: /tmp/quest/lib64/libQuEST.so
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuESTConfig.cmake
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuESTConfigVersion.cmake
-- Installing: /tmp/quest/include/quest.h
-- Up-to-date: /tmp/quest/include/quest/include
-- Up-to-date: /tmp/quest/include/quest/include/calculations.h
-- Up-to-date: /tmp/quest/include/quest/include/channels.h
-- Up-to-date: /tmp/quest/include/quest/include/decoherence.h
-- Up-to-date: /tmp/quest/include/quest/include/environment.h
-- Up-to-date: /tmp/quest/include/quest/include/initialisations.h
-- Up-to-date: /tmp/quest/include/quest/include/matrices.h
-- Up-to-date: /tmp/quest/include/quest/include/modes.h
-- Up-to-date: /tmp/quest/include/quest/include/operations.h
-- Up-to-date: /tmp/quest/include/quest/include/paulis.h
-- Up-to-date: /tmp/quest/include/quest/include/precision.h
-- Up-to-date: /tmp/quest/include/quest/include/qureg.h
-- Up-to-date: /tmp/quest/include/quest/include/types.h
-- Up-to-date: /tmp/quest/include/quest/include/version.h
-- Up-to-date: /tmp/quest/include/quest/include/wrappers.h
-- Up-to-date: /tmp/quest/include/quest/include/debug.h
-- Up-to-date: /tmp/quest/include/quest/include/deprecated.h
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuESTTargets.cmake
-- Installing: /tmp/quest/lib64/cmake/QuEST/QuESTTargets-debug.cmake
```