### PR TITLE
Fix for quest.h generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
   set(MULTI_LIB_HEADERS 0)
   function(compile_option VAR VALUE)
     target_compile_definitions(QuEST PRIVATE ${VAR}=${VALUE})
-    set(${VAR} ${VALUE})
+    set(${VAR} ${VALUE} PARENT_SCOPE)
   endfunction()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,13 +576,18 @@ install(FILES
         DESTINATION "${QuEST_INSTALL_CONFIGDIR}"
 )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/quest.h"
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/quest/include/quest.h"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/quest/include/config.h"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/quest/include"
 )
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/quest/include"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/quest"
         FILES_MATCHING PATTERN "*.h"
+        PATTERN "quest.h" EXCLUDE
 )
 
 install(EXPORT QuESTTargets

--- a/quest/include/CMakeLists.txt
+++ b/quest/include/CMakeLists.txt
@@ -2,4 +2,4 @@
 # @author Erich Essmann
 # @author Luc Jaulmes (using config file)
 
-configure_file(quest.h.in "${CMAKE_BINARY_DIR}/include/quest.h" @ONLY)
+configure_file(config.h.in "${CMAKE_BINARY_DIR}/include/quest/include/config.h" @ONLY)

--- a/quest/include/config.h.in
+++ b/quest/include/config.h.in
@@ -1,6 +1,12 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+// be warned, the below is sensitive to whitespace after the slash
+#if !defined(FLOAT_PRECISION)\
+    || !defined(COMPILE_MPI)\
+    || !defined(COMPILE_OPENMP)\
+    || !defined(COMPILE_CUDA)\
+    || !defined(COMPILE_CUQUANTUM)
 
 // bind compile settings to installed exec
 #if !@MULTI_LIB_HEADERS@
@@ -11,5 +17,6 @@
 #cmakedefine01 COMPILE_CUQUANTUM
 #endif
 
+#endif
 
 #endif

--- a/quest/include/config.h.in
+++ b/quest/include/config.h.in
@@ -1,0 +1,15 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+
+// bind compile settings to installed exec
+#if !@MULTI_LIB_HEADERS@
+#cmakedefine FLOAT_PRECISION @FLOAT_PRECISION@
+#cmakedefine01 COMPILE_MPI
+#cmakedefine01 COMPILE_OPENMP
+#cmakedefine01 COMPILE_CUDA
+#cmakedefine01 COMPILE_CUQUANTUM
+#endif
+
+
+#endif

--- a/quest/include/modes.h
+++ b/quest/include/modes.h
@@ -15,27 +15,8 @@
 
 
 
-// ensure all mode flags are defined
-
-#ifndef COMPILE_MPI
-    #error "Compiler must define COMPILE_MPI"
-#endif
-
-#ifndef COMPILE_OPENMP
-    #error "Compiler must define COMPILE_OPENMP"
-#endif
-
-#ifndef COMPILE_CUDA
-    #error "Compiler must define COMPILE_CUDA"
-#endif
-
-#ifndef COMPILE_CUQUANTUM
-    #error "Compiler must define COMPILE_CUQUANTUM"
-#endif
-
-
-
 // ensure all mode flags are valid values
+// undefined allowed as undefined == 0 in C/C++ standards
 
 #if ! (COMPILE_MPI == 0 || COMPILE_MPI == 1)
     #error "Macro COMPILE_MPI must have value 0 or 1"

--- a/quest/include/quest.h
+++ b/quest/include/quest.h
@@ -31,19 +31,11 @@
 #define QUEST_H
 
 
-// bind compile settings to installed exec
-#if !@MULTI_LIB_HEADERS@
-#cmakedefine FLOAT_PRECISION @FLOAT_PRECISION@
-#cmakedefine01 COMPILE_MPI
-#cmakedefine01 COMPILE_OPENMP
-#cmakedefine01 COMPILE_CUDA
-#cmakedefine01 COMPILE_CUQUANTUM
-#endif
-
-
 // include version first so it is accessible to 
 // debuggers in case a subsequent include fails
 #include "quest/include/version.h"
+
+#include "quest/include/config.h"
 
 // include before API headers since it validates
 // preprocessor configuration, and affirms macro


### PR DESCRIPTION
Hi Tyson,

Hope the unitary hack is going well!

I've finally updated to 4.1 locally and spotted a subtle bug with Luc's custom `compile_option` function in CMake -- the variables set within it were dutifully thrown away at return. The fix is trivial, just needed to added `PARENT_SCOPE` to the set command.

As that function also independently set `target_compile_definitions` the library itself is still compiled correctly, this bug would only impact downstream projects (like my CQ!).

Cheers,
Oliver