### PR TITLE
changed PERMIT_NODES_TO_SHARE_GPU from macro to env-var

### DIFF
--- a/.github/workflows/test_paid.yml
+++ b/.github/workflows/test_paid.yml
@@ -257,11 +257,14 @@ jobs:
           -DCMAKE_CUDA_ARCHITECTURES=${{ env.cuda_arch }}
           -DTEST_ALL_DEPLOYMENTS=${{ env.test_all_deploys }}
           -DTEST_NUM_MIXED_DEPLOYMENT_REPETITIONS=${{ env.test_repetitions }}
-          -DPERMIT_NODES_TO_SHARE_GPU=${{ env.mpi_share_gpu }}
           -DCMAKE_CXX_FLAGS=${{ matrix.mpi == 'ON' && matrix.cuda == 'ON' && '-fno-lto' || '' }}
 
       - name: Compile
         run: cmake --build ${{ env.build_dir }} --parallel
+
+      # permit use of single GPU by multiple MPI processes (detriments performance)
+      - name: Set env-var to permit GPU sharing
+        run: echo "PERMIT_NODES_TO_SHARE_GPU=${{ env.mpi_share_gpu }}" >> $GITHUB_ENV
 
       # cannot use ctests when distributed, grr!
       - name: Run GPU + distributed v4 mixed tests (4 nodes sharing 1 GPU)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,15 +231,6 @@ if ((ENABLE_CUDA OR ENABLE_HIP) AND FLOAT_PRECISION STREQUAL 4)
   message(FATAL_ERROR "Quad precision is not supported on GPU. Please disable GPU acceleration or lower precision.")
 endif()
 
-option(
-  PERMIT_NODES_TO_SHARE_GPU
-  "Whether to permit multiple distributed nodes to share a single GPU at the detriment of performance. Turned OFF by default."
-  OFF
-)
-if (ENABLE_DISTRIBUTION AND (ENABLE_CUDA OR ENABLE_HIP))
-  message(STATUS "Permitting nodes to share GPUs is turned ${PERMIT_NODES_TO_SHARE_GPU}. Set PERMIT_NODES_TO_SHARE_GPU to modify.")
-endif()
-
 # Deprecated API
 option(
   ENABLE_DEPRECATED_API
@@ -318,7 +309,7 @@ if (ENABLE_MULTITHREADING)
   if (NOT OpenMP_FOUND)
     set(ErrorMsg "Could not find OpenMP, necessary for enabling multithreading.")
     if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      string(APPEND ErrorMsg " Try first calling `brew install libomp` then `export OpenMP_ROOT=$(brew --prefix)/opt/libomp`")
+      string(APPEND ErrorMsg " Try first calling \n\tbrew install libomp\nthen\n\texport OpenMP_ROOT=$(brew --prefix)/opt/libomp")
     endif()
     message(FATAL_ERROR ${ErrorMsg})
   endif()
@@ -431,14 +422,6 @@ if (ENABLE_DEPRECATED_API)
 
 else()
   target_compile_definitions(QuEST PRIVATE INCLUDE_DEPRECATED_FUNCTIONS=0)
-endif()
-
-
-if (ENABLE_DISTRIBUTION AND (ENABLE_CUDA OR ENABLE_HIP))
-  target_compile_definitions(
-    QuEST PRIVATE 
-    PERMIT_NODES_TO_SHARE_GPU=$<IF:$<BOOL:${PERMIT_NODES_TO_SHARE_GPU}>,1,0>
-  )
 endif()
 
 

--- a/quest/include/environment.h
+++ b/quest/include/environment.h
@@ -40,6 +40,9 @@ typedef struct {
     // deployment modes which cannot be directly changed after compilation
     int isCuQuantumEnabled;
 
+    // deployment configurations which can be changed via environment variables
+    int isGpuSharingEnabled;
+
     // distributed configuration
     int rank;
     int numNodes;

--- a/quest/include/modes.h
+++ b/quest/include/modes.h
@@ -75,10 +75,6 @@
 
 // define optional-macro defaults (mostly to list them)
 
-#ifndef PERMIT_NODES_TO_SHARE_GPU
-#define PERMIT_NODES_TO_SHARE_GPU 0
-#endif
-
 #ifndef INCLUDE_DEPRECATED_FUNCTIONS
 #define INCLUDE_DEPRECATED_FUNCTIONS 0
 #endif
@@ -95,17 +91,46 @@
 
     /// @notyetdoced
     /// @macrodoc
-    const int PERMIT_NODES_TO_SHARE_GPU = 0;
-
-
-    /// @notyetdoced
-    /// @macrodoc
     const int INCLUDE_DEPRECATED_FUNCTIONS = 0;
 
 
     /// @notyetdoced
     /// @macrodoc
     const int DISABLE_DEPRECATION_WARNINGS = 0;
+
+
+#endif
+
+
+
+// document environment variables
+
+// spoof env-vars as consts to doc (hackily and hopefully temporarily)
+#if 0
+
+
+    /** @envvardoc
+     * 
+     * Specifies whether to permit multiple MPI processes to deploy to the same GPU.
+     * 
+     * @attention 
+     * This environment variable has no effect when either (or both) of distribution or 
+     * GPU-acceleration are disabled.
+     * 
+     * In multi-GPU execution, which combines distribution with GPU-acceleration, it is 
+     * prudent to assign each GPU to at most one MPI process in order to avoid superfluous 
+     * slowdown. Hence by default, initQuESTEnv() will forbid assigning multiple MPI processes 
+     * to the same GPU. This environment variable can be set to `1` to disable this validation, 
+     * permitting sharing of a single GPU, as is often useful for debugging or unit testing 
+     * (for example, testing multi-GPU execution when only a single GPU is available).
+     * 
+     * @par Values
+     *  - forbid sharing: @p 0, @p '0', @p '', @p , (unspecified)
+     *  - permit sharing: @p 1, @p '1'
+     * 
+     * @author Tyson Jones
+     */
+    const int PERMIT_NODES_TO_SHARE_GPU = 0;
 
 
 #endif

--- a/quest/include/modes.h
+++ b/quest/include/modes.h
@@ -124,6 +124,9 @@
      * permitting sharing of a single GPU, as is often useful for debugging or unit testing 
      * (for example, testing multi-GPU execution when only a single GPU is available).
      * 
+     * @warning
+     * Permitting GPU sharing may cause unintended behaviour when additionally using cuQuantum.
+     * 
      * @par Values
      *  - forbid sharing: @p 0, @p '0', @p '', @p , (unspecified)
      *  - permit sharing: @p 1, @p '1'

--- a/quest/src/comm/comm_routines.cpp
+++ b/quest/src/comm/comm_routines.cpp
@@ -76,6 +76,12 @@ using std::vector;
  * 
  * - look into UCX CUDA multi-rail:
  *   https://docs.nvidia.com/networking/display/hpcxv215/unified+communication+-+x+framework+library#src-119764120_UnifiedCommunicationXFrameworkLibrary-Multi-RailMulti-Rail 
+ * 
+ * - by default, we validate to prevent sharing a GPU between multiple MPI processes since it is
+ *   easy to do unintentionally yet is rarely necessary (outside of unit testing) and can severely 
+ *   degrade performance. If we motivated a strong non-testing use-case for this however, we could
+ *   improve performance through use of CUDA's Multi-Process Service (MPS) which will prevent
+ *   serialisation of memcpy to distinct memory partitions and improve kernel scheduling.  
  */
 
 

--- a/quest/src/core/parser.cpp
+++ b/quest/src/core/parser.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <cstdlib>
 #include <stdexcept>
 #include <algorithm>
 
@@ -442,4 +443,31 @@ string parser_loadFile(string fn) {
     stringstream buffer;
     buffer << file.rdbuf();
     return buffer.str();
+}
+
+
+
+/*
+ * ENVIRONMENT VARIABLES
+ */
+
+
+bool parser_isStrEmpty(const char* str) {
+
+    // str can be unallocated or empty, but not e.g. whitespace
+    return (str == nullptr) || (str[0] == '\0');
+}
+
+
+bool parser_validateAndParseOptionalBoolEnvVar(string varName, bool defaultVal, const char* caller) {
+
+    const char* varStr = std::getenv(varName.c_str());
+
+    // permit specifying no or empty environment variable (triggering default)
+    if (parser_isStrEmpty(varStr))
+        return defaultVal;
+
+    // otherwise it must be precisely 0 or 1 without whitespace
+    validate_envVarIsBoolean(varName, varStr, caller);
+    return (varStr[0] == '0')? 0 : 1;
 }

--- a/quest/src/core/parser.hpp
+++ b/quest/src/core/parser.hpp
@@ -42,5 +42,13 @@ bool parser_canReadFile(string fn);
 string parser_loadFile(string fn);
 
 
+/*
+ * ENVIRONMENT VARIABLES
+ */
+
+bool parser_isStrEmpty(const char* str);
+
+bool parser_validateAndParseOptionalBoolEnvVar(string varName, bool defaultVal, const char* caller);
+
 
 #endif // PARSER_HPP

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -488,7 +488,6 @@ void validate_densMatrExpecDiagMatrValueIsReal(qcomp value, qcomp exponent, cons
  * PARTIAL TRACE
  */
 
-
 void validate_quregCanBeReduced(Qureg qureg, int numTraceQubits, const char* caller);
 
 void validate_quregCanBeSetToReducedDensMatr(Qureg out, Qureg in, int numTraceQubits, const char* caller);
@@ -508,6 +507,14 @@ void validate_canReadFile(string fn, const char* caller);
  */
 
 void validate_tempAllocSucceeded(bool succeeded, qindex numElems, qindex numBytesPerElem, const char* caller);
+
+
+
+/*
+ * ENVIRONMENT VARIABLES
+ */
+
+void validate_envVarIsBoolean(std::string varName, const char* varStr, const char* caller);
 
 
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -88,13 +88,14 @@ public:
         QuESTEnv env = getQuESTEnv();
         std::cout << std::endl;
         std::cout << "QuEST execution environment:" << std::endl;
-        std::cout << "  precision:       " << FLOAT_PRECISION        << std::endl;
-        std::cout << "  multithreaded:   " << env.isMultithreaded    << std::endl;
-        std::cout << "  distributed:     " << env.isDistributed      << std::endl;
-        std::cout << "  GPU-accelerated: " << env.isGpuAccelerated   << std::endl;
-        std::cout << "  cuQuantum:       " << env.isCuQuantumEnabled << std::endl;
-        std::cout << "  num nodes:       " << env.numNodes           << std::endl;
-        std::cout << "  num qubits:      " << getNumCachedQubits()   << std::endl;
+        std::cout << "  precision:       " << FLOAT_PRECISION         << std::endl;
+        std::cout << "  multithreaded:   " << env.isMultithreaded     << std::endl;
+        std::cout << "  distributed:     " << env.isDistributed       << std::endl;
+        std::cout << "  GPU-accelerated: " << env.isGpuAccelerated    << std::endl;
+        std::cout << "  GPU-sharing ok:  " << env.isGpuSharingEnabled << std::endl;
+        std::cout << "  cuQuantum:       " << env.isCuQuantumEnabled  << std::endl;
+        std::cout << "  num nodes:       " << env.numNodes            << std::endl;
+        std::cout << "  num qubits:      " << getNumCachedQubits()    << std::endl;
         std::cout << "  num qubit perms: " << TEST_MAX_NUM_QUBIT_PERMUTATIONS << std::endl;
         std::cout << std::endl;
 

--- a/tests/unit/environment.cpp
+++ b/tests/unit/environment.cpp
@@ -54,6 +54,13 @@ TEST_CASE( "initQuESTEnv", TEST_CATEGORY ) {
     SECTION( LABEL_VALIDATION ) {
 
         REQUIRE_THROWS_WITH( initQuESTEnv(), ContainsSubstring( "already been initialised") );
+
+        // cannot automatically check other validations, such as:
+        // - has env been previously initialised then finalised?
+        // - is env distributed over power-of-2 nodes?
+        // - are environment-variables valid?
+        // - is max 1 MPI process bound to each GPU?
+        // - is GPU compatible with cuQuantum (if enabled)?
     }
 }
 
@@ -133,10 +140,11 @@ TEST_CASE( "getQuESTEnv", TEST_CATEGORY ) {
 
         QuESTEnv env = getQuESTEnv();
 
-        REQUIRE( (env.isMultithreaded    == 0 || env.isMultithreaded    == 1) );
-        REQUIRE( (env.isGpuAccelerated   == 0 || env.isGpuAccelerated   == 1) );
-        REQUIRE( (env.isDistributed      == 0 || env.isDistributed      == 1) );
-        REQUIRE( (env.isCuQuantumEnabled == 0 || env.isCuQuantumEnabled == 1) );
+        REQUIRE( (env.isMultithreaded     == 0 || env.isMultithreaded     == 1) );
+        REQUIRE( (env.isGpuAccelerated    == 0 || env.isGpuAccelerated    == 1) );
+        REQUIRE( (env.isDistributed       == 0 || env.isDistributed       == 1) );
+        REQUIRE( (env.isCuQuantumEnabled  == 0 || env.isCuQuantumEnabled  == 1) );
+        REQUIRE( (env.isGpuSharingEnabled == 0 || env.isGpuSharingEnabled == 1) );
         
         REQUIRE( env.rank     >= 0 );
         REQUIRE( env.numNodes >= 0 );

--- a/utils/docs/Doxyfile
+++ b/utils/docs/Doxyfile
@@ -301,6 +301,7 @@ ALIASES += "notyetdoced=@note Documentation for this function or struct is under
 ALIASES += "cpponly=@remark This function is only available in C++."
 ALIASES += "conly=@remark This function is only available in C."
 ALIASES += "macrodoc=@note This entity is actually a macro."
+ALIASES += "envvardoc=@note This entity is actually an environment variable."
 ALIASES += "neverdoced=@warning This entity is a macro, undocumented directly due to a Doxygen limitation. If you see this doc rendered, contact the devs!"
 ALIASES += "myexample=@par Example"
 ALIASES += "equivalences=@par Equivalences"


### PR DESCRIPTION
This allows it to be changed post-compilation/installation, pre-execution, as per the machinations in #645

Additionally inserted whitespaces into cmake error message about MacOS multithreading to make the advised commands clearer