### PR TITLE
Update setBit due to overflow in bit shift

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,6 +44,8 @@ Dr Ian Bush [consultant]
     HPC
 
 External contributors:
+James Richings
+    patched overflow in bitwise.hpp logic
 Luc Jaulmes
     patched v4's install process using CMake
 Jakub Adamski

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ See the [docs](docs/README.md) for enabling acceleration and running the unit te
 
 In addition to QuEST's [authors](AUTHORS.txt), we sincerely thank the following external contributors to QuEST.
 
+- [James Richings](https://github.com/JPRichings) for patching a v4 overflow bug.
 - [Luc Jaulmes](https://github.com/lucjaulmes) for patching v4's CMake installation.
 - [Jakub Adamski](https://github.com/jjacobx) for optimising distributed communication of max-size messages.
 - [Bruno Villasenor Alvarez](https://github.com/bvillasen) of [AMD](https://www.amd.com/en.html) for porting the v3 GPU backend to [HIP](https://github.com/ROCm-Developer-Tools/HIP), for compatibility with AMD GPUs.

--- a/quest/src/core/bitwise.hpp
+++ b/quest/src/core/bitwise.hpp
@@ -4,6 +4,7 @@
  * 
  * @author Tyson Jones
  * @author Erich Essmann (improved OS agnosticism)
+ * @author James Richings (patched setBit)
  */
 
 #ifndef BITWISE_HPP
@@ -106,8 +107,8 @@ INLINE qindex insertBit(qindex number, int bitIndex, int bitValue) {
 
 INLINE qindex setBit(qindex number, int bitIndex, int bitValue) {
     
-    // beware that shifting the raw int would overflow
-    qindex bitInPlace = ((qindex) bitValue)   << bitIndex;
+    // beware that shifting the raw int would overflow (#623)
+    qindex bitInPlace = ((qindex) bitValue) << bitIndex;
     qindex oneInPlace = QINDEX_ONE << bitIndex;
     return (number & ~oneInPlace) | bitInPlace;
 }

--- a/quest/src/core/bitwise.hpp
+++ b/quest/src/core/bitwise.hpp
@@ -104,9 +104,10 @@ INLINE qindex insertBit(qindex number, int bitIndex, int bitValue) {
 }
 
 
-INLINE qindex setBit(qindex number, int bitIndex, unsigned long long int bitValue) {
+INLINE qindex setBit(qindex number, int bitIndex, int bitValue) {
     
-    qindex bitInPlace = bitValue   << bitIndex;
+    // beware that shifting the raw int would overflow
+    qindex bitInPlace = ((qindex) bitValue)   << bitIndex;
     qindex oneInPlace = QINDEX_ONE << bitIndex;
     return (number & ~oneInPlace) | bitInPlace;
 }

--- a/quest/src/core/bitwise.hpp
+++ b/quest/src/core/bitwise.hpp
@@ -104,7 +104,7 @@ INLINE qindex insertBit(qindex number, int bitIndex, int bitValue) {
 }
 
 
-INLINE qindex setBit(qindex number, int bitIndex, int bitValue) {
+INLINE qindex setBit(qindex number, int bitIndex, unsigned long long int bitValue) {
     
     qindex bitInPlace = bitValue   << bitIndex;
     qindex oneInPlace = QINDEX_ONE << bitIndex;


### PR DESCRIPTION
Hardware target: Nvidia grace-hopper single node

Compile target: COMPILE_CUDA

Cmake: cmake .. -D ENABLE_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES=90 -D CMAKE_INSTALL_PREFIX=/work/jriching/Quest/prefix -D USER_SOURCE=../../QFT/qft.cpp -D OUTPUT_EXE=qft


code: qft implementation used previous Archer2 benchmarking work updated for quest v4.0 

Error: 
```
terminate called after throwing an instance of 'thrust::system::system_error'
  what():  reduce failed to synchronize: cudaErrorIllegalAddress: an illegal memory access was encountered
Aborted (core dumped)
```

Compute sanitize output:

```
compute-sanitizer qft 32
```

```
Total number of gates: 528
Measured probability amplitude of |0..0> state: 2.32831e-10
Calculated probability amplitude of |0..0>, C0 = 1 / 2^32: 2.32831e-10
Measuring final state: (all probabilities should be 0.5)
========= Invalid __global__ read of size 16 bytes
=========     at void cub::CUB_200200_900_NS::DeviceReduceKernel<cub::CUB_200200_900_NS::DeviceReducePolicy<double, unsigned int, thrust::plus<double>>::Policy600, thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<(int)1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default>>, thrust::use_default, thrust::use_default>, unsigned int, thrust::plus<double>, double>(T2, T5 *, T3, cub::CUB_200200_900_NS::GridEvenShare<T3>, T4)+0x2e0
=========     by thread (96,0,0) in block (100,0,0)
=========     Address 0xffd240320600 is out of bounds
=========     and is 33,855,240,704 bytes before the nearest allocation at 0xffda22200000 of size 4 bytes
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame: [0x2dabd0]
=========                in /lib/aarch64-linux-gnu/libcuda.so.1
=========     Host Frame:libcudart_static_4d8b33a106dceb3c07a56e26de61f2d53bb62a68 [0x408b68]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:cudaLaunchKernel [0x45b678]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:void cub::CUB_200200_900_NS::DeviceReduceKernel<cub::CUB_200200_900_NS::DeviceReducePolicy<double, unsigned int, thrust::plus<double> >::Policy600, thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default> >, thrust::use_default, thrust::use_default>, unsigned int, thrust::plus<double>, double>(thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default> >, thrust::use_default, thrust::use_default>, double*, unsigned int, cub::CUB_200200_900_NS::GridEvenShare<unsigned int>, thrust::plus<double>) in /work/shared/nvhpc/24.3/Linux_aarch64/24.3/cuda/12.3/include/cub/device/dispatch/dispatch_reduce.cuh:183 [0x3ff008]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:cub::CUB_200200_900_NS::DispatchReduce<thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default> >, thrust::use_default, thrust::use_default>, double*, unsigned int, thrust::plus<double>, double, double, cub::CUB_200200_900_NS::DeviceReducePolicy<double, unsigned int, thrust::plus<double> > >::Dispatch(void*, unsigned long&, thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default> >, thrust::use_default, thrust::use_default>, double*, unsigned int, thrust::plus<double>, double, CUstream_st*) in /work/shared/nvhpc/24.3/Linux_aarch64/24.3/cuda/12.3/include/cub/device/dispatch/dispatch_reduce.cuh:0 [0x3e0bd4]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:double thrust::cuda_cub::detail::reduce_n_impl<thrust::cuda_cub::tag, thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default> >, thrust::use_default, thrust::use_default>, long, double, thrust::plus<double> >(thrust::cuda_cub::execution_policy<thrust::cuda_cub::tag>&, thrust::transform_iterator<functor_getAmpNorm, thrust::permutation_iterator<thrust::device_ptr<double2>, thrust::transform_iterator<functor_insertBits<1>, thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default> >, thrust::use_default, thrust::use_default>, long, double, thrust::plus<double>) in /work/shared/nvhpc/24.3/Linux_aarch64/24.3/cuda/12.3/include/thrust/system/cuda/detail/reduce.h:975 [0x3f9520]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:double thrust_statevec_calcProbOfMultiQubitOutcome_sub<1>(Qureg, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >) in /work/jriching/Quest/QuEST/quest/src/gpu/gpu_thrust.cuh:81 [0x3ca86c]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:double gpu_statevec_calcProbOfMultiQubitOutcome_sub<1>(Qureg, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >) in /work/jriching/Quest/QuEST/quest/src/gpu/gpu_subroutines.cpp:1470 [0x39fcdc]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:accel_statevec_calcProbOfMultiQubitOutcome_sub(Qureg, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >) in /work/jriching/Quest/QuEST/quest/src/core/accelerator.cpp:874 [0xf7954]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:localiser_statevec_calcProbOfMultiQubitOutcome(Qureg, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >) in /work/jriching/Quest/QuEST/quest/src/core/localiser.cpp:0 [0x1159d8]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:calcProbOfMultiQubitOutcome in /work/jriching/Quest/QuEST/quest/src/api/calculations.cpp:259 [0xb4b44]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:calcProbOfQubitOutcome in /work/jriching/Quest/QuEST/quest/src/api/calculations.cpp:247 [0xb47c8]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:applyQubitMeasurementAndGetProb in /work/jriching/Quest/QuEST/quest/src/api/operations.cpp:1799 [0xdfb08]
=========                in /work/jriching/Quest/QuEST/build/libQuEST.so
=========     Host Frame:main in /work/jriching/Quest/QFT/qft.cpp:91 [0x15d0]
=========                in /work/jriching/Quest/QuEST/build/qft
=========     Host Frame:__libc_start_call_main in ../sysdeps/nptl/libc_start_call_main.h:74 [0x273fc]
=========                in /lib/aarch64-linux-gnu/libc.so.6
=========     Host Frame:__libc_start_main in ../csu/libc-start.c:379 [0x274cc]
=========                in /lib/aarch64-linux-gnu/libc.so.6
=========     Host Frame:_start [0x1170]
=========                in /work/jriching/Quest/QuEST/build/qft
=========
```

Output with additional printing from inside https://github.com/QuEST-Kit/QuEST/blob/53f8f3ad60e5b0171646ee8250c0e6ea65878b44/quest/src/gpu/gpu_thrust.cuh#L789C7-L789C54

```
after second calProbOfQubitOutcomeBefore first calProbOfQubitOutcomequbits
31
outcomes
0
valueMask: 0
qureg.logNumColsPerNode: 0
powerOf2(qureg.logNumColsPerNode - qubits.size()): -9223372036854775808
qureg.numAmpsPerNode: 4294967296
qubits.size(): 1
powerOf2(qubits.size()): 2
numIts: 2147483648
before prob.
Func end
Before second calProbOfQubitOutcomequbits
31
outcomes
1
valueMask: -2147483648
qureg.logNumColsPerNode: 0
powerOf2(qureg.logNumColsPerNode - qubits.size()): -9223372036854775808
qureg.numAmpsPerNode: 4294967296
qubits.size(): 1
powerOf2(qubits.size()): 2
numIts: 2147483648
before prob.
terminate called after throwing an instance of 'thrust::system::system_error'
  what():  reduce failed to synchronize: cudaErrorIllegalAddress: an illegal memory access was encountered
Aborted (core dumped)
```

With proposed change:

```
Total number of gates: 528
Measured probability amplitude of |0..0> state: 2.32831e-10
Calculated probability amplitude of |0..0>, C0 = 1 / 2^32: 2.32831e-10
Measuring final state: (all probabilities should be 0.5)
Qubit 0 measured in state 0 with probability 0.5
Qubit 1 measured in state 1 with probability 0.5
Qubit 2 measured in state 0 with probability 0.5
Qubit 3 measured in state 0 with probability 0.5
Qubit 4 measured in state 1 with probability 0.5
Qubit 5 measured in state 0 with probability 0.5
Qubit 6 measured in state 1 with probability 0.5
Qubit 7 measured in state 1 with probability 0.5
Qubit 8 measured in state 1 with probability 0.5
Qubit 9 measured in state 0 with probability 0.5
Qubit 10 measured in state 0 with probability 0.5
Qubit 11 measured in state 1 with probability 0.5
Qubit 12 measured in state 1 with probability 0.5
Qubit 13 measured in state 1 with probability 0.5
Qubit 14 measured in state 1 with probability 0.5
Qubit 15 measured in state 1 with probability 0.5
Qubit 16 measured in state 0 with probability 0.5
Qubit 17 measured in state 0 with probability 0.5
Qubit 18 measured in state 0 with probability 0.5
Qubit 19 measured in state 0 with probability 0.5
Qubit 20 measured in state 1 with probability 0.5
Qubit 21 measured in state 1 with probability 0.5
Qubit 22 measured in state 1 with probability 0.5
Qubit 23 measured in state 1 with probability 0.5
Qubit 24 measured in state 1 with probability 0.5
Qubit 25 measured in state 1 with probability 0.5
Qubit 26 measured in state 0 with probability 0.5
Qubit 27 measured in state 1 with probability 0.5
Qubit 28 measured in state 0 with probability 0.5
Qubit 29 measured in state 1 with probability 0.5
Qubit 30 measured in state 1 with probability 0.5
Qubit 31 measured in state 0 with probability 0.5

Final state:
|01001011100111110000111111010110>
QFT run time: 11.8524s
Total run time: 15.4872s
```