### PR TITLE
Optimise calcExpecPauliStrSum() by batch-processing similar PauliStr …

### DIFF
--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -23,6 +23,7 @@
 #include "quest/src/core/accelerator.hpp"
 #include "quest/src/comm/comm_config.hpp"
 #include "quest/src/comm/comm_routines.hpp"
+#include "quest/src/core/fastmath.hpp"
 #include "quest/src/cpu/cpu_config.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
 


### PR DESCRIPTION
This PR implements the batch-processing optimization for calcExpecPauliStrSum as described in issue #599.

- Groups Pauli strings by both prefix (communication pattern) and suffix (amplitude-mixing pattern).
- Processes all Pauli strings in a suffix group in a single pass over the statevector, reducing redundant memory access.
- Adds a static helper for suffix grouping.
- Refactors localiser_statevec_calcExpecPauliStrSum to use the new grouping and processing logic.
- Only applies this optimization to the statevector case, not density matrix.
- Adds comments to clarify the new logic.

Closes #599. 
Solved under unitaryhack