### PR TITLE
optimised applyPauliGadget edgecase

### DIFF
--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1454,7 +1454,7 @@ void applyMultiStateControlledPauliGadget(Qureg qureg, int* controls, int* state
     // a non-controlled str=I effects a global phase change (of -angle/2) which does not 
     // at all change a density matrix; the subsequent dagger operation would undo it,
     // which we avoid to preserve numerical accuracy
-    if (paulis_isIdentity(str) && qureg.isDensityMatrix && numControls == 0)
+    if (paulis_isIdentity(str) && numControls == 0 && qureg.isDensityMatrix)
         return;
 
     // when numControls >= 1, all amps satisfying the control condition undergo a phase 

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -29,6 +29,7 @@ using std::vector;
  * PRVIATE UTILITIES
  */
 
+extern bool paulis_isIdentity(PauliStr str);
 extern bool paulis_hasOddNumY(PauliStr str);
 extern PauliStr paulis_getShiftedPauliStr(PauliStr str, int pauliShift);
 extern PauliStr paulis_getKetAndBraPauliStr(PauliStr str, Qureg qureg);
@@ -1450,11 +1451,10 @@ void applyMultiStateControlledPauliGadget(Qureg qureg, int* controls, int* state
     validate_controlsAndPauliStrTargets(qureg, controls, numControls, str, __func__);
     validate_controlStates(states, numControls, __func__); // permits states==nullptr
 
-    /// @todo
-    /// CRUCIAL NOTE:
-    /// exp(theta I..I) might be algorithmically ok (I'm not sure), but it WILL NOT
-    /// effect a global phase change of theta (I think). Should validate against this
-    /// sitaution just in case, or make the doc extremely explicit
+    // str=I is permitted, in which case this function effects a global phase which
+    // does not at all change a density matrix (the dagger operation undoes it)
+    if (paulis_isIdentity(str) && qureg.isDensityMatrix)
+        return;
 
     qreal phase = util_getPhaseFromGateAngle(angle);
     auto ctrlVec = util_getVector(controls, numControls);

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -95,6 +95,14 @@ void freeAllMemoryIfAnyAllocsFailed(PauliStrSum sum) {
  */
 
 
+bool paulis_isIdentity(PauliStr str) {
+
+    return 
+        (str.lowPaulis  == 0) && 
+        (str.highPaulis == 0);
+}
+
+
 int paulis_getPauliAt(PauliStr str, int ind) {
 
     return (ind < MAX_NUM_PAULIS_PER_MASK)?


### PR DESCRIPTION
When the passed PauliStr is identity and no control qubits are imposed, the function merely effects a change in global phase. For density matrices, this induces no change at all; the two constituent operations upon the Choi vector cancel one-another, wasting time and numerical accuracy. So, we abort in that scenario.

This is truly an insignificant runtime and accuracy optimisation, and this scenario is superfluously handled mostly to document the validity of the scenario (i.e. the use of gadgets to effect arbitrary phase changes)