### PR TITLE
added controlled Trotter functions

### DIFF
--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -2387,6 +2387,30 @@ void multiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 void applyTrotterizedPauliStrSumGadget(Qureg qureg, PauliStrSum sum, qreal angle, int order, int reps);
 
 
+/// @notyetdoced
+/// @notyettested
+/// @see
+///  - applyTrotterizedPauliStrSumGadget()
+///  - applyControlledCompMatr1()
+void applyControlledTrotterizedPauliStrSumGadget(Qureg qureg, int control, PauliStrSum sum, qreal angle, int order, int reps);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see
+///  - applyTrotterizedPauliStrSumGadget()
+///  - applyMultiControlledCompMatr1()
+void applyMultiControlledTrotterizedPauliStrSumGadget(Qureg qureg, int* controls, int numControls, PauliStrSum sum, qreal angle, int order, int reps);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see
+///  - applyTrotterizedPauliStrSumGadget()
+///  - applyMultiStateControlledCompMatr1()
+void applyMultiStateControlledTrotterizedPauliStrSumGadget(Qureg qureg, int* controls, int* states, int numControls, PauliStrSum sum, qreal angle, int order, int reps);
+
+
 /** @notyettested
  * 
  * A generalisation of applyTrotterizedPauliStrSumGadget() which accepts a complex angle and permits

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -2516,6 +2516,26 @@ void applyNonUnitaryTrotterizedPauliStrSumGadget(Qureg qureg, PauliStrSum sum, q
 }
 #endif
 
+#ifdef __cplusplus
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see applyMultiControlledTrotterizedPauliStrSumGadget()
+void applyMultiControlledTrotterizedPauliStrSumGadget(Qureg qureg, std::vector<int> controls, PauliStrSum sum, qreal angle, int order, int reps);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see applyMultiStateControlledTrotterizedPauliStrSumGadget()
+void applyMultiStateControlledTrotterizedPauliStrSumGadget(Qureg qureg, std::vector<int> controls, std::vector<int> states, PauliStrSum sum, qreal angle, int order, int reps);
+
+
+#endif // __cplusplus
 
 /** @} */
 

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1140,8 +1140,8 @@ void internal_applyFirstOrderTrotterRepetition(
         qcomp coeff = sum.coeffs[j];
         PauliStr str = sum.strings[j];
 
-        // effect |psi> -> exp(i angle * sum)|psi> by undoing gadget pre-factor
-        qcomp arg = angle * coeff / util_getPhaseFromGateAngle(1);
+        // effect |psi> -> exp(i angle * sum)|psi>
+        qcomp arg = angle * coeff;
         localiser_statevec_anyCtrlPauliGadget(qureg, ketCtrls, states, str, arg);
 
         if (!qureg.isDensityMatrix)

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1258,6 +1258,17 @@ void applyMultiStateControlledTrotterizedPauliStrSumGadget(Qureg qureg, int* con
 
 } // end de-mangler
 
+void applyMultiControlledTrotterizedPauliStrSumGadget(Qureg qureg, vector<int> controls, PauliStrSum sum, qreal angle, int order, int reps) {
+
+    applyMultiControlledTrotterizedPauliStrSumGadget(qureg, controls.data(), controls.size(), sum, angle, order, reps);
+}
+
+void applyMultiStateControlledTrotterizedPauliStrSumGadget(Qureg qureg, vector<int> controls, vector<int> states, PauliStrSum sum, qreal angle, int order, int reps) {
+    validate_controlsMatchStates(controls.size(), states.size(), __func__);
+
+    applyMultiStateControlledTrotterizedPauliStrSumGadget(qureg, controls.data(), states.data(), controls.size(), sum, angle, order, reps);
+}
+
 
 
 /*

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1188,9 +1188,9 @@ void internal_applyAllTrotterRepetitions(
         return;
 
     // prepare control-qubit lists once for all invoked gadgets below
-    auto ketCtrlsVec = util_getVector(controls, numControls); // may be empty
-    auto braCtrlsVec = util_getBraQubits(ketCtrlsVec, qureg); // used only by densmatr 
-    auto statesVec = util_getVector(states, numControls); // empty if states==nullptr
+    auto ketCtrlsVec = util_getVector(controls, numControls);
+    auto braCtrlsVec = (qureg.isDensityMatrix)? util_getBraQubits(ketCtrlsVec, qureg) : vector<int>{};
+    auto statesVec = util_getVector(states, numControls);
 
     qcomp arg = angle / reps;
 

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -207,7 +207,7 @@ qcomp paulis_getPrefixPaulisElem(Qureg qureg, vector<int> prefixY, vector<int> p
 }
 
 
-vector<int> paulis_getInds(PauliStr str) {
+vector<int> paulis_getTargetInds(PauliStr str) {
 
     int maxInd = paulis_getIndOfLefmostNonIdentityPauli(str);
 
@@ -215,16 +215,33 @@ vector<int> paulis_getInds(PauliStr str) {
     inds.reserve(maxInd+1);
 
     for (int i=0; i<=maxInd; i++)
-        if (paulis_getPauliAt(str, i) != 0)
+        if (paulis_getPauliAt(str, i) != 0) // Id
             inds.push_back(i);
 
     return inds;
 }
 
 
+qindex paulis_getTargetBitMask(PauliStr str) {
+    
+    /// @todo 
+    /// would compile-time MAX_NUM_PAULIS_PER_STR bound be faster here,
+    /// since this function is invoked upon every PauliStrSum element?
+    int maxInd = paulis_getIndOfLefmostNonIdentityPauli(str);
+
+    qindex mask = 0;
+
+    for (int i=0; i<=maxInd; i++)
+        if (paulis_getPauliAt(str, i) != 0) // Id
+            mask = flipBit(mask, i);
+
+    return mask;
+}
+
+
 array<vector<int>,3> paulis_getSeparateInds(PauliStr str, Qureg qureg) {
 
-    vector<int> iXYZ = paulis_getInds(str);
+    vector<int> iXYZ = paulis_getTargetInds(str);
     vector<int> iX, iY, iZ;
 
     vector<int>* ptrs[] = {&iX, &iY, &iZ};
@@ -292,6 +309,18 @@ PAULI_MASK_TYPE paulis_getKeyOfSameMixedAmpsGroup(PauliStr str) {
     }
 
     return key;
+}
+
+
+qindex paulis_getTargetBitMask(PauliStrSum sum) {
+
+    qindex mask = 0;
+
+    // mask has 1 where any str has a != Id
+    for (int t=0; t<sum.numTerms; t++)
+        mask |= paulis_getTargetBitMask(sum.strings[t]);
+
+    return mask;
 }
 
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -1238,7 +1238,7 @@ template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vecto
 
 
 extern bool paulis_containsXOrY(PauliStr str);
-extern vector<int> paulis_getInds(PauliStr str);
+extern vector<int> paulis_getTargetInds(PauliStr str);
 extern std::array<vector<int>,3> paulis_getSeparateInds(PauliStr str, Qureg qureg);
 extern int paulis_getPrefixZSign(Qureg qureg, vector<int> prefixZ) ;
 extern qcomp paulis_getPrefixPaulisElem(Qureg qureg, vector<int> prefixY, vector<int> prefixZ);
@@ -1334,7 +1334,7 @@ void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, vector<int> ctrls, vecto
 
         bool isGadget = false;
         qreal phase = 0; // ignored
-        anyCtrlZTensorOrGadget(qureg, ctrls, ctrlStates, paulis_getInds(str), isGadget, phase);
+        anyCtrlZTensorOrGadget(qureg, ctrls, ctrlStates, paulis_getTargetInds(str), isGadget, phase);
     }
 }
 
@@ -1350,7 +1350,7 @@ void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, vector<int> ctrls, vecto
 
     // when str=IZ, we must use the above bespoke algorithm
     if (!paulis_containsXOrY(str)) {
-        localiser_statevec_anyCtrlPhaseGadget(qureg, ctrls, ctrlStates, paulis_getInds(str), phase);
+        localiser_statevec_anyCtrlPhaseGadget(qureg, ctrls, ctrlStates, paulis_getTargetInds(str), phase);
         return;
     }
 

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -342,6 +342,10 @@ void validate_pauliStrSumIsHermitian(PauliStrSum sum, const char* caller);
 
 void validate_pauliStrSumTargets(PauliStrSum sum, Qureg qureg, const char* caller);
 
+void validate_controlAndPauliStrSumTargets(Qureg qureg, int ctrl, PauliStrSum sum, const char* caller);
+
+void validate_controlsAndPauliStrSumTargets(Qureg qureg, int* ctrls, int numCtrls, PauliStrSum sum, const char* caller);
+
 void validate_pauliStrSumCanInitMatrix(FullStateDiagMatr matr, PauliStrSum sum, const char* caller);
 
 

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1958,6 +1958,12 @@ TEST_CASE( "applyNonUnitaryPauliGadget", TEST_CATEGORY ) {
  * UNTESTED FUNCTIONS
  */
 
+void applyNonUnitaryTrotterizedPauliStrSumGadget(Qureg qureg, PauliStrSum sum, qcomp angle, int order, int reps);
+
 void applyTrotterizedPauliStrSumGadget(Qureg qureg, PauliStrSum sum, qreal angle, int order, int reps);
 
-void applyNonUnitaryTrotterizedPauliStrSumGadget(Qureg qureg, PauliStrSum sum, qcomp angle, int order, int reps);
+void applyControlledTrotterizedPauliStrSumGadget(Qureg qureg, int control, PauliStrSum sum, qreal angle, int order, int reps);
+
+void applyMultiControlledTrotterizedPauliStrSumGadget(Qureg qureg, int* controls, int numControls, PauliStrSum sum, qreal angle, int order, int reps);
+
+void applyMultiStateControlledTrotterizedPauliStrSumGadget(Qureg qureg, int* controls, int* states, int numControls, PauliStrSum sum, qreal angle, int order, int reps);


### PR DESCRIPTION
as well as:
- renamed the internal constituent functions, like applyFirstOrderTrotter(), to explicit internal_applyFirstOrderTrotterRepetition() for clarity
- renamed paulis_getInds() to paulis_getTargetInds()