### PR TITLE
separated API multiplications from operations

### DIFF
--- a/quest/include/multiplication.h
+++ b/quest/include/multiplication.h
@@ -1,0 +1,760 @@
+/** @file
+ * API signatures for directly pre- and post-multiplying 
+ * operators upon density matrices, likely constituting 
+ * non-physical operations which break state normalisation.
+ * 
+ * @author Tyson Jones
+ * 
+ * @defgroup multiplication Multiplication
+ * @ingroup api
+ * @brief Functions for directly multiplying operators upon 
+ *        density matrices.
+ * @{
+ */
+
+#ifndef MULTIPLICATION_H
+#define MULTIPLICATION_H
+
+#include "quest/include/qureg.h"
+#include "quest/include/paulis.h"
+#include "quest/include/matrices.h"
+#include "quest/include/channels.h"
+
+#ifdef __cplusplus
+    #include <vector>
+#endif
+
+
+/*
+ * unlike some other headers, we here intermix the C and C++-only
+ * signatures, grouping them semantically & by their doc groups
+ */
+
+
+
+/** 
+ * @defgroup mult_compmatr1 CompMatr1
+ * @brief Functions for pre- or post-multiplying general one-qubit dense matrices
+ *        (as CompMatr1) upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** Multiplies a general one-qubit dense @p matrix upon the specified @p target 
+ * qubit of @p qureg.
+ *  
+ * @formulae
+ * Let @f$ \hat{M} = @f$ @p matrix and @f$ t = @f$ @p target, and notate 
+ * @f$\hat{M}_t@f$ as per applyCompMatr1(). Unlike applyCompMatr1() however,
+ * this function only ever left-multiplies @p matrix upon @p qureg, regardless
+ * of whether it is a statevector or density matrix.
+ * 
+ * Explicitly,
+ * - When @p qureg is a statevector @f$ \svpsi @f$, this function effects
+ *   @f[ 
+        \svpsi \rightarrow \hat{M}_t \, \svpsi.
+ *   @f]
+ * - When @p qureg is a density matrix @f$\dmrho@f$, this function effects
+ *   @f[ 
+        \dmrho \rightarrow \hat{M}_t \, \dmrho.
+ *   @f]
+ *  
+ * There are no additional constraints like unitarity.
+ *
+ * @myexample
+ * ```
+    Qureg qureg = createDensityQureg(5);
+
+    CompMatr1 matrix = getInlineCompMatr1({
+        {0.1, 0.2},
+        {0.3i, 0.4i}
+    });
+
+    multiplyCompMatr1(qureg, 2, matrix); 
+ * ```
+ *
+ * @param[in,out] qureg  the state to modify.
+ * @param[in]     target the index of the target qubit.
+ * @param[in]     matrix the Z-basis matrix to multiply.
+ * @throws @validationerror
+ * - if @p qureg or @p matrix are uninitialised.
+ * - if @p target is an invalid qubit index.
+ * @see
+ * - getCompMatr1()
+ * - getInlineCompMatr1()
+ * - applyCompMatr1()
+ * - postMultiplyCompMatr1()
+ * - applyQubitProjector()
+ * - multiplyCompMatr()
+ * @author Tyson Jones
+ */
+void multiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
+
+
+/** @notyettested
+ * 
+ * Multiplies a general one-qubit dense @p matrix upon the specified @p target 
+ * qubit of the density matrix @p qureg, from the right-hand side.
+ *  
+ * @formulae
+ * Let @f$ \dmrho = @f$ @p qureg, @f$ \hat{M} = @f$ @p matrix and @f$ t = @f$ @p target, 
+ * and notate @f$\hat{M}_t@f$ as per applyCompMatr1(). Unlike applyCompMatr1() however,
+ * this function only ever right-multiplies @p matrix upon @p qureg.
+ * 
+ * Explicitly
+ *   @f[ 
+        \dmrho \rightarrow \dmrho \, \hat{M}_t
+ *   @f]
+ * where @f$ \hat{M} @f$ is not conjugated nor transposed, and there are no additional 
+ * constraints like unitarity.
+ * 
+ * In general, this function will break the normalisation of @p qureg and result in a
+ * non-physical state, and is useful for preparing sub-expressions of formulae like
+ * the Linbladian.
+ *
+ * @myexample
+ * ```
+    Qureg qureg = createDensityQureg(5);
+
+    CompMatr1 matrix = getInlineCompMatr1({
+        {0.1, 0.2},
+        {0.3i, 0.4i}
+    });
+
+    postMultiplyCompMatr1(qureg, 2, matrix); 
+ * ```
+ *
+ * @param[in,out] qureg  the state to modify.
+ * @param[in]     target the index of the target qubit.
+ * @param[in]     matrix the Z-basis matrix to post-multiply.
+ * @throws @validationerror
+ * - if @p qureg or @p matrix are uninitialised.
+ * - if @p qureg is not a density matrix.
+ * - if @p target is an invalid qubit index.
+ * @see
+ * - getCompMatr1()
+ * - getInlineCompMatr1()
+ * - applyCompMatr1()
+ * - multiplyCompMatr1()
+ * - multiplyCompMatr()
+ * @author Tyson Jones
+ */
+void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_compmatr2 CompMatr2
+ * @brief Functions for pre- or post-multiplying general two-qubit dense matrices
+ *        (as CompMatr2) upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see
+/// - applyCompMatr2()
+/// - multiplyCompMatr1()
+void multiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+/// @see
+/// - postMultiplyCompMatr1
+void postMultiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+
+/** 
+ * @defgroup mult_compmatr CompMatr
+ * @brief Functions for pre- or post-multiplying general many-target dense matrices
+ *        (as CompMatr) upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** @notyetdoced
+ * 
+ * @see
+ * - applyCompMatr()
+ * - multiplyCompMatr1()
+ */
+void multiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+/// @see
+/// - postMultiplyCompMatr1
+void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see multiplyCompMatr()
+void multiplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see postMultiplyCompMatr()
+void postMultiplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
+
+
+#endif 
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_diagmatr1 DiagMatr1
+ * @brief Functions for pre- or post-multiplying general single-qubit diagonal 
+ *        matrices (as DiagMatr1) upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see multiplyCompMatr1()
+void multiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+void postMultiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_diagmatr2 DiagMatr2
+ * @brief Functions for pre- or post-multiplying general two-qubit diagonal 
+ *        matrices (as DiagMatr2) upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see multiplyCompMatr1()
+void multiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+void postMultiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_diagmatr DiagMatr
+ * @brief Functions for pre- or post-multiplying general any-target diagonal 
+ *        matrices (as DiagMatr), or powers thereof, upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see multiplyCompMatr1()
+void multiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
+
+
+/// @notyetdoced
+/// @see
+/// - multiplyCompMatr1()
+/// - applyDiagMatrPower()
+void multiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see multiplyDiagMatr()
+void multiplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see postMultiplyDiagMatr()
+void postMultiplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see multiplyDiagMatrPower()
+void multiplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see postMultiplyDiagMatrPower()
+void postMultiplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
+
+
+#endif 
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_fullstatediagmatr FullStateDiagMatr
+ * @brief Functions for pre- or post-multiplying general full-state diagonal 
+ *        matrices (FullStateDiagMatr), or powers thereof, upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @notyetvalidated
+/// @see
+/// - multiplyCompMatr1
+void multiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
+
+
+/// @notyetdoced
+/// @notyetvalidated
+/// @see
+/// - multiplyCompMatr1
+/// - applyDiagMatrPower
+void multiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup multi_swap Swap
+ * @brief Functions for pre- or post-multiplying the two-qubit SWAP
+ *        gate upon density matrices
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see multiplyCompMatr1()
+void multiplySwap(Qureg qureg, int qubit1, int qubit2);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplySwap(Qureg qureg, int qubit1, int qubit2);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_pauli Pauli
+ * @brief Functions for pre- or post-multiplying the individual one-qubit 
+ *        Pauli operators upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see multiplyCompMatr1()
+void multiplyPauliX(Qureg qureg, int target);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see multiplyCompMatr1()
+void multiplyPauliY(Qureg qureg, int target);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see multiplyCompMatr1()
+void multiplyPauliZ(Qureg qureg, int target);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see postMultiplyCompMatr1()
+void postMultiplyPauliX(Qureg qureg, int target);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see postMultiplyCompMatr1()
+void postMultiplyPauliY(Qureg qureg, int target);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @see postMultiplyCompMatr1()
+void postMultiplyPauliZ(Qureg qureg, int target);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_paulistr PauliStr
+ * @brief Functions for pre- or post-multiplying a tensor product of 
+ *       Pauli operators (as a PauliStr) upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see multiplyCompMatr1()
+void multiplyPauliStr(Qureg qureg, PauliStr str);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyPauliStr(Qureg qureg, PauliStr str);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_pauligadget Pauli gadgets
+ * @brief Functions for pre- or post-multiplying many-qubit rotations around 
+ *        arbitrary PauliStr upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see 
+/// - multiplyCompMatr1()
+/// - applyPauliGadget()
+void multiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_phasegadget Phase gates
+ * @brief Functions for pre- or post-multiplying many-qubit rotations around 
+ *        the Pauli Z axis upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see 
+/// - multiplyCompMatr1()
+/// - applyPhaseGadget
+void multiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see multiplyPhaseGadget()
+void multiplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see postMultiplyPhaseGadget()
+void postMultiplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
+
+
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_nots Many-not gates
+ * @brief Functions for pre- or post-multiplying many-qubit NOT gates 
+ *        upon density matrices.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @see multiplyCompMatr1()
+void multiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see multiplyMultiQubitNot()
+void multiplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
+
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+/// @cppvectoroverload
+/// @see postMultiplyMultiQubitNot()
+void postMultiplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
+
+
+#endif
+
+/** @} */
+
+
+
+/** 
+ * @defgroup mult_paulistrsum PauliStrSum
+ * @brief Functions for pre- or post-multiplying weighted sums of Pauli 
+ *        tensors upon a density matrix.
+ * @{
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/// @notyetdoced
+/// @notyetvalidated
+/// @see multiplyCompMatr1()
+void multiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
+
+
+/// @notyetdoced
+/// @notyettested
+/// @notyetvalidated
+void postMultiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+
+
+#endif // MULTIPLICATION_H
+
+/** @} */ // (end file-wide doxygen defgroup)

--- a/quest/include/quest.h
+++ b/quest/include/quest.h
@@ -50,6 +50,7 @@
 #include "quest/include/environment.h"
 #include "quest/include/initialisations.h"
 #include "quest/include/channels.h"
+#include "quest/include/multiplication.h"
 #include "quest/include/operations.h"
 #include "quest/include/paulis.h"
 #include "quest/include/qureg.h"

--- a/quest/src/api/CMakeLists.txt
+++ b/quest/src/api/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(QuEST
   initialisations.cpp
   matrices.cpp
   modes.cpp
+  multiplication.cpp
   operations.cpp
   paulis.cpp
   qureg.cpp

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -1,0 +1,624 @@
+/** @file
+ * API definitions for directly pre- and post-multiplying 
+ * operators upon density matrices, likely constituting 
+ * non-physical operations which break state normalisation.
+ * 
+ * @author Tyson Jones
+ */
+
+#include "quest/include/qureg.h"
+#include "quest/include/paulis.h"
+#include "quest/include/matrices.h"
+#include "quest/include/multiplication.h"
+
+#include "quest/src/core/validation.hpp"
+#include "quest/src/core/utilities.hpp"
+#include "quest/src/core/localiser.hpp"
+
+#include <vector>
+
+using std::vector;
+
+
+
+/*
+ * CompMatr1
+ */
+
+extern "C" {
+
+void multiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_target(qureg, target, __func__);
+    validate_matrixFields(matrix, __func__);
+
+    bool conj = false;
+    bool transp = false;
+    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, target, matrix, conj, transp);
+}
+
+void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_target(qureg, target, __func__);
+    validate_matrixFields(matrix, __func__);
+    
+    // rho matrix ~ transpose(rho) (x) I ||rho>>
+    bool conj = false;
+    bool transp = true;
+    int qubit = util_getBraQubit(target, qureg);
+    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, qubit, matrix, conj, transp);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * CompMatr2
+ */
+
+extern "C" {
+
+void multiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_twoTargets(qureg, target1, target2, __func__);
+    validate_matrixFields(matrix, __func__);
+    validate_mixedAmpsFitInNode(qureg, 2, __func__);
+
+    bool conj = false;
+    bool transp = false;
+    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, target1, target2, matrix, conj, transp);
+}
+
+void postMultiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_twoTargets(qureg, target1, target2, __func__);
+    validate_matrixFields(matrix, __func__);
+    validate_mixedAmpsFitInNode(qureg, 2, __func__);
+
+    // rho matrix ~ transpose(rho) (x) I ||rho>>
+    bool conj = false;
+    bool transp = true;
+    int qubit1 = util_getBraQubit(target1, qureg);
+    int qubit2 = util_getBraQubit(target2, qureg);
+    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, qubit1, qubit2, matrix, conj, transp);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * CompMatr
+ */
+
+extern "C" {
+
+void multiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
+    validate_mixedAmpsFitInNode(qureg, numTargets, __func__);
+
+    bool conj = false;
+    bool transp = false;
+    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, util_getVector(targets, numTargets), matrix, conj, transp);
+}
+
+void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
+    validate_mixedAmpsFitInNode(qureg, numTargets, __func__);
+
+    // rho matrix ~ transpose(rho) (x) I ||rho>>
+    bool conj = false;
+    bool transp = true;
+    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, qubits, matrix, conj, transp);
+}
+
+} // end de-mangler
+
+void multiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
+
+    multiplyCompMatr(qureg, targets.data(), targets.size(), matr);
+}
+
+void postMultiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
+
+    postMultiplyCompMatr(qureg, targets.data(), targets.size(), matr);
+}
+
+
+
+/*
+ * DiagMatr1
+ */
+
+extern "C" {
+
+void multiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_target(qureg, target, __func__);
+    validate_matrixFields(matrix, __func__);
+
+    bool conj = false;
+    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, target, matrix, conj);
+}
+
+void postMultiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_target(qureg, target, __func__);
+    validate_matrixFields(matrix, __func__);
+
+    bool conj = false;
+    int qubit = util_getBraQubit(target, qureg);
+    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, qubit, matrix, conj);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * DiagMatr2
+ */
+
+extern "C" {
+
+void multiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_twoTargets(qureg, target1, target2, __func__);
+    validate_matrixFields(matrix, __func__);
+
+    bool conj = false;
+    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, target1, target2, matrix, conj);
+}
+
+void postMultiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_twoTargets(qureg, target1, target2, __func__);
+    validate_matrixFields(matrix, __func__);
+
+    bool conj = false;
+    int qubit1 = util_getBraQubit(target1, qureg);
+    int qubit2 = util_getBraQubit(target2, qureg);
+    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, qubit1, qubit2, matrix, conj);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * DiagMatr
+ */
+
+extern "C" {
+
+void multiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
+
+    bool conj = false;
+    qcomp exponent = 1;
+    auto qubits = util_getVector(targets, numTargets);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+}
+
+void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
+
+    bool conj = false;
+    qcomp exponent = 1;
+    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+}
+
+} // end de-mangler
+
+void multiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
+
+    multiplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
+}
+
+void postMultiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
+
+    postMultiplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
+}
+
+
+
+/*
+ * DiagMatrPower
+ */
+
+extern "C" {
+
+void multiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
+    validate_quregFields(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
+    validate_matrixExpIsNonDiverging(matrix, exponent, __func__); // harmlessly re-validates fields and is-sync
+
+    bool conj = false;
+    auto qubits = util_getVector(targets, numTargets);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+}
+
+void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
+    validate_matrixExpIsNonDiverging(matrix, exponent, __func__); // harmlessly re-validates fields and is-sync
+
+    bool conj = false;
+    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+}
+
+} // end de-mangler
+
+void multiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
+
+    multiplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
+}
+
+void postMultiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
+
+    postMultiplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
+}
+
+
+
+/*
+ * FullStateDiagMatr (and power)
+ */
+
+extern "C" {
+
+void multiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_matrixFields(matrix, __func__);
+    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
+
+    multiplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
+}
+
+void multiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
+    validate_quregFields(qureg, __func__);
+    validate_matrixFields(matrix, __func__);
+    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
+    validate_matrixExpIsNonDiverging(matrix, exponent, __func__);
+
+    // rho -> matrix^exponent rho
+    bool leftMultiply = true;
+    bool rightMultiply = false;
+    bool rightConj = false;
+
+    (qureg.isDensityMatrix)?
+        localiser_densmatr_allTargDiagMatr(qureg, matrix, exponent, leftMultiply, rightMultiply, rightConj):
+        localiser_statevec_allTargDiagMatr(qureg, matrix, exponent);
+}
+
+void postMultiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_matrixFields(matrix, __func__);
+    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
+
+    postMultiplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
+}
+
+void postMultiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_matrixFields(matrix, __func__);
+    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
+    validate_matrixExpIsNonDiverging(matrix, exponent, __func__);
+
+    // rho -> rho matrix^exponent
+    bool leftMultiply = false;
+    bool rightMultiply = true;
+    bool rightConj = false;
+    localiser_densmatr_allTargDiagMatr(qureg, matrix, exponent, leftMultiply, rightMultiply, rightConj);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * swap
+ */
+
+extern "C" {
+
+void multiplySwap(Qureg qureg, int qubit1, int qubit2) {
+    validate_quregFields(qureg, __func__);
+    validate_twoTargets(qureg, qubit1, qubit2, __func__);
+
+    localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
+}
+
+void postMultiplySwap(Qureg qureg, int qubit1, int qubit2) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_twoTargets(qureg, qubit1, qubit2, __func__);
+
+    qubit1 = util_getBraQubit(qubit1, qureg);
+    qubit2 = util_getBraQubit(qubit2, qureg);
+    localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * individual Paulis
+ */
+
+extern PauliStr paulis_getShiftedPauliStr(PauliStr str, int pauliShift);
+
+extern "C" {
+
+void multiplyPauliX(Qureg qureg, int target) {
+    validate_quregFields(qureg, __func__);
+    validate_target(qureg, target, __func__);
+
+    PauliStr str = getPauliStr("X", {target});
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+}
+
+void multiplyPauliY(Qureg qureg, int target) {
+    validate_quregFields(qureg, __func__);
+    validate_target(qureg, target, __func__);
+
+    PauliStr str = getPauliStr("Y", {target});
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+}
+
+void multiplyPauliZ(Qureg qureg, int target) {
+    validate_quregFields(qureg, __func__);
+    validate_target(qureg, target, __func__);
+
+    PauliStr str = getPauliStr("Z", {target});
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+}
+
+void postMultiplyPauliX(Qureg qureg, int target) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_target(qureg, target, __func__);
+
+    PauliStr str = getPauliStr("X", {target});
+    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+}
+
+void postMultiplyPauliY(Qureg qureg, int target) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_target(qureg, target, __func__);
+
+    qcomp factor = -1; // undo transpose
+    PauliStr str = getPauliStr("Y", {target});
+    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
+}
+
+void postMultiplyPauliZ(Qureg qureg, int target) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_target(qureg, target, __func__);
+
+    PauliStr str = getPauliStr("Z", {target});
+    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * Pauli strings
+ */
+
+extern bool paulis_hasOddNumY(PauliStr str);
+
+extern "C" {
+
+void multiplyPauliStr(Qureg qureg, PauliStr str) {
+    validate_quregFields(qureg, __func__);
+    validate_pauliStrTargets(qureg, str, __func__);
+
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+}
+
+void postMultiplyPauliStr(Qureg qureg, PauliStr str) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_pauliStrTargets(qureg, str, __func__);
+
+    qcomp factor = paulis_hasOddNumY(str)? -1 : 1; // undo transpose
+    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
+    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * Pauli gadgets
+ */
+
+extern "C" {
+
+void multiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
+    validate_quregFields(qureg, __func__);
+    validate_pauliStrTargets(qureg, str, __func__);
+
+    qreal phase = util_getPhaseFromGateAngle(angle);
+    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
+}
+
+void postMultiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_pauliStrTargets(qureg, str, __func__);
+
+    qreal factor = paulis_hasOddNumY(str)? -1 : 1;
+    qreal phase = factor * util_getPhaseFromGateAngle(angle);
+    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
+    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
+}
+
+} // end de-mangler
+
+
+
+/*
+ * phase gadgets
+ */
+
+extern "C" {
+
+void multiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
+    validate_quregFields(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+
+    qreal phase = util_getPhaseFromGateAngle(angle);
+    auto qubits = util_getVector(targets, numTargets);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
+}
+
+void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+
+    qreal phase = util_getPhaseFromGateAngle(angle);
+    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
+}
+
+} // end de-mangler
+
+void multiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
+
+    multiplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
+}
+
+void postMultiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
+
+    postMultiplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
+}
+
+
+
+/*
+ * many-qubit NOTs
+ */
+
+extern "C" {
+
+void multiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
+    validate_quregFields(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+
+    // harmlessly re-validates
+    PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
+    multiplyPauliStr(qureg, str);
+}
+
+void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
+    validate_quregFields(qureg, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_targets(qureg, targets, numTargets, __func__);
+
+    // harmlessly re-validates
+    PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
+    postMultiplyPauliStr(qureg, str);
+}
+
+} // end de-mangler
+
+void multiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
+
+    multiplyMultiQubitNot(qureg, targets.data(), targets.size());
+}
+
+void postMultiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
+
+    postMultiplyMultiQubitNot(qureg, targets.data(), targets.size());
+}
+
+
+
+/*
+ * Pauli string sums
+ */
+
+extern "C" {
+
+void multiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
+    validate_quregFields(qureg, __func__);
+    validate_quregFields(workspace, __func__);
+    validate_quregCanBeWorkspace(qureg, workspace, __func__);
+    validate_pauliStrSumFields(sum, __func__);
+    validate_pauliStrSumTargets(sum, qureg, __func__);
+
+    // clone qureg to workspace, set qureg to blank
+    localiser_statevec_setQuregToSuperposition(0, workspace, 1, qureg, 0, qureg);
+    localiser_statevec_initUniformState(qureg, 0);
+
+    // left-multiply each term in-turn, mixing into output qureg, then undo using idempotency
+    for (qindex i=0; i<sum.numTerms; i++) {
+        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
+        localiser_statevec_setQuregToSuperposition(1, qureg, sum.coeffs[i], workspace, 0, workspace);
+        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
+    }
+
+    // workspace -> qureg, and qureg -> sum * qureg
+}
+
+void postMultiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
+    validate_quregFields(qureg, __func__);
+    validate_quregFields(workspace, __func__);
+    validate_quregIsDensityMatrix(qureg, __func__);
+    validate_quregCanBeWorkspace(qureg, workspace, __func__);
+    validate_pauliStrSumFields(sum, __func__);
+    validate_pauliStrSumTargets(sum, qureg, __func__);
+
+    // clone qureg to workspace, set qureg to blank
+    localiser_statevec_setQuregToSuperposition(0, workspace, 1, qureg, 0, qureg);
+    localiser_statevec_initUniformState(qureg, 0);
+
+    // post-multiply each term in-turn, mixing into output qureg, then undo using idempotency
+    for (qindex i=0; i<sum.numTerms; i++) {
+        PauliStr str =  paulis_getShiftedPauliStr(sum.strings[i], qureg.numQubits);
+        qcomp factor = paulis_hasOddNumY(str)? -1 : 1; // undoes transpose
+
+        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
+        localiser_statevec_setQuregToSuperposition(1, qureg, sum.coeffs[i], workspace, 0, workspace);
+        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
+    }
+
+    // workspace -> qureg, and qureg -> sum * qureg
+}
+
+} // end de-mangler

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "quest/include/qureg.h"
+#include "quest/include/paulis.h"
 #include "quest/include/matrices.h"
 #include "quest/include/operations.h"
 #include "quest/include/calculations.h"
@@ -75,29 +76,6 @@ void validateAndApplyAnyCtrlAnyTargUnitaryMatrix(Qureg qureg, int* ctrls, int* s
 
 extern "C" {
 
-void multiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_target(qureg, target, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-
-    bool conj = false;
-    bool transp = false;
-    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, target, matrix, conj, transp);
-}
-
-void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_target(qureg, target, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-    
-    // rho matrix ~ transpose(rho) (x) I ||rho>>
-    bool conj = false;
-    bool transp = true;
-    int qubit = util_getBraQubit(target, qureg);
-    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, qubit, matrix, conj, transp);
-}
-
 void applyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
 
     validateAndApplyAnyCtrlAnyTargUnitaryMatrix(qureg, nullptr, nullptr, 0, &target, 1, matrix, __func__);
@@ -138,32 +116,6 @@ void applyMultiStateControlledCompMatr1(Qureg qureg, vector<int> controls, vecto
  */
 
 extern "C" {
-
-void multiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_twoTargets(qureg, target1, target2, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-    validate_mixedAmpsFitInNode(qureg, 2, __func__);
-
-    bool conj = false;
-    bool transp = false;
-    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, target1, target2, matrix, conj, transp);
-}
-
-void postMultiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_twoTargets(qureg, target1, target2, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-    validate_mixedAmpsFitInNode(qureg, 2, __func__);
-
-    // rho matrix ~ transpose(rho) (x) I ||rho>>
-    bool conj = false;
-    bool transp = true;
-    int qubit1 = util_getBraQubit(target1, qureg);
-    int qubit2 = util_getBraQubit(target2, qureg);
-    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, qubit1, qubit2, matrix, conj, transp);
-}
 
 void applyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
 
@@ -210,31 +162,6 @@ void applyMultiStateControlledCompMatr2(Qureg qureg, vector<int> controls, vecto
 
 extern "C" {
 
-void multiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
-    validate_mixedAmpsFitInNode(qureg, numTargets, __func__);
-
-    bool conj = false;
-    bool transp = false;
-    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, util_getVector(targets, numTargets), matrix, conj, transp);
-}
-
-void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
-    validate_mixedAmpsFitInNode(qureg, numTargets, __func__);
-
-    // rho matrix ~ transpose(rho) (x) I ||rho>>
-    bool conj = false;
-    bool transp = true;
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, qubits, matrix, conj, transp);
-}
-
 void applyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
 
     validateAndApplyAnyCtrlAnyTargUnitaryMatrix(qureg, nullptr, nullptr, 0, targets, numTargets, matrix, __func__);
@@ -256,16 +183,6 @@ void applyMultiStateControlledCompMatr(Qureg qureg, int* controls, int* states, 
 }
 
 } // end de-mangler
-
-void multiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
-
-    multiplyCompMatr(qureg, targets.data(), targets.size(), matr);
-}
-
-void postMultiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
-
-    postMultiplyCompMatr(qureg, targets.data(), targets.size(), matr);
-}
 
 void applyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
@@ -295,26 +212,6 @@ void applyMultiStateControlledCompMatr(Qureg qureg, vector<int> controls, vector
  */
 
 extern "C" {
-
-void multiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_target(qureg, target, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-
-    bool conj = false;
-    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, target, matrix, conj);
-}
-
-void postMultiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_target(qureg, target, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-
-    bool conj = false;
-    int qubit = util_getBraQubit(target, qureg);
-    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, qubit, matrix, conj);
-}
 
 void applyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
 
@@ -356,27 +253,6 @@ void applyMultiStateControlledDiagMatr1(Qureg qureg, vector<int> controls, vecto
  */
 
 extern "C" {
-
-void multiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_twoTargets(qureg, target1, target2, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-
-    bool conj = false;
-    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, target1, target2, matrix, conj);
-}
-
-void postMultiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_twoTargets(qureg, target1, target2, __func__);
-    validate_matrixFields(matrix, __func__); // matrix can be non-unitary
-
-    bool conj = false;
-    int qubit1 = util_getBraQubit(target1, qureg);
-    int qubit2 = util_getBraQubit(target2, qureg);
-    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, qubit1, qubit2, matrix, conj);
-}
 
 void applyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
 
@@ -423,29 +299,6 @@ void applyMultiStateControlledDiagMatr2(Qureg qureg, vector<int> controls, vecto
 
 extern "C" {
 
-void multiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
-
-    bool conj = false;
-    qcomp exponent = 1;
-    auto qubits = util_getVector(targets, numTargets);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
-}
-
-void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
-
-    bool conj = false;
-    qcomp exponent = 1;
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
-}
-
 void applyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
 
     validateAndApplyAnyCtrlAnyTargUnitaryMatrix(qureg, nullptr, nullptr, 0, targets, numTargets, matrix, __func__);
@@ -467,16 +320,6 @@ void applyMultiStateControlledDiagMatr(Qureg qureg, int* controls, int* states, 
 }
 
 } // end de-mangler
-
-void multiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
-
-    multiplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
-}
-
-void postMultiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
-
-    postMultiplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
-}
 
 void applyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
@@ -504,34 +347,11 @@ void applyMultiStateControlledDiagMatr(Qureg qureg, vector<int> controls, vector
 /*
  * DiagMatrPower
  *
- * which still (except for multiply) assert unitarity,
- * even though a non-real exponent is possible
+ * which still assert unitarity despite that passing
+ * a non-real exponent is permitted
  */
 
 extern "C" {
-
-void multiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
-    validate_quregFields(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
-    validate_matrixExpIsNonDiverging(matrix, exponent, __func__); // harmlessly re-validates fields and is-sync
-
-    bool conj = false;
-    auto qubits = util_getVector(targets, numTargets);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
-}
-
-void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-    validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
-    validate_matrixExpIsNonDiverging(matrix, exponent, __func__); // harmlessly re-validates fields and is-sync
-
-    bool conj = false;
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
-}
 
 void applyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent)  {
     validate_quregFields(qureg, __func__);
@@ -610,16 +430,6 @@ void applyMultiStateControlledDiagMatrPower(Qureg qureg, int* controls, int* sta
 
 } // end de-mangler
 
-void multiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
-
-    multiplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
-}
-
-void postMultiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
-
-    postMultiplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
-}
-
 void applyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
 
     applyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
@@ -648,53 +458,6 @@ void applyMultiStateControlledDiagMatrPower(Qureg qureg, vector<int> controls, v
  */
 
 extern "C" {
-
-void multiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_matrixFields(matrix, __func__);
-    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
-
-    multiplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
-}
-
-void multiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
-    validate_quregFields(qureg, __func__);
-    validate_matrixFields(matrix, __func__);
-    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
-    validate_matrixExpIsNonDiverging(matrix, exponent, __func__);
-
-    // rho -> matrix^exponent rho
-    bool leftMultiply = true;
-    bool rightMultiply = false;
-    bool rightConj = false;
-
-    (qureg.isDensityMatrix)?
-        localiser_densmatr_allTargDiagMatr(qureg, matrix, exponent, leftMultiply, rightMultiply, rightConj):
-        localiser_statevec_allTargDiagMatr(qureg, matrix, exponent);
-}
-
-void postMultiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_matrixFields(matrix, __func__);
-    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
-
-    postMultiplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
-}
-
-void postMultiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_matrixFields(matrix, __func__);
-    validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
-    validate_matrixExpIsNonDiverging(matrix, exponent, __func__);
-
-    // rho -> rho matrix^exponent
-    bool leftMultiply = false;
-    bool rightMultiply = true;
-    bool rightConj = false;
-    localiser_densmatr_allTargDiagMatr(qureg, matrix, exponent, leftMultiply, rightMultiply, rightConj);
-}
 
 void applyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
     validate_quregFields(qureg, __func__);
@@ -890,23 +653,6 @@ void applyMultiStateControlledHadamard(Qureg qureg, vector<int> controls, vector
 
 extern "C" {
 
-void multiplySwap(Qureg qureg, int qubit1, int qubit2) {
-    validate_quregFields(qureg, __func__);
-    validate_twoTargets(qureg, qubit1, qubit2, __func__);
-
-    localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
-}
-
-void postMultiplySwap(Qureg qureg, int qubit1, int qubit2) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_twoTargets(qureg, qubit1, qubit2, __func__);
-
-    qubit1 = util_getBraQubit(qubit1, qureg);
-    qubit2 = util_getBraQubit(qubit2, qureg);
-    localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
-}
-
 void applySwap(Qureg qureg, int qubit1, int qubit2) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, qubit1, qubit2, __func__);
@@ -1039,61 +785,6 @@ void applyMultiStateControlledSqrtSwap(Qureg qureg, vector<int> controls, vector
  */
 
 extern "C" {
-
-void multiplyPauliX(Qureg qureg, int target) {
-    validate_quregFields(qureg, __func__);
-    validate_target(qureg, target, __func__);
-
-    PauliStr str = getPauliStr("X", {target});
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
-}
-
-void multiplyPauliY(Qureg qureg, int target) {
-    validate_quregFields(qureg, __func__);
-    validate_target(qureg, target, __func__);
-
-    PauliStr str = getPauliStr("Y", {target});
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
-}
-
-void multiplyPauliZ(Qureg qureg, int target) {
-    validate_quregFields(qureg, __func__);
-    validate_target(qureg, target, __func__);
-
-    PauliStr str = getPauliStr("Z", {target});
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
-}
-
-void postMultiplyPauliX(Qureg qureg, int target) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_target(qureg, target, __func__);
-
-    PauliStr str = getPauliStr("X", {target});
-    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
-}
-
-void postMultiplyPauliY(Qureg qureg, int target) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_target(qureg, target, __func__);
-
-    qcomp factor = -1; // undo transpose
-    PauliStr str = getPauliStr("Y", {target});
-    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
-}
-
-void postMultiplyPauliZ(Qureg qureg, int target) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_target(qureg, target, __func__);
-
-    PauliStr str = getPauliStr("Z", {target});
-    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
-}
 
 void applyPauliX(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
@@ -1238,23 +929,6 @@ void applyMultiStateControlledPauliZ(Qureg qureg, vector<int> controls, vector<i
 
 extern "C" {
 
-void multiplyPauliStr(Qureg qureg, PauliStr str) {
-    validate_quregFields(qureg, __func__);
-    validate_pauliStrTargets(qureg, str, __func__);
-
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
-}
-
-void postMultiplyPauliStr(Qureg qureg, PauliStr str) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_pauliStrTargets(qureg, str, __func__);
-
-    qcomp factor = paulis_hasOddNumY(str)? -1 : 1; // undo transpose
-    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
-}
-
 void applyPauliStr(Qureg qureg, PauliStr str) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
@@ -1329,52 +1003,6 @@ void applyMultiStateControlledPauliStr(Qureg qureg, vector<int> controls, vector
  */
 
 extern "C" {
-
-void multiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
-    validate_quregFields(qureg, __func__);
-    validate_quregFields(workspace, __func__);
-    validate_quregCanBeWorkspace(qureg, workspace, __func__);
-    validate_pauliStrSumFields(sum, __func__);
-    validate_pauliStrSumTargets(sum, qureg, __func__);
-
-    // clone qureg to workspace, set qureg to blank
-    localiser_statevec_setQuregToSuperposition(0, workspace, 1, qureg, 0, qureg);
-    localiser_statevec_initUniformState(qureg, 0);
-
-    // left-multiply each term in-turn, mixing into output qureg, then undo using idempotency
-    for (qindex i=0; i<sum.numTerms; i++) {
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
-        localiser_statevec_setQuregToSuperposition(1, qureg, sum.coeffs[i], workspace, 0, workspace);
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
-    }
-
-    // workspace -> qureg, and qureg -> sum * qureg
-}
-
-void postMultiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
-    validate_quregFields(qureg, __func__);
-    validate_quregFields(workspace, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_quregCanBeWorkspace(qureg, workspace, __func__);
-    validate_pauliStrSumFields(sum, __func__);
-    validate_pauliStrSumTargets(sum, qureg, __func__);
-
-    // clone qureg to workspace, set qureg to blank
-    localiser_statevec_setQuregToSuperposition(0, workspace, 1, qureg, 0, qureg);
-    localiser_statevec_initUniformState(qureg, 0);
-
-    // post-multiply each term in-turn, mixing into output qureg, then undo using idempotency
-    for (qindex i=0; i<sum.numTerms; i++) {
-        PauliStr str =  paulis_getShiftedPauliStr(sum.strings[i], qureg.numQubits);
-        qcomp factor = paulis_hasOddNumY(str)? -1 : 1; // undoes transpose
-
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
-        localiser_statevec_setQuregToSuperposition(1, qureg, sum.coeffs[i], workspace, 0, workspace);
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
-    }
-
-    // workspace -> qureg, and qureg -> sum * qureg
-}
 
 void internal_applyFirstOrderTrotterRepetition(
     Qureg qureg, vector<int>& ketCtrls, vector<int>& braCtrls,
@@ -1522,8 +1150,6 @@ void applyMultiStateControlledTrotterizedPauliStrSumGadget(Qureg qureg, vector<i
  */
 
 extern "C" {
-
-// don't think users will ever want to left-multiply only
 
 void applyRotateX(Qureg qureg, int target, qreal angle) {
     validate_quregFields(qureg, __func__);
@@ -1734,25 +1360,6 @@ void applyMultiStateControlledRotateAroundAxis(Qureg qureg, vector<int> ctrls, v
 
 extern "C" {
 
-void multiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
-    validate_quregFields(qureg, __func__);
-    validate_pauliStrTargets(qureg, str, __func__);
-
-    qreal phase = util_getPhaseFromGateAngle(angle);
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
-}
-
-void postMultiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_pauliStrTargets(qureg, str, __func__);
-
-    qreal factor = paulis_hasOddNumY(str)? -1 : 1;
-    qreal phase = factor * util_getPhaseFromGateAngle(angle);
-    str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
-}
-
 void applyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
@@ -1841,25 +1448,6 @@ void applyMultiStateControlledPauliGadget(Qureg qureg, vector<int> controls, vec
 
 extern "C" {
 
-void multiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
-    validate_quregFields(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-
-    qreal phase = util_getPhaseFromGateAngle(angle);
-    auto qubits = util_getVector(targets, numTargets);
-    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
-}
-
-void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-
-    qreal phase = util_getPhaseFromGateAngle(angle);
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
-}
-
 void applyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -1905,16 +1493,6 @@ void applyMultiStateControlledPhaseGadget(Qureg qureg, int* controls, int* state
 }
 
 } // end de-mangler
-
-void multiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
-
-    multiplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
-}
-
-void postMultiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
-
-    postMultiplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
-}
 
 void applyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
@@ -2026,29 +1604,10 @@ void applyMultiQubitPhaseFlip(Qureg qureg, vector<int> targets) {
 
 
 /*
- * many-qubit CNOTs
+ * many-qubit NOTs and CNOTs
  */
 
 extern "C" {
-
-void multiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
-    validate_quregFields(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-
-    // harmlessly re-validates
-    PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
-    multiplyPauliStr(qureg, str);
-}
-
-void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
-    validate_quregFields(qureg, __func__);
-    validate_quregIsDensityMatrix(qureg, __func__);
-    validate_targets(qureg, targets, numTargets, __func__);
-
-    // harmlessly re-validates
-    PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
-    postMultiplyPauliStr(qureg, str);
-}
 
 void applyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     validate_quregFields(qureg, __func__);
@@ -2087,16 +1646,6 @@ void applyMultiStateControlledMultiQubitNot(Qureg qureg, int* controls, int* sta
 }
 
 } // end de-mangler
-
-void multiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
-
-    multiplyMultiQubitNot(qureg, targets.data(), targets.size());
-}
-
-void postMultiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
-
-    postMultiplyMultiQubitNot(qureg, targets.data(), targets.size());
-}
 
 void applyMultiQubitNot(Qureg qureg, vector<int> targets) {
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(tests
   environment.cpp
   initialisations.cpp
   matrices.cpp
+  multiplication.cpp
   operations.cpp
   paulis.cpp
   qureg.cpp

--- a/tests/unit/multiplication.cpp
+++ b/tests/unit/multiplication.cpp
@@ -1,0 +1,7 @@
+/*
+ * Testing of the multiplication API module is actually 
+ * performed in operations.cpp, in addition to testing
+ * the operations module, since their testing logics are
+ * inextricable. This file exists only to redirect the
+ * confused reader searching for the multiplication tests.
+ */

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1,5 +1,6 @@
 /** @file
- * Unit tests of the operations module. Beware that because the 
+ * Unit tests of both multiplication and operations modules, since
+ * they use inextricable testing logic. Beware that because the 
  * operation functions have so much interface and test-semantic 
  * overlap (e.g. the logic of control qubits, of control-states,
  * of density matrix variants), this file has opted to make 
@@ -12,6 +13,9 @@
  * @author Tyson Jones
  * 
  * @defgroup unitops Operations
+ * @ingroup unittests
+ * 
+ * @defgroup unitmult Multiplication
  * @ingroup unittests
  */
 
@@ -46,8 +50,11 @@ using Catch::Matchers::ContainsSubstring;
  * UTILITIES
  */
 
-#define TEST_CATEGORY \
+#define TEST_CATEGORY_OPS \
     LABEL_UNIT_TAG "[operations]"
+
+#define TEST_CATEGORY_MULT \
+    LABEL_UNIT_TAG "[multiplication]"
 
 
 /*
@@ -1169,10 +1176,10 @@ void testOperation(auto operation, auto matrixRefGen) {
 // C-compatible version. Alas, to your imminent horror, this is.. erm...
 
 // #define TEST_ALL_CTRL_OPERATIONS( namesuffix, numtargs, argtype, matrixgen ) \
-//     TEST_CASE( "apply" #namesuffix,                     TEST_CATEGORY ) { testOperation<zero,     numtargs,argtype>( apply ## namesuffix,                     matrixgen); } \
-//     TEST_CASE( "applyControlled" #namesuffix,           TEST_CATEGORY ) { testOperation<one,      numtargs,argtype>( applyControlled ## namesuffix,           matrixgen); } \
-//     TEST_CASE( "applyMultiControlled" #namesuffix,      TEST_CATEGORY ) { testOperation<any,      numtargs,argtype>( applyMultiControlled ## namesuffix,      matrixgen); } \
-//     TEST_CASE( "applyMultiStateControlled" #namesuffix, TEST_CATEGORY ) { testOperation<anystates,numtargs,argtype>( applyMultiStateControlled ## namesuffix, matrixgen); } 
+//     TEST_CASE( "apply" #namesuffix,                     TEST_CATEGORY_OPS ) { testOperation<zero,     numtargs,argtype>( apply ## namesuffix,                     matrixgen); } \
+//     TEST_CASE( "applyControlled" #namesuffix,           TEST_CATEGORY_OPS ) { testOperation<one,      numtargs,argtype>( applyControlled ## namesuffix,           matrixgen); } \
+//     TEST_CASE( "applyMultiControlled" #namesuffix,      TEST_CATEGORY_OPS ) { testOperation<any,      numtargs,argtype>( applyMultiControlled ## namesuffix,      matrixgen); } \
+//     TEST_CASE( "applyMultiStateControlled" #namesuffix, TEST_CATEGORY_OPS ) { testOperation<anystates,numtargs,argtype>( applyMultiStateControlled ## namesuffix, matrixgen); } 
 
 
 /*
@@ -1267,7 +1274,7 @@ void testOperation(auto operation, auto matrixRefGen) {
 
 // defines a Catch2 test-case for the implied function
 #define TEST_CASE_OPERATION( namesuffix, numctrls, numtargs, argtype, matrixgen ) \
-    TEST_CASE( GET_FUNC_NAME_STR(numctrls, namesuffix), TEST_CATEGORY ) {         \
+    TEST_CASE( GET_FUNC_NAME_STR(numctrls, namesuffix), TEST_CATEGORY_OPS ) {         \
         testOperation<numctrls, numtargs, argtype, apply>(                        \
             GET_CASTED_FUNC(namesuffix, numctrls, numtargs, argtype),             \
             matrixgen);                                                           \
@@ -1283,7 +1290,7 @@ void testOperation(auto operation, auto matrixRefGen) {
 
 
 /** 
- * TESTS
+ * OPERATOR TESTS
  * 
  * @ingroup unitops
  * @{
@@ -1323,32 +1330,10 @@ TEST_ALL_CTRL_OPERATIONS( PhaseGadget, any, scalar, VariableSizeParameterisedMat
  * non-controlled operations with no C++ overloads
  */
 
-TEST_CASE( "applyPhaseFlip",          TEST_CATEGORY ) { testOperation<zero,one,none,apply>  (applyPhaseFlip,          VariableSizeMatrices::PF(1)); }
-TEST_CASE( "applyTwoQubitPhaseFlip",  TEST_CATEGORY ) { testOperation<zero,two,none,apply>  (applyTwoQubitPhaseFlip,  VariableSizeMatrices::PF(2)); }
-TEST_CASE( "applyPhaseShift",         TEST_CATEGORY ) { testOperation<zero,one,scalar,apply>(applyPhaseShift,         ParameterisedMatrices::PS  ); }
-TEST_CASE( "applyTwoQubitPhaseShift", TEST_CATEGORY ) { testOperation<zero,two,scalar,apply>(applyTwoQubitPhaseShift, ParameterisedMatrices::PS2 ); }
-
-TEST_CASE( "multiplySwap",            TEST_CATEGORY ) { testOperation<zero,two,none,multiply>(multiplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "multiplyPauliX",          TEST_CATEGORY ) { testOperation<zero,one,none,multiply>(multiplyPauliX, FixedMatrices::X); }
-TEST_CASE( "multiplyPauliY",          TEST_CATEGORY ) { testOperation<zero,one,none,multiply>(multiplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "multiplyPauliZ",          TEST_CATEGORY ) { testOperation<zero,one,none,multiply>(multiplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "multiplyPauliStr",        TEST_CATEGORY ) { testOperation<zero,any,paulistr,multiply>(multiplyPauliStr,    nullptr); }
-TEST_CASE( "multiplyPauliGadget",     TEST_CATEGORY ) { testOperation<zero,any,pauligad,multiply>(multiplyPauliGadget, nullptr); }
-TEST_CASE( "multiplyCompMatr1",       TEST_CATEGORY ) { testOperation<zero,one,compmatr,multiply>(multiplyCompMatr1,   nullptr); }
-TEST_CASE( "multiplyCompMatr2",       TEST_CATEGORY ) { testOperation<zero,two,compmatr,multiply>(multiplyCompMatr2,   nullptr); }
-TEST_CASE( "multiplyDiagMatr1",       TEST_CATEGORY ) { testOperation<zero,one,diagmatr,multiply>(multiplyDiagMatr1,   nullptr); }
-TEST_CASE( "multiplyDiagMatr2",       TEST_CATEGORY ) { testOperation<zero,two,diagmatr,multiply>(multiplyDiagMatr2,   nullptr); }
-
-TEST_CASE( "postMultiplySwap",            TEST_CATEGORY ) { testOperation<zero,two,none,postmultiply>(postMultiplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "postMultiplyPauliX",          TEST_CATEGORY ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliX, FixedMatrices::X); }
-TEST_CASE( "postMultiplyPauliY",          TEST_CATEGORY ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "postMultiplyPauliZ",          TEST_CATEGORY ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "postMultiplyPauliStr",        TEST_CATEGORY ) { testOperation<zero,any,paulistr,postmultiply>(postMultiplyPauliStr,    nullptr); }
-TEST_CASE( "postMultiplyPauliGadget",     TEST_CATEGORY ) { testOperation<zero,any,pauligad,postmultiply>(postMultiplyPauliGadget, nullptr); }
-TEST_CASE( "postMultiplyCompMatr1",       TEST_CATEGORY ) { testOperation<zero,one,compmatr,postmultiply>(postMultiplyCompMatr1,   nullptr); }
-TEST_CASE( "postMultiplyCompMatr2",       TEST_CATEGORY ) { testOperation<zero,two,compmatr,postmultiply>(postMultiplyCompMatr2,   nullptr); }
-TEST_CASE( "postMultiplyDiagMatr1",       TEST_CATEGORY ) { testOperation<zero,one,diagmatr,postmultiply>(postMultiplyDiagMatr1,   nullptr); }
-TEST_CASE( "postMultiplyDiagMatr2",       TEST_CATEGORY ) { testOperation<zero,two,diagmatr,postmultiply>(postMultiplyDiagMatr2,   nullptr); }
+TEST_CASE( "applyPhaseFlip",          TEST_CATEGORY_OPS ) { testOperation<zero,one,none,apply>  (applyPhaseFlip,          VariableSizeMatrices::PF(1)); }
+TEST_CASE( "applyTwoQubitPhaseFlip",  TEST_CATEGORY_OPS ) { testOperation<zero,two,none,apply>  (applyTwoQubitPhaseFlip,  VariableSizeMatrices::PF(2)); }
+TEST_CASE( "applyPhaseShift",         TEST_CATEGORY_OPS ) { testOperation<zero,one,scalar,apply>(applyPhaseShift,         ParameterisedMatrices::PS  ); }
+TEST_CASE( "applyTwoQubitPhaseShift", TEST_CATEGORY_OPS ) { testOperation<zero,two,scalar,apply>(applyTwoQubitPhaseShift, ParameterisedMatrices::PS2 ); }
 
 
 /*
@@ -1358,75 +1343,22 @@ TEST_CASE( "postMultiplyDiagMatr2",       TEST_CATEGORY ) { testOperation<zero,t
  * compiler ambiguity (spaghetti 4 lyf)
  */
 
-TEST_CASE( "applyMultiQubitPhaseFlip",  TEST_CATEGORY ) {
+TEST_CASE( "applyMultiQubitPhaseFlip",  TEST_CATEGORY_OPS ) {
     auto func = static_cast<void(*)(Qureg, int*, int)>(applyMultiQubitPhaseFlip);
     testOperation<zero,any,none,apply>(func, VariableSizeMatrices::PF);
 }
 
-TEST_CASE( "applyMultiQubitPhaseShift",  TEST_CATEGORY ) {
+TEST_CASE( "applyMultiQubitPhaseShift",  TEST_CATEGORY_OPS ) {
     auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(applyMultiQubitPhaseShift);
     testOperation<zero,any,scalar,apply>(func, VariableSizeParameterisedMatrices::PS);
 }
-
-
-TEST_CASE( "multiplyCompMatr",  TEST_CATEGORY ) { 
-    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(multiplyCompMatr);
-    testOperation<zero,any,compmatr,multiply>(func, nullptr); 
-}
-
-TEST_CASE( "multiplyDiagMatr",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(multiplyDiagMatr);
-    testOperation<zero,any,diagmatr,multiply>(func, nullptr);
-}
-
-TEST_CASE( "multiplyDiagMatrPower",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(multiplyDiagMatrPower);
-    testOperation<zero,any,diagpower,multiply>(func, nullptr);
-}
-
-TEST_CASE( "multiplyMultiQubitNot",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int)>(multiplyMultiQubitNot);
-    testOperation<zero,any,none,multiply>(func, VariableSizeMatrices::X);
-}
-
-TEST_CASE( "multiplyPhaseGadget",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(multiplyPhaseGadget);
-    testOperation<zero,any,scalar,multiply>(func, VariableSizeParameterisedMatrices::Z);
-}
-
-
-TEST_CASE( "postMultiplyCompMatr",  TEST_CATEGORY ) { 
-    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(postMultiplyCompMatr);
-    testOperation<zero,any,compmatr,postmultiply>(func, nullptr); 
-}
-
-TEST_CASE( "postMultiplyDiagMatr",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(postMultiplyDiagMatr);
-    testOperation<zero,any,diagmatr,postmultiply>(func, nullptr);
-}
-
-TEST_CASE( "postMultiplyDiagMatrPower",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(postMultiplyDiagMatrPower);
-    testOperation<zero,any,diagpower,postmultiply>(func, nullptr);
-}
-
-TEST_CASE( "postMultiplyMultiQubitNot",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int)>(postMultiplyMultiQubitNot);
-    testOperation<zero,any,none,postmultiply>(func, VariableSizeMatrices::X);
-}
-
-TEST_CASE( "postMultiplyPhaseGadget",  TEST_CATEGORY ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(postMultiplyPhaseGadget);
-    testOperation<zero,any,scalar,postmultiply>(func, VariableSizeParameterisedMatrices::Z);
-}
-
 
 
 /*
  * operations which need custom logic
  */
 
-TEST_CASE( "applyQuantumFourierTransform", TEST_CATEGORY ) {
+TEST_CASE( "applyQuantumFourierTransform", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1474,7 +1406,7 @@ TEST_CASE( "applyQuantumFourierTransform", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyFullQuantumFourierTransform", TEST_CATEGORY ) {
+TEST_CASE( "applyFullQuantumFourierTransform", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1519,7 +1451,7 @@ TEST_CASE( "applyFullQuantumFourierTransform", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyQubitProjector", TEST_CATEGORY ) {
+TEST_CASE( "applyQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1545,7 +1477,7 @@ TEST_CASE( "applyQubitProjector", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyMultiQubitProjector", TEST_CATEGORY ) {
+TEST_CASE( "applyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1571,7 +1503,7 @@ TEST_CASE( "applyMultiQubitProjector", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyForcedQubitMeasurement", TEST_CATEGORY ) {
+TEST_CASE( "applyForcedQubitMeasurement", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1610,7 +1542,7 @@ TEST_CASE( "applyForcedQubitMeasurement", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyForcedMultiQubitMeasurement", TEST_CATEGORY ) {
+TEST_CASE( "applyForcedMultiQubitMeasurement", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1656,7 +1588,7 @@ TEST_CASE( "applyForcedMultiQubitMeasurement", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyMultiQubitMeasurement", TEST_CATEGORY ) {
+TEST_CASE( "applyMultiQubitMeasurement", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1693,7 +1625,7 @@ TEST_CASE( "applyMultiQubitMeasurement", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyMultiQubitMeasurementAndGetProb", TEST_CATEGORY ) {
+TEST_CASE( "applyMultiQubitMeasurementAndGetProb", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1732,7 +1664,7 @@ TEST_CASE( "applyMultiQubitMeasurementAndGetProb", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyQubitMeasurement", TEST_CATEGORY ) {
+TEST_CASE( "applyQubitMeasurement", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1768,7 +1700,7 @@ TEST_CASE( "applyQubitMeasurement", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "applyQubitMeasurementAndGetProb", TEST_CATEGORY ) {
+TEST_CASE( "applyQubitMeasurementAndGetProb", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -1806,142 +1738,7 @@ TEST_CASE( "applyQubitMeasurementAndGetProb", TEST_CATEGORY ) {
 }
 
 
-TEST_CASE( "multiplyFullStateDiagMatr", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
-
-    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
-
-    auto cachedMatrs = getCachedFullStateDiagMatrs();
-
-    SECTION( LABEL_CORRECTNESS ) {
-
-        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        auto apiFunc = multiplyFullStateDiagMatr;
-
-        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
-
-        SECTION( LABEL_STATEVEC ) {
-
-            auto refFunc = [&] (qvector& state, qmatrix matr) { multiplyReferenceOperator(state, matr); };
-
-            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedSV, cachedMatrs, apiFunc, refSV, refMatr, refFunc);
-        }
-
-        SECTION( LABEL_DENSMATR ) {
-
-            auto refFunc = [&] (qmatrix& state, qmatrix matr) { multiplyReferenceOperator(state, matr); };
-
-            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
-        }
-    }
-
-    /// @todo input validation
-}
-
-
-TEST_CASE( "multiplyFullStateDiagMatrPower", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
-
-    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
-
-    auto cachedMatrs = getCachedFullStateDiagMatrs();
-
-    SECTION( LABEL_CORRECTNESS ) {
-
-        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        qcomp exponent = getRandomComplex();
-
-        auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
-            return multiplyFullStateDiagMatrPower(qureg, matr, exponent);
-        };
-
-        CAPTURE( exponent );
-        
-        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
-
-        SECTION( LABEL_STATEVEC ) {
-
-            auto refFunc = [&] (qvector& state, qmatrix matr) { 
-                matr = getPowerOfDiagonalMatrix(matr, exponent);
-                multiplyReferenceOperator(state, matr);
-            };
-
-            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedSV, cachedMatrs, apiFunc, refSV, refMatr, refFunc);
-        }
-
-        SECTION( LABEL_DENSMATR ) {
-
-            auto refFunc = [&] (qmatrix& state, qmatrix matr) { 
-                matr = getPowerOfDiagonalMatrix(matr, exponent);
-                multiplyReferenceOperator(state, matr);
-            };
-
-            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
-        }
-    }
-
-    /// @todo input validation
-}
-
-
-TEST_CASE( "postMultiplyFullStateDiagMatr", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
-
-    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
-
-    auto cachedMatrs = getCachedFullStateDiagMatrs();
-
-    SECTION( LABEL_CORRECTNESS ) {
-
-        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        auto apiFunc = postMultiplyFullStateDiagMatr;
-
-        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
-
-        SECTION( LABEL_DENSMATR ) {
-
-            auto refFunc = [&] (qmatrix& state, qmatrix matr) { postMultiplyReferenceOperator(state, matr); };
-
-            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
-        }
-    }
-
-    /// @todo input validation
-}
-
-
-TEST_CASE( "postMultiplyFullStateDiagMatrPower", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
-
-    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
-
-    auto cachedMatrs = getCachedFullStateDiagMatrs();
-
-    SECTION( LABEL_CORRECTNESS ) {
-
-        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        qcomp exponent = getRandomComplex();
-
-        auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
-            return postMultiplyFullStateDiagMatrPower(qureg, matr, exponent);
-        };
-
-        CAPTURE( exponent );
-        
-        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
-
-        SECTION( LABEL_DENSMATR ) {
-
-            auto refFunc = [&] (qmatrix& state, qmatrix matr) { 
-                matr = getPowerOfDiagonalMatrix(matr, exponent);
-                postMultiplyReferenceOperator(state, matr);
-            };
-
-            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
-        }
-    }
-
-    /// @todo input validation
-}
-
-
-TEST_CASE( "applyFullStateDiagMatr", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "applyFullStateDiagMatr", TEST_CATEGORY_OPS LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -1973,7 +1770,7 @@ TEST_CASE( "applyFullStateDiagMatr", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
 }
 
 
-TEST_CASE( "applyFullStateDiagMatrPower", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "applyFullStateDiagMatrPower", TEST_CATEGORY_OPS LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -2028,7 +1825,270 @@ TEST_CASE( "applyFullStateDiagMatrPower", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG )
 }
 
 
-TEST_CASE( "multiplyPauliStrSum", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "applyNonUnitaryPauliGadget", TEST_CATEGORY_OPS ) {
+
+    PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        // prepare a random Pauli string and angle
+        int numTargs = GENERATE_COPY( range(1, numQubits+1) );
+        auto targs = GENERATE_TARGS( numQubits, numTargs );
+        PauliStr str = getRandomPauliStr(targs);
+        qcomp angle = getRandomComplex();
+
+        // prepare the corresponding reference matrix exp(-i angle pauli)
+        auto matrRef = getExponentialOfPauliMatrix(angle, getMatrix(str, numQubits));
+
+        auto testFunc = [&](Qureg qureg, auto& stateRef) {
+            applyNonUnitaryPauliGadget(qureg, str, angle);
+            applyReferenceOperator(stateRef, matrRef);
+        };
+
+        CAPTURE( targs, angle );
+        SECTION( LABEL_STATEVEC ) { TEST_ON_CACHED_QUREGS(statevecQuregs, statevecRef, testFunc); }
+        SECTION( LABEL_DENSMATR ) { TEST_ON_CACHED_QUREGS(densmatrQuregs, densmatrRef, testFunc); }
+    }
+
+    /// @todo input validation
+}
+
+
+/** @} (end defgroup) */
+
+
+
+/** 
+ * OPERATOR TESTS
+ * 
+ * @ingroup unitmult
+ * @{
+ */
+
+
+TEST_CASE( "multiplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,multiply>(multiplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "multiplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(multiplyPauliX, FixedMatrices::X); }
+TEST_CASE( "multiplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(multiplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "multiplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(multiplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "multiplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,multiply>(multiplyPauliStr,    nullptr); }
+TEST_CASE( "multiplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,multiply>(multiplyPauliGadget, nullptr); }
+TEST_CASE( "multiplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,multiply>(multiplyCompMatr1,   nullptr); }
+TEST_CASE( "multiplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,multiply>(multiplyCompMatr2,   nullptr); }
+TEST_CASE( "multiplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(multiplyDiagMatr1,   nullptr); }
+TEST_CASE( "multiplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(multiplyDiagMatr2,   nullptr); }
+
+TEST_CASE( "postMultiplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(postMultiplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "postMultiplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliX, FixedMatrices::X); }
+TEST_CASE( "postMultiplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "postMultiplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "postMultiplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,postmultiply>(postMultiplyPauliStr,    nullptr); }
+TEST_CASE( "postMultiplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,postmultiply>(postMultiplyPauliGadget, nullptr); }
+TEST_CASE( "postMultiplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,postmultiply>(postMultiplyCompMatr1,   nullptr); }
+TEST_CASE( "postMultiplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,postmultiply>(postMultiplyCompMatr2,   nullptr); }
+TEST_CASE( "postMultiplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,postmultiply>(postMultiplyDiagMatr1,   nullptr); }
+TEST_CASE( "postMultiplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,postmultiply>(postMultiplyDiagMatr2,   nullptr); }
+
+
+/*
+ * C++ overloads which accept qubit lists as vectors
+ * and so which require explicit casting to resolve the
+ * compiler ambiguity (spaghetti 4 lyf)
+ */
+
+
+TEST_CASE( "multiplyCompMatr",  TEST_CATEGORY_MULT ) { 
+    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(multiplyCompMatr);
+    testOperation<zero,any,compmatr,multiply>(func, nullptr); 
+}
+
+TEST_CASE( "multiplyDiagMatr",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(multiplyDiagMatr);
+    testOperation<zero,any,diagmatr,multiply>(func, nullptr);
+}
+
+TEST_CASE( "multiplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(multiplyDiagMatrPower);
+    testOperation<zero,any,diagpower,multiply>(func, nullptr);
+}
+
+TEST_CASE( "multiplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int)>(multiplyMultiQubitNot);
+    testOperation<zero,any,none,multiply>(func, VariableSizeMatrices::X);
+}
+
+TEST_CASE( "multiplyPhaseGadget",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(multiplyPhaseGadget);
+    testOperation<zero,any,scalar,multiply>(func, VariableSizeParameterisedMatrices::Z);
+}
+
+
+TEST_CASE( "postMultiplyCompMatr",  TEST_CATEGORY_MULT ) { 
+    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(postMultiplyCompMatr);
+    testOperation<zero,any,compmatr,postmultiply>(func, nullptr); 
+}
+
+TEST_CASE( "postMultiplyDiagMatr",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(postMultiplyDiagMatr);
+    testOperation<zero,any,diagmatr,postmultiply>(func, nullptr);
+}
+
+TEST_CASE( "postMultiplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(postMultiplyDiagMatrPower);
+    testOperation<zero,any,diagpower,postmultiply>(func, nullptr);
+}
+
+TEST_CASE( "postMultiplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int)>(postMultiplyMultiQubitNot);
+    testOperation<zero,any,none,postmultiply>(func, VariableSizeMatrices::X);
+}
+
+TEST_CASE( "postMultiplyPhaseGadget",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(postMultiplyPhaseGadget);
+    testOperation<zero,any,scalar,postmultiply>(func, VariableSizeParameterisedMatrices::Z);
+}
+
+
+/*
+ * operations which need custom logic
+ */
+
+
+TEST_CASE( "multiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+
+    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
+
+    auto cachedMatrs = getCachedFullStateDiagMatrs();
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
+        auto apiFunc = multiplyFullStateDiagMatr;
+
+        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
+
+        SECTION( LABEL_STATEVEC ) {
+
+            auto refFunc = [&] (qvector& state, qmatrix matr) { multiplyReferenceOperator(state, matr); };
+
+            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedSV, cachedMatrs, apiFunc, refSV, refMatr, refFunc);
+        }
+
+        SECTION( LABEL_DENSMATR ) {
+
+            auto refFunc = [&] (qmatrix& state, qmatrix matr) { multiplyReferenceOperator(state, matr); };
+
+            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
+        }
+    }
+
+    /// @todo input validation
+}
+
+
+TEST_CASE( "postMultiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+
+    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
+
+    auto cachedMatrs = getCachedFullStateDiagMatrs();
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
+        auto apiFunc = postMultiplyFullStateDiagMatr;
+
+        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
+
+        SECTION( LABEL_DENSMATR ) {
+
+            auto refFunc = [&] (qmatrix& state, qmatrix matr) { postMultiplyReferenceOperator(state, matr); };
+
+            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
+        }
+    }
+
+    /// @todo input validation
+}
+
+
+TEST_CASE( "multiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+
+    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
+
+    auto cachedMatrs = getCachedFullStateDiagMatrs();
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
+        qcomp exponent = getRandomComplex();
+
+        auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
+            return multiplyFullStateDiagMatrPower(qureg, matr, exponent);
+        };
+
+        CAPTURE( exponent );
+        
+        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
+
+        SECTION( LABEL_STATEVEC ) {
+
+            auto refFunc = [&] (qvector& state, qmatrix matr) { 
+                matr = getPowerOfDiagonalMatrix(matr, exponent);
+                multiplyReferenceOperator(state, matr);
+            };
+
+            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedSV, cachedMatrs, apiFunc, refSV, refMatr, refFunc);
+        }
+
+        SECTION( LABEL_DENSMATR ) {
+
+            auto refFunc = [&] (qmatrix& state, qmatrix matr) { 
+                matr = getPowerOfDiagonalMatrix(matr, exponent);
+                multiplyReferenceOperator(state, matr);
+            };
+
+            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
+        }
+    }
+
+    /// @todo input validation
+}
+
+
+TEST_CASE( "postMultiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+
+    PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
+
+    auto cachedMatrs = getCachedFullStateDiagMatrs();
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
+        qcomp exponent = getRandomComplex();
+
+        auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
+            return postMultiplyFullStateDiagMatrPower(qureg, matr, exponent);
+        };
+
+        CAPTURE( exponent );
+        
+        GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
+
+        SECTION( LABEL_DENSMATR ) {
+
+            auto refFunc = [&] (qmatrix& state, qmatrix matr) { 
+                matr = getPowerOfDiagonalMatrix(matr, exponent);
+                postMultiplyReferenceOperator(state, matr);
+            };
+
+            TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
+        }
+    }
+
+    /// @todo input validation
+}
+
+
+TEST_CASE( "multiplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2058,7 +2118,7 @@ TEST_CASE( "multiplyPauliStrSum", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
 }
 
 
-TEST_CASE( "postMultiplyPauliStrSum", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "postMultiplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2080,35 +2140,6 @@ TEST_CASE( "postMultiplyPauliStrSum", TEST_CATEGORY LABEL_MIXED_DEPLOY_TAG ) {
         };
 
         CAPTURE( numTerms );
-        SECTION( LABEL_DENSMATR ) { TEST_ON_CACHED_QUREGS(densmatrQuregs, densmatrRef, testFunc); }
-    }
-
-    /// @todo input validation
-}
-
-
-TEST_CASE( "applyNonUnitaryPauliGadget", TEST_CATEGORY ) {
-
-    PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
-
-    SECTION( LABEL_CORRECTNESS ) {
-
-        // prepare a random Pauli string and angle
-        int numTargs = GENERATE_COPY( range(1, numQubits+1) );
-        auto targs = GENERATE_TARGS( numQubits, numTargs );
-        PauliStr str = getRandomPauliStr(targs);
-        qcomp angle = getRandomComplex();
-
-        // prepare the corresponding reference matrix exp(-i angle pauli)
-        auto matrRef = getExponentialOfPauliMatrix(angle, getMatrix(str, numQubits));
-
-        auto testFunc = [&](Qureg qureg, auto& stateRef) {
-            applyNonUnitaryPauliGadget(qureg, str, angle);
-            applyReferenceOperator(stateRef, matrRef);
-        };
-
-        CAPTURE( targs, angle );
-        SECTION( LABEL_STATEVEC ) { TEST_ON_CACHED_QUREGS(statevecQuregs, statevecRef, testFunc); }
         SECTION( LABEL_DENSMATR ) { TEST_ON_CACHED_QUREGS(densmatrQuregs, densmatrRef, testFunc); }
     }
 


### PR DESCRIPTION
in order to shrink the bloated set of operations, making those remaining "standard" and trace-preserving (with the exception of  the applyQubitProjector and applyMultiQubitProjector)