### PR TITLE
bound isCuQuantumEnabled to QuESTEnv

### DIFF
--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -32,10 +32,13 @@ extern "C" {
 /// @notyetdoced
 typedef struct {
 
-    // deployment mode
+    // deployment modes which can be runtime disabled
     int isMultithreaded;
     int isGpuAccelerated;
     int isDistributed;
+
+    // deployment modes which cannot be directly changed after compilation
+    int isCuQuantumEnabled;
 
     // distributed configuration
     int rank;

--- a/quest/include/qureg.h
+++ b/quest/include/qureg.h
@@ -329,7 +329,7 @@ Qureg createForcedDensityQureg(int numQubits);
  * </center>
  * 
  * @constraints
- * - Cannot use any deployment which has not been prior enabled during compilation, or disabled by createCustomQuESTEnv().
+ * - Cannot use any deployment which has not been prior enabled during compilation, or disabled by initCustomQuESTEnv().
  * - Cannot distribute @f$ N @f$ qubits over more than @f$ 2^N @f$ nodes (regardless of @p isDensMatr).
  * - Cannot distribute when the executable was not launched using MPI (e.g. via @c mpirun).
  * - Cannot GPU-accelerate when a GPU is not available at runtime, or has insufficient memory.

--- a/quest/src/api/environment.cpp
+++ b/quest/src/api/environment.cpp
@@ -114,8 +114,9 @@ void validateAndInitCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMulti
     /// should we warn here if each machine contains
     /// more GPUs than deployed MPI-processes (some GPUs idle)?
 
-    // use cuQuantum if compiled
-    if (useGpuAccel && gpu_isCuQuantumCompiled()) {
+    // cuQuantum is always used in GPU-accelerated envs when available
+    bool useCuQuantum = useGpuAccel && gpu_isCuQuantumCompiled();
+    if (useCuQuantum) {
         validate_gpuIsCuQuantumCompatible(caller); // assesses above bound GPU
         gpu_initCuQuantum();
     }
@@ -131,9 +132,10 @@ void validateAndInitCustomQuESTEnv(int useDistrib, int useGpuAccel, int useMulti
         error_allocOfQuESTEnvFailed();
 
     // bind deployment info to global instance
-    globalEnvPtr->isMultithreaded  = useMultithread;
-    globalEnvPtr->isGpuAccelerated = useGpuAccel;
-    globalEnvPtr->isDistributed    = useDistrib;
+    globalEnvPtr->isMultithreaded    = useMultithread;
+    globalEnvPtr->isGpuAccelerated   = useGpuAccel;
+    globalEnvPtr->isDistributed      = useDistrib;
+    globalEnvPtr->isCuQuantumEnabled = useCuQuantum;
 
     // bind distributed info
     globalEnvPtr->rank     = (useDistrib)? comm_getRank()     : 0;
@@ -174,7 +176,7 @@ void printCompilationInfo() {
 
     print_table(
         "compilation", {
-        {"isMpiCompiled",      comm_isMpiCompiled()},
+        {"isMpiCompiled",       comm_isMpiCompiled()},
         {"isGpuCompiled",       gpu_isGpuCompiled()},
         {"isOmpCompiled",       cpu_isOpenmpCompiled()},
         {"isCuQuantumCompiled", gpu_isCuQuantumCompiled()},
@@ -186,9 +188,10 @@ void printDeploymentInfo() {
 
     print_table(
         "deployment", {
-        {"isMpiEnabled", globalEnvPtr->isDistributed},
-        {"isGpuEnabled", globalEnvPtr->isGpuAccelerated},
-        {"isOmpEnabled", globalEnvPtr->isMultithreaded},
+        {"isMpiEnabled",       globalEnvPtr->isDistributed},
+        {"isGpuEnabled",       globalEnvPtr->isGpuAccelerated},
+        {"isOmpEnabled",       globalEnvPtr->isMultithreaded},
+        {"isCuQuantumEnabled", globalEnvPtr->isCuQuantumEnabled},
     });
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -88,13 +88,13 @@ public:
         QuESTEnv env = getQuESTEnv();
         std::cout << std::endl;
         std::cout << "QuEST execution environment:" << std::endl;
-        std::cout << "  precision:       " << FLOAT_PRECISION      << std::endl;
-        std::cout << "  multithreaded:   " << env.isMultithreaded  << std::endl;
-        std::cout << "  distributed:     " << env.isDistributed    << std::endl;
-        std::cout << "  GPU-accelerated: " << env.isGpuAccelerated << std::endl;
-        std::cout << "  cuQuantum:       " << (env.isGpuAccelerated && COMPILE_CUQUANTUM) << std::endl;
-        std::cout << "  num nodes:       " << env.numNodes         << std::endl;
-        std::cout << "  num qubits:      " << getNumCachedQubits() << std::endl;
+        std::cout << "  precision:       " << FLOAT_PRECISION        << std::endl;
+        std::cout << "  multithreaded:   " << env.isMultithreaded    << std::endl;
+        std::cout << "  distributed:     " << env.isDistributed      << std::endl;
+        std::cout << "  GPU-accelerated: " << env.isGpuAccelerated   << std::endl;
+        std::cout << "  cuQuantum:       " << env.isCuQuantumEnabled << std::endl;
+        std::cout << "  num nodes:       " << env.numNodes           << std::endl;
+        std::cout << "  num qubits:      " << getNumCachedQubits()   << std::endl;
         std::cout << "  num qubit perms: " << TEST_MAX_NUM_QUBIT_PERMUTATIONS << std::endl;
         std::cout << std::endl;
 

--- a/tests/unit/environment.cpp
+++ b/tests/unit/environment.cpp
@@ -133,9 +133,10 @@ TEST_CASE( "getQuESTEnv", TEST_CATEGORY ) {
 
         QuESTEnv env = getQuESTEnv();
 
-        REQUIRE( (env.isMultithreaded  == 0 || env.isMultithreaded  == 1) );
-        REQUIRE( (env.isGpuAccelerated == 0 || env.isGpuAccelerated == 1) );
-        REQUIRE( (env.isDistributed    == 0 || env.isDistributed    == 1) );
+        REQUIRE( (env.isMultithreaded    == 0 || env.isMultithreaded    == 1) );
+        REQUIRE( (env.isGpuAccelerated   == 0 || env.isGpuAccelerated   == 1) );
+        REQUIRE( (env.isDistributed      == 0 || env.isDistributed      == 1) );
+        REQUIRE( (env.isCuQuantumEnabled == 0 || env.isCuQuantumEnabled == 1) );
         
         REQUIRE( env.rank     >= 0 );
         REQUIRE( env.numNodes >= 0 );


### PR DESCRIPTION
so that the COMPILE_CUQUANTUM preprocessor need only ever be consulted by the source during compilation, as per Oliver's suggestion in #645