### PR TITLE
renaming multiply functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ applyMultiQubitProjector(qureg, targs, outcomes, ntargs);
 applyControlledPauliGadget(qureg, ctrl, paulistr, angle);
 applyMultiStateControlledSwap(qureg, ctrls, states, nctrls, targ1, targ2);
 
-multiplyCompMatr1(qureg, targ, getInlineCompMatr1( {{1,2i},{3i,4}} ));
-multiplyDiagMatrPower(qureg, targs, ntargs, diagmatr, exponent);
+preapplyCompMatr1(qureg, targ, getInlineCompMatr1( {{1,2i},{3i,4}} ));
+preapplyDiagMatrPower(qureg, targs, ntargs, diagmatr, exponent);
 ```
 and extremely powerful
 ```cpp

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ applyMultiQubitProjector(qureg, targs, outcomes, ntargs);
 applyControlledPauliGadget(qureg, ctrl, paulistr, angle);
 applyMultiStateControlledSwap(qureg, ctrls, states, nctrls, targ1, targ2);
 
-preapplyCompMatr1(qureg, targ, getInlineCompMatr1( {{1,2i},{3i,4}} ));
-preapplyDiagMatrPower(qureg, targs, ntargs, diagmatr, exponent);
+leftapplyCompMatr1(qureg, targ, getInlineCompMatr1( {{1,2i},{3i,4}} ));
+leftapplyDiagMatrPower(qureg, targs, ntargs, diagmatr, exponent);
 ```
 and extremely powerful
 ```cpp

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -713,9 +713,9 @@ We can even directy mix density matrices together
 mixQureg(rho1, rho2, prob);
 ```
 
-Sometimes we wish to left-multiply general operators upon density matrices without also right-multiplying their adjoint - i.e. our operators should _not_ be effected as unitaries. We can do this with the `multiply*()` functions.
+Sometimes we wish to left-multiply general operators upon density matrices without also right-multiplying their adjoint - i.e. our operators should _not_ be effected as unitaries. We can do this with the `leftapply*()` and `rightapply*()` functions.
 ```cpp
-preapplyDiagMatrPower(rho, fullmatrix, 0.5);
+leftapplyDiagMatrPower(rho, fullmatrix, 0.5);
 ```
 
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -715,7 +715,7 @@ mixQureg(rho1, rho2, prob);
 
 Sometimes we wish to left-multiply general operators upon density matrices without also right-multiplying their adjoint - i.e. our operators should _not_ be effected as unitaries. We can do this with the `multiply*()` functions.
 ```cpp
-multiplyDiagMatrPower(rho, fullmatrix, 0.5);
+preapplyDiagMatrPower(rho, fullmatrix, 0.5);
 ```
 
 

--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -370,7 +370,7 @@ typedef enum pauliOpType _NoWarnPauliOpType;
 
 
 #define applyMultiControlledMatrixN(...) \
-    _ERROR_FUNC_REMOVED("applyMultiControlledMatrixN()") // our new preapplyCompMatr doesn't accept controls
+    _ERROR_FUNC_REMOVED("applyMultiControlledMatrixN()") // our new leftapplyCompMatr doesn't accept controls
 
 
 #define syncQuESTSuccess(...) \
@@ -800,8 +800,8 @@ static inline QuESTEnv _createQuESTEnv() {
     createFullStateDiagMatrFromPauliStrSumFile(fn)
 
 #define applyDiagonalOp(...) \
-    _WARN_FUNC_RENAMED("applyDiagonalOp()", "preapplyFullStateDiagMatr()") \
-    preapplyFullStateDiagMatr(__VA_ARGS__)
+    _WARN_FUNC_RENAMED("applyDiagonalOp()", "leftapplyFullStateDiagMatr()") \
+    leftapplyFullStateDiagMatr(__VA_ARGS__)
 
 #define calcExpecDiagonalOp(...) \
     _WARN_FUNC_RENAMED("calcExpecDiagonalOp()", "calcExpecNonHermitianFullStateDiagMatr()") \
@@ -822,8 +822,8 @@ static inline QuESTEnv _createQuESTEnv() {
     applyDiagMatr(__VA_ARGS__)
 
 #define applySubDiagonalOp(...) \
-    _WARN_FUNC_RENAMED("applySubDiagonalOp()", "preapplyDiagMatr()") \
-    preapplyDiagMatr(__VA_ARGS__)
+    _WARN_FUNC_RENAMED("applySubDiagonalOp()", "leftapplyDiagMatr()") \
+    leftapplyDiagMatr(__VA_ARGS__)
 
 static inline void _applyGateSubDiagonalOp(Qureg qureg, int* targets, int numTargets, DiagMatr op) {
     qreal eps = getValidationEpsilon();
@@ -1029,21 +1029,21 @@ static inline qreal _calcExpecPauliSum(Qureg qureg, _NoWarnPauliOpType* allPauli
 static inline void _applyPauliSum(Qureg inQureg, _NoWarnPauliOpType* allPauliCodes, qreal* termCoeffs, int numSumTerms, Qureg outQureg) {
     PauliStrSum sum = _createPauliStrSumFromCodes(inQureg.numQubits, allPauliCodes, termCoeffs, numSumTerms);
     setQuregToClone(outQureg, inQureg); 
-    preapplyPauliStrSum(outQureg, sum, inQureg);
+    leftapplyPauliStrSum(outQureg, sum, inQureg);
     destroyPauliStrSum(sum);
 }
 
 #define applyPauliSum(...) \
-    _WARN_FUNC_RENAMED("applyPauliSum(inQureg, ..., outQureg)", "preapplyPauliStrSum(outQureg, PauliStrSum)") \
+    _WARN_FUNC_RENAMED("applyPauliSum(inQureg, ..., outQureg)", "leftapplyPauliStrSum(outQureg, PauliStrSum)") \
     _applyPauliSum(__VA_ARGS__)
 
 static inline void _applyPauliHamil(Qureg inQureg, PauliStrSum hamil, Qureg outQureg) {
     setQuregToClone(outQureg, inQureg); 
-    preapplyPauliStrSum(outQureg, hamil, inQureg);
+    leftapplyPauliStrSum(outQureg, hamil, inQureg);
 }
 
 #define applyPauliHamil(...) \
-    _WARN_FUNC_RENAMED("applyPauliHamil(inQureg, PauliHamil, outQureg)", "preapplyPauliStrSum(qureg, PauliStrSum, workspace)") \
+    _WARN_FUNC_RENAMED("applyPauliHamil(inQureg, PauliHamil, outQureg)", "leftapplyPauliStrSum(qureg, PauliStrSum, workspace)") \
     _applyPauliHamil(__VA_ARGS__)
 
 
@@ -1109,16 +1109,16 @@ static inline void _applyPauliHamil(Qureg inQureg, PauliStrSum hamil, Qureg outQ
 
 
 #define applyMatrix2(qureg, targ, ...) \
-    _WARN_FUNC_RENAMED("applyMatrix2()", "preapplyCompMatr1()") \
-    preapplyCompMatr1(qureg, targ, _GET_COMP_MATR_1_FROM_COMPLEX_MATRIX_2(__VA_ARGS__))
+    _WARN_FUNC_RENAMED("applyMatrix2()", "leftapplyCompMatr1()") \
+    leftapplyCompMatr1(qureg, targ, _GET_COMP_MATR_1_FROM_COMPLEX_MATRIX_2(__VA_ARGS__))
 
 #define applyMatrix4(qureg, targ1, targ2, ...) \
-    _WARN_FUNC_RENAMED("applyMatrix4()", "preapplyCompMatr2()") \
-    preapplyCompMatr2(qureg, targ1, targ2, _GET_COMP_MATR_2_FROM_COMPLEX_MATRIX_4(__VA_ARGS__))
+    _WARN_FUNC_RENAMED("applyMatrix4()", "leftapplyCompMatr2()") \
+    leftapplyCompMatr2(qureg, targ1, targ2, _GET_COMP_MATR_2_FROM_COMPLEX_MATRIX_4(__VA_ARGS__))
 
 #define applyMatrixN(...) \
-    _WARN_FUNC_RENAMED("applyMatrixN()", "preapplyCompMatr()") \
-    preapplyCompMatr(__VA_ARGS__)
+    _WARN_FUNC_RENAMED("applyMatrixN()", "leftapplyCompMatr()") \
+    leftapplyCompMatr(__VA_ARGS__)
 
 
 

--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -370,7 +370,7 @@ typedef enum pauliOpType _NoWarnPauliOpType;
 
 
 #define applyMultiControlledMatrixN(...) \
-    _ERROR_FUNC_REMOVED("applyMultiControlledMatrixN()") // our new multiplyCompMatr doesn't accept controls
+    _ERROR_FUNC_REMOVED("applyMultiControlledMatrixN()") // our new preapplyCompMatr doesn't accept controls
 
 
 #define syncQuESTSuccess(...) \
@@ -800,8 +800,8 @@ static inline QuESTEnv _createQuESTEnv() {
     createFullStateDiagMatrFromPauliStrSumFile(fn)
 
 #define applyDiagonalOp(...) \
-    _WARN_FUNC_RENAMED("applyDiagonalOp()", "multiplyFullStateDiagMatr()") \
-    multiplyFullStateDiagMatr(__VA_ARGS__)
+    _WARN_FUNC_RENAMED("applyDiagonalOp()", "preapplyFullStateDiagMatr()") \
+    preapplyFullStateDiagMatr(__VA_ARGS__)
 
 #define calcExpecDiagonalOp(...) \
     _WARN_FUNC_RENAMED("calcExpecDiagonalOp()", "calcExpecNonHermitianFullStateDiagMatr()") \
@@ -822,8 +822,8 @@ static inline QuESTEnv _createQuESTEnv() {
     applyDiagMatr(__VA_ARGS__)
 
 #define applySubDiagonalOp(...) \
-    _WARN_FUNC_RENAMED("applySubDiagonalOp()", "multiplyDiagMatr()") \
-    multiplyDiagMatr(__VA_ARGS__)
+    _WARN_FUNC_RENAMED("applySubDiagonalOp()", "preapplyDiagMatr()") \
+    preapplyDiagMatr(__VA_ARGS__)
 
 static inline void _applyGateSubDiagonalOp(Qureg qureg, int* targets, int numTargets, DiagMatr op) {
     qreal eps = getValidationEpsilon();
@@ -1029,21 +1029,21 @@ static inline qreal _calcExpecPauliSum(Qureg qureg, _NoWarnPauliOpType* allPauli
 static inline void _applyPauliSum(Qureg inQureg, _NoWarnPauliOpType* allPauliCodes, qreal* termCoeffs, int numSumTerms, Qureg outQureg) {
     PauliStrSum sum = _createPauliStrSumFromCodes(inQureg.numQubits, allPauliCodes, termCoeffs, numSumTerms);
     setQuregToClone(outQureg, inQureg); 
-    multiplyPauliStrSum(outQureg, sum, inQureg);
+    preapplyPauliStrSum(outQureg, sum, inQureg);
     destroyPauliStrSum(sum);
 }
 
 #define applyPauliSum(...) \
-    _WARN_FUNC_RENAMED("applyPauliSum(inQureg, ..., outQureg)", "multiplyPauliStrSum(outQureg, PauliStrSum)") \
+    _WARN_FUNC_RENAMED("applyPauliSum(inQureg, ..., outQureg)", "preapplyPauliStrSum(outQureg, PauliStrSum)") \
     _applyPauliSum(__VA_ARGS__)
 
 static inline void _applyPauliHamil(Qureg inQureg, PauliStrSum hamil, Qureg outQureg) {
     setQuregToClone(outQureg, inQureg); 
-    multiplyPauliStrSum(outQureg, hamil, inQureg);
+    preapplyPauliStrSum(outQureg, hamil, inQureg);
 }
 
 #define applyPauliHamil(...) \
-    _WARN_FUNC_RENAMED("applyPauliHamil(inQureg, PauliHamil, outQureg)", "multiplyPauliStrSum(qureg, PauliStrSum, workspace)") \
+    _WARN_FUNC_RENAMED("applyPauliHamil(inQureg, PauliHamil, outQureg)", "preapplyPauliStrSum(qureg, PauliStrSum, workspace)") \
     _applyPauliHamil(__VA_ARGS__)
 
 
@@ -1109,16 +1109,16 @@ static inline void _applyPauliHamil(Qureg inQureg, PauliStrSum hamil, Qureg outQ
 
 
 #define applyMatrix2(qureg, targ, ...) \
-    _WARN_FUNC_RENAMED("applyMatrix2()", "multiplyCompMatr1()") \
-    multiplyCompMatr1(qureg, targ, _GET_COMP_MATR_1_FROM_COMPLEX_MATRIX_2(__VA_ARGS__))
+    _WARN_FUNC_RENAMED("applyMatrix2()", "preapplyCompMatr1()") \
+    preapplyCompMatr1(qureg, targ, _GET_COMP_MATR_1_FROM_COMPLEX_MATRIX_2(__VA_ARGS__))
 
 #define applyMatrix4(qureg, targ1, targ2, ...) \
-    _WARN_FUNC_RENAMED("applyMatrix4()", "multiplyCompMatr2()") \
-    multiplyCompMatr2(qureg, targ1, targ2, _GET_COMP_MATR_2_FROM_COMPLEX_MATRIX_4(__VA_ARGS__))
+    _WARN_FUNC_RENAMED("applyMatrix4()", "preapplyCompMatr2()") \
+    preapplyCompMatr2(qureg, targ1, targ2, _GET_COMP_MATR_2_FROM_COMPLEX_MATRIX_4(__VA_ARGS__))
 
 #define applyMatrixN(...) \
-    _WARN_FUNC_RENAMED("applyMatrixN()", "multiplyCompMatr()") \
-    multiplyCompMatr(__VA_ARGS__)
+    _WARN_FUNC_RENAMED("applyMatrixN()", "preapplyCompMatr()") \
+    preapplyCompMatr(__VA_ARGS__)
 
 
 

--- a/quest/include/multiplication.h
+++ b/quest/include/multiplication.h
@@ -75,12 +75,12 @@ extern "C" {
         {0.3i, 0.4i}
     });
 
-    multiplyCompMatr1(qureg, 2, matrix); 
+    preapplyCompMatr1(qureg, 2, matrix); 
  * ```
  *
  * @param[in,out] qureg  the state to modify.
  * @param[in]     target the index of the target qubit.
- * @param[in]     matrix the Z-basis matrix to multiply.
+ * @param[in]     matrix the Z-basis matrix to preapply.
  * @throws @validationerror
  * - if @p qureg or @p matrix are uninitialised.
  * - if @p target is an invalid qubit index.
@@ -90,10 +90,10 @@ extern "C" {
  * - applyCompMatr1()
  * - postMultiplyCompMatr1()
  * - applyQubitProjector()
- * - multiplyCompMatr()
+ * - preapplyCompMatr()
  * @author Tyson Jones
  */
-void multiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
+void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
 
 
 /** Multiplies a general one-qubit dense @p matrix upon the specified @p target 
@@ -138,8 +138,8 @@ void multiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
  * - getCompMatr1()
  * - getInlineCompMatr1()
  * - applyCompMatr1()
- * - multiplyCompMatr1()
- * - multiplyCompMatr()
+ * - preapplyCompMatr1()
+ * - preapplyCompMatr()
  * @author Tyson Jones
  */
 void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
@@ -170,8 +170,8 @@ extern "C" {
 /// @notyetdoced
 /// @see
 /// - applyCompMatr2()
-/// - multiplyCompMatr1()
-void multiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
+/// - preapplyCompMatr1()
+void preapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
 
 
 /// @notyetdoced
@@ -207,9 +207,9 @@ extern "C" {
  * 
  * @see
  * - applyCompMatr()
- * - multiplyCompMatr1()
+ * - preapplyCompMatr1()
  */
-void multiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
+void preapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
 
 
 /// @notyetdoced
@@ -230,8 +230,8 @@ void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr ma
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see multiplyCompMatr()
-void multiplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
+/// @see preapplyCompMatr()
+void preapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
 
 
 /// @notyettested
@@ -262,8 +262,8 @@ extern "C" {
 
 
 /// @notyetdoced
-/// @see multiplyCompMatr1()
-void multiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
+/// @see preapplyCompMatr1()
+void preapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
 
 
 /// @notyetdoced
@@ -294,8 +294,8 @@ extern "C" {
 
 
 /// @notyetdoced
-/// @see multiplyCompMatr1()
-void multiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
+/// @see preapplyCompMatr1()
+void preapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
 
 
 /// @notyetdoced
@@ -326,8 +326,8 @@ extern "C" {
 
 
 /// @notyetdoced
-/// @see multiplyCompMatr1()
-void multiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
+/// @see preapplyCompMatr1()
+void preapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
 
 
 /// @notyetdoced
@@ -337,9 +337,9 @@ void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr ma
 
 /// @notyetdoced
 /// @see
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyDiagMatrPower()
-void multiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
+void preapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
 
 
 /// @notyetdoced
@@ -361,8 +361,8 @@ void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMa
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see multiplyDiagMatr()
-void multiplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
+/// @see preapplyDiagMatr()
+void preapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 
 
 /// @notyettested
@@ -377,8 +377,8 @@ void postMultiplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see multiplyDiagMatrPower()
-void multiplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
+/// @see preapplyDiagMatrPower()
+void preapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
 
 
 /// @notyettested
@@ -411,8 +411,8 @@ extern "C" {
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - multiplyCompMatr1()
-void multiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
+/// - preapplyCompMatr1()
+void preapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 
 
 /// @notyetdoced
@@ -426,9 +426,9 @@ void postMultiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyFullStateDiagMatr()
-void multiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+void preapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
 
 
 /// @notyetdoced
@@ -463,14 +463,14 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applySwap()
-void multiplySwap(Qureg qureg, int qubit1, int qubit2);
+void preapplySwap(Qureg qureg, int qubit1, int qubit2);
 
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applySwap()
 void postMultiplySwap(Qureg qureg, int qubit1, int qubit2);
 
@@ -499,23 +499,23 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyPauliX()
-void multiplyPauliX(Qureg qureg, int target);
+void preapplyPauliX(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyPauliY()
-void multiplyPauliY(Qureg qureg, int target);
+void preapplyPauliY(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyPauliZ()
-void multiplyPauliZ(Qureg qureg, int target);
+void preapplyPauliZ(Qureg qureg, int target);
 
 
 /// @notyetdoced
@@ -563,9 +563,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyPauliStr()
-void multiplyPauliStr(Qureg qureg, PauliStr str);
+void preapplyPauliStr(Qureg qureg, PauliStr str);
 
 
 /// @notyetdoced
@@ -599,9 +599,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyPauliGadget()
-void multiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
+void preapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
 
 
 /// @notyetdoced
@@ -635,9 +635,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyPhaseGadget()
-void multiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
+void preapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
 
 
 /// @notyetdoced
@@ -659,8 +659,8 @@ void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal an
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see multiplyPhaseGadget()
-void multiplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
+/// @see preapplyPhaseGadget()
+void preapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
 
 
 /// @notyettested
@@ -692,9 +692,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyMultiQubitNot()
-void multiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
+void preapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 
 
 /// @notyetdoced
@@ -716,8 +716,8 @@ void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see multiplyMultiQubitNot()
-void multiplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
+/// @see preapplyMultiQubitNot()
+void preapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
 
 
 /// @notyetvalidated
@@ -748,17 +748,17 @@ extern "C" {
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyQubitProjector()
-void multiplyQubitProjector(Qureg qureg, int qubit, int outcome);
+void preapplyQubitProjector(Qureg qureg, int qubit, int outcome);
 
 
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - multiplyCompMatr1()
+/// - preapplyCompMatr1()
 /// - applyMultiQubitProjector()
-void multiplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
+void preapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
 
 
 /// @notyetdoced
@@ -799,13 +799,13 @@ extern "C" {
 
 /// @notyetdoced
 /// @notyetvalidated
-/// @see multiplyCompMatr1()
-void multiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
+/// @see preapplyCompMatr1()
+void preapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 
 
 /// @notyetdoced
 /// @notyetvalidated
-/// @see multiplyCompMatr1()
+/// @see preapplyCompMatr1()
 void postMultiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 
 

--- a/quest/include/multiplication.h
+++ b/quest/include/multiplication.h
@@ -75,12 +75,12 @@ extern "C" {
         {0.3i, 0.4i}
     });
 
-    preapplyCompMatr1(qureg, 2, matrix); 
+    leftapplyCompMatr1(qureg, 2, matrix); 
  * ```
  *
  * @param[in,out] qureg  the state to modify.
  * @param[in]     target the index of the target qubit.
- * @param[in]     matrix the Z-basis matrix to preapply.
+ * @param[in]     matrix the Z-basis matrix to multiply upon the left.
  * @throws @validationerror
  * - if @p qureg or @p matrix are uninitialised.
  * - if @p target is an invalid qubit index.
@@ -90,10 +90,10 @@ extern "C" {
  * - applyCompMatr1()
  * - postapplyCompMatr1()
  * - applyQubitProjector()
- * - preapplyCompMatr()
+ * - leftapplyCompMatr()
  * @author Tyson Jones
  */
-void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
+void leftapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
 
 
 /** Multiplies a general one-qubit dense @p matrix upon the specified @p target 
@@ -138,8 +138,8 @@ void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
  * - getCompMatr1()
  * - getInlineCompMatr1()
  * - applyCompMatr1()
- * - preapplyCompMatr1()
- * - preapplyCompMatr()
+ * - leftapplyCompMatr1()
+ * - leftapplyCompMatr()
  * @author Tyson Jones
  */
 void postapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
@@ -170,8 +170,8 @@ extern "C" {
 /// @notyetdoced
 /// @see
 /// - applyCompMatr2()
-/// - preapplyCompMatr1()
-void preapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
+/// - leftapplyCompMatr1()
+void leftapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
 
 
 /// @notyetdoced
@@ -207,9 +207,9 @@ extern "C" {
  * 
  * @see
  * - applyCompMatr()
- * - preapplyCompMatr1()
+ * - leftapplyCompMatr1()
  */
-void preapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
+void leftapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
 
 
 /// @notyetdoced
@@ -230,8 +230,8 @@ void postapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matri
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see preapplyCompMatr()
-void preapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
+/// @see leftapplyCompMatr()
+void leftapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
 
 
 /// @notyettested
@@ -262,8 +262,8 @@ extern "C" {
 
 
 /// @notyetdoced
-/// @see preapplyCompMatr1()
-void preapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
+/// @see leftapplyCompMatr1()
+void leftapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
 
 
 /// @notyetdoced
@@ -294,8 +294,8 @@ extern "C" {
 
 
 /// @notyetdoced
-/// @see preapplyCompMatr1()
-void preapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
+/// @see leftapplyCompMatr1()
+void leftapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
 
 
 /// @notyetdoced
@@ -326,8 +326,8 @@ extern "C" {
 
 
 /// @notyetdoced
-/// @see preapplyCompMatr1()
-void preapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
+/// @see leftapplyCompMatr1()
+void leftapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
 
 
 /// @notyetdoced
@@ -337,9 +337,9 @@ void postapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matri
 
 /// @notyetdoced
 /// @see
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyDiagMatrPower()
-void preapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
+void leftapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
 
 
 /// @notyetdoced
@@ -361,8 +361,8 @@ void postapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr 
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see preapplyDiagMatr()
-void preapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
+/// @see leftapplyDiagMatr()
+void leftapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 
 
 /// @notyettested
@@ -377,8 +377,8 @@ void postapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see preapplyDiagMatrPower()
-void preapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
+/// @see leftapplyDiagMatrPower()
+void leftapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
 
 
 /// @notyettested
@@ -411,8 +411,8 @@ extern "C" {
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - preapplyCompMatr1()
-void preapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
+/// - leftapplyCompMatr1()
+void leftapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 
 
 /// @notyetdoced
@@ -426,9 +426,9 @@ void postapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyFullStateDiagMatr()
-void preapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+void leftapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
 
 
 /// @notyetdoced
@@ -463,14 +463,14 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applySwap()
-void preapplySwap(Qureg qureg, int qubit1, int qubit2);
+void leftapplySwap(Qureg qureg, int qubit1, int qubit2);
 
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applySwap()
 void postapplySwap(Qureg qureg, int qubit1, int qubit2);
 
@@ -499,23 +499,23 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyPauliX()
-void preapplyPauliX(Qureg qureg, int target);
+void leftapplyPauliX(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyPauliY()
-void preapplyPauliY(Qureg qureg, int target);
+void leftapplyPauliY(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyPauliZ()
-void preapplyPauliZ(Qureg qureg, int target);
+void leftapplyPauliZ(Qureg qureg, int target);
 
 
 /// @notyetdoced
@@ -563,9 +563,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyPauliStr()
-void preapplyPauliStr(Qureg qureg, PauliStr str);
+void leftapplyPauliStr(Qureg qureg, PauliStr str);
 
 
 /// @notyetdoced
@@ -599,9 +599,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyPauliGadget()
-void preapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
+void leftapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
 
 
 /// @notyetdoced
@@ -635,9 +635,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyPhaseGadget()
-void preapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
+void leftapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
 
 
 /// @notyetdoced
@@ -659,8 +659,8 @@ void postapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see preapplyPhaseGadget()
-void preapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
+/// @see leftapplyPhaseGadget()
+void leftapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
 
 
 /// @notyettested
@@ -692,9 +692,9 @@ extern "C" {
 
 /// @notyetdoced
 /// @see 
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyMultiQubitNot()
-void preapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
+void leftapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 
 
 /// @notyetdoced
@@ -716,8 +716,8 @@ void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see preapplyMultiQubitNot()
-void preapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
+/// @see leftapplyMultiQubitNot()
+void leftapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
 
 
 /// @notyetvalidated
@@ -748,17 +748,17 @@ extern "C" {
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyQubitProjector()
-void preapplyQubitProjector(Qureg qureg, int qubit, int outcome);
+void leftapplyQubitProjector(Qureg qureg, int qubit, int outcome);
 
 
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - preapplyCompMatr1()
+/// - leftapplyCompMatr1()
 /// - applyMultiQubitProjector()
-void preapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
+void leftapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
 
 
 /// @notyetdoced
@@ -799,13 +799,13 @@ extern "C" {
 
 /// @notyetdoced
 /// @notyetvalidated
-/// @see preapplyCompMatr1()
-void preapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
+/// @see leftapplyCompMatr1()
+void leftapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 
 
 /// @notyetdoced
 /// @notyetvalidated
-/// @see preapplyCompMatr1()
+/// @see leftapplyCompMatr1()
 void postapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 
 

--- a/quest/include/multiplication.h
+++ b/quest/include/multiplication.h
@@ -88,7 +88,7 @@ extern "C" {
  * - getCompMatr1()
  * - getInlineCompMatr1()
  * - applyCompMatr1()
- * - postMultiplyCompMatr1()
+ * - postapplyCompMatr1()
  * - applyQubitProjector()
  * - preapplyCompMatr()
  * @author Tyson Jones
@@ -124,7 +124,7 @@ void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
         {0.3i, 0.4i}
     });
 
-    postMultiplyCompMatr1(qureg, 2, matrix); 
+    postapplyCompMatr1(qureg, 2, matrix); 
  * ```
  *
  * @param[in,out] qureg  the state to modify.
@@ -142,7 +142,7 @@ void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
  * - preapplyCompMatr()
  * @author Tyson Jones
  */
-void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
+void postapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
 
 
 // end de-mangler
@@ -176,8 +176,8 @@ void preapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
 
 /// @notyetdoced
 /// @see
-/// - postMultiplyCompMatr1()
-void postMultiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
+/// - postapplyCompMatr1()
+void postapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
 
 
 // end de-mangler
@@ -214,8 +214,8 @@ void preapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix
 
 /// @notyetdoced
 /// @see
-/// - postMultiplyCompMatr1()
-void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
+/// - postapplyCompMatr1()
+void postapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
 
 
 // end de-mangler
@@ -238,8 +238,8 @@ void preapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postMultiplyCompMatr()
-void postMultiplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
+/// @see postapplyCompMatr()
+void postapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
 
 
 #endif 
@@ -267,8 +267,8 @@ void preapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
 
 
 /// @notyetdoced
-/// @see postMultiplyCompMatr1()
-void postMultiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix);
+/// @see postapplyCompMatr1()
+void postapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix);
 
 
 // end de-mangler
@@ -299,8 +299,8 @@ void preapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
 
 
 /// @notyetdoced
-/// @see postMultiplyCompMatr1()
-void postMultiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix);
+/// @see postapplyCompMatr1()
+void postapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix);
 
 
 // end de-mangler
@@ -331,8 +331,8 @@ void preapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix
 
 
 /// @notyetdoced
-/// @see postMultiplyCompMatr1()
-void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
+/// @see postapplyCompMatr1()
+void postapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
 
 
 /// @notyetdoced
@@ -344,9 +344,9 @@ void preapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr m
 
 /// @notyetdoced
 /// @see 
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyDiagMatrPower()
-void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
+void postapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
 
 
 // end de-mangler
@@ -369,8 +369,8 @@ void preapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postMultiplyDiagMatr()
-void postMultiplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
+/// @see postapplyDiagMatr()
+void postapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 
 
 /// @notyettested
@@ -385,8 +385,8 @@ void preapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matri
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postMultiplyDiagMatrPower()
-void postMultiplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
+/// @see postapplyDiagMatrPower()
+void postapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
 
 
 #endif 
@@ -418,9 +418,9 @@ void preapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyFullStateDiagMatr()
-void postMultiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
+void postapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 
 
 /// @notyetdoced
@@ -434,9 +434,9 @@ void preapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyFullStateDiagMatr()
-void postMultiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+void postapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
 
 
 // end de-mangler
@@ -472,7 +472,7 @@ void preapplySwap(Qureg qureg, int qubit1, int qubit2);
 /// @see 
 /// - preapplyCompMatr1()
 /// - applySwap()
-void postMultiplySwap(Qureg qureg, int qubit1, int qubit2);
+void postapplySwap(Qureg qureg, int qubit1, int qubit2);
 
 
 // end de-mangler
@@ -520,23 +520,23 @@ void preapplyPauliZ(Qureg qureg, int target);
 
 /// @notyetdoced
 /// @see 
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyPauliX()
-void postMultiplyPauliX(Qureg qureg, int target);
+void postapplyPauliX(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyPauliY()
-void postMultiplyPauliY(Qureg qureg, int target);
+void postapplyPauliY(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyPauliZ()
-void postMultiplyPauliZ(Qureg qureg, int target);
+void postapplyPauliZ(Qureg qureg, int target);
 
 
 // end de-mangler
@@ -570,9 +570,9 @@ void preapplyPauliStr(Qureg qureg, PauliStr str);
 
 /// @notyetdoced
 /// @see 
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyPauliStr()
-void postMultiplyPauliStr(Qureg qureg, PauliStr str);
+void postapplyPauliStr(Qureg qureg, PauliStr str);
 
 
 // end de-mangler
@@ -606,9 +606,9 @@ void preapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
 
 /// @notyetdoced
 /// @see 
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyPauliGadget()
-void postMultiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
+void postapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
 
 
 // end de-mangler
@@ -642,9 +642,9 @@ void preapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle)
 
 /// @notyetdoced
 /// @see
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyPhaseGadget()
-void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
+void postapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
 
 
 // end de-mangler
@@ -667,8 +667,8 @@ void preapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postMultiplyPhaseGadget()
-void postMultiplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
+/// @see postapplyPhaseGadget()
+void postapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
 
 
 #endif
@@ -700,9 +700,9 @@ void preapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyMultiQubitNot()
-void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
+void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 
 
 // end de-mangler
@@ -723,8 +723,8 @@ void preapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postMultiplyMultiQubitNot()
-void postMultiplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
+/// @see postapplyMultiQubitNot()
+void postapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
 
 
 #endif
@@ -764,17 +764,17 @@ void preapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int nu
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyQubitProjector()
-void postMultiplyQubitProjector(Qureg qureg, int qubit, int outcome);
+void postapplyQubitProjector(Qureg qureg, int qubit, int outcome);
 
 
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postMultiplyCompMatr1()
+/// - postapplyCompMatr1()
 /// - applyMultiQubitProjector()
-void postMultiplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
+void postapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
 
 
 // end de-mangler
@@ -806,7 +806,7 @@ void preapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see preapplyCompMatr1()
-void postMultiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
+void postapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 
 
 // end de-mangler

--- a/quest/include/multiplication.h
+++ b/quest/include/multiplication.h
@@ -88,7 +88,7 @@ extern "C" {
  * - getCompMatr1()
  * - getInlineCompMatr1()
  * - applyCompMatr1()
- * - postapplyCompMatr1()
+ * - rightapplyCompMatr1()
  * - applyQubitProjector()
  * - leftapplyCompMatr()
  * @author Tyson Jones
@@ -124,7 +124,7 @@ void leftapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
         {0.3i, 0.4i}
     });
 
-    postapplyCompMatr1(qureg, 2, matrix); 
+    rightapplyCompMatr1(qureg, 2, matrix); 
  * ```
  *
  * @param[in,out] qureg  the state to modify.
@@ -142,7 +142,7 @@ void leftapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
  * - leftapplyCompMatr()
  * @author Tyson Jones
  */
-void postapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
+void rightapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix);
 
 
 // end de-mangler
@@ -176,8 +176,8 @@ void leftapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr);
 
 /// @notyetdoced
 /// @see
-/// - postapplyCompMatr1()
-void postapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
+/// - rightapplyCompMatr1()
+void rightapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
 
 
 // end de-mangler
@@ -214,8 +214,8 @@ void leftapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matri
 
 /// @notyetdoced
 /// @see
-/// - postapplyCompMatr1()
-void postapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
+/// - rightapplyCompMatr1()
+void rightapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix);
 
 
 // end de-mangler
@@ -238,8 +238,8 @@ void leftapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postapplyCompMatr()
-void postapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
+/// @see rightapplyCompMatr()
+void rightapplyCompMatr(Qureg qureg, std::vector<int> targets, CompMatr matr);
 
 
 #endif 
@@ -267,8 +267,8 @@ void leftapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
 
 
 /// @notyetdoced
-/// @see postapplyCompMatr1()
-void postapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix);
+/// @see rightapplyCompMatr1()
+void rightapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix);
 
 
 // end de-mangler
@@ -299,8 +299,8 @@ void leftapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr);
 
 
 /// @notyetdoced
-/// @see postapplyCompMatr1()
-void postapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix);
+/// @see rightapplyCompMatr1()
+void rightapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix);
 
 
 // end de-mangler
@@ -331,8 +331,8 @@ void leftapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matri
 
 
 /// @notyetdoced
-/// @see postapplyCompMatr1()
-void postapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
+/// @see rightapplyCompMatr1()
+void rightapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix);
 
 
 /// @notyetdoced
@@ -344,9 +344,9 @@ void leftapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr 
 
 /// @notyetdoced
 /// @see 
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyDiagMatrPower()
-void postapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
+void rightapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent);
 
 
 // end de-mangler
@@ -369,8 +369,8 @@ void leftapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postapplyDiagMatr()
-void postapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
+/// @see rightapplyDiagMatr()
+void rightapplyDiagMatr(Qureg qureg, std::vector<int> targets, DiagMatr matrix);
 
 
 /// @notyettested
@@ -385,8 +385,8 @@ void leftapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matr
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postapplyDiagMatrPower()
-void postapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
+/// @see rightapplyDiagMatrPower()
+void rightapplyDiagMatrPower(Qureg qureg, std::vector<int> targets, DiagMatr matrix, qcomp exponent);
 
 
 #endif 
@@ -418,9 +418,9 @@ void leftapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyFullStateDiagMatr()
-void postapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
+void rightapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix);
 
 
 /// @notyetdoced
@@ -434,9 +434,9 @@ void leftapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcom
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyFullStateDiagMatr()
-void postapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
+void rightapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent);
 
 
 // end de-mangler
@@ -472,7 +472,7 @@ void leftapplySwap(Qureg qureg, int qubit1, int qubit2);
 /// @see 
 /// - leftapplyCompMatr1()
 /// - applySwap()
-void postapplySwap(Qureg qureg, int qubit1, int qubit2);
+void rightapplySwap(Qureg qureg, int qubit1, int qubit2);
 
 
 // end de-mangler
@@ -520,23 +520,23 @@ void leftapplyPauliZ(Qureg qureg, int target);
 
 /// @notyetdoced
 /// @see 
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyPauliX()
-void postapplyPauliX(Qureg qureg, int target);
+void rightapplyPauliX(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyPauliY()
-void postapplyPauliY(Qureg qureg, int target);
+void rightapplyPauliY(Qureg qureg, int target);
 
 
 /// @notyetdoced
 /// @see 
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyPauliZ()
-void postapplyPauliZ(Qureg qureg, int target);
+void rightapplyPauliZ(Qureg qureg, int target);
 
 
 // end de-mangler
@@ -570,9 +570,9 @@ void leftapplyPauliStr(Qureg qureg, PauliStr str);
 
 /// @notyetdoced
 /// @see 
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyPauliStr()
-void postapplyPauliStr(Qureg qureg, PauliStr str);
+void rightapplyPauliStr(Qureg qureg, PauliStr str);
 
 
 // end de-mangler
@@ -606,9 +606,9 @@ void leftapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
 
 /// @notyetdoced
 /// @see 
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyPauliGadget()
-void postapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
+void rightapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle);
 
 
 // end de-mangler
@@ -642,9 +642,9 @@ void leftapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle
 
 /// @notyetdoced
 /// @see
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyPhaseGadget()
-void postapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
+void rightapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle);
 
 
 // end de-mangler
@@ -667,8 +667,8 @@ void leftapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postapplyPhaseGadget()
-void postapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
+/// @see rightapplyPhaseGadget()
+void rightapplyPhaseGadget(Qureg qureg, std::vector<int> targets, qreal angle);
 
 
 #endif
@@ -700,9 +700,9 @@ void leftapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyMultiQubitNot()
-void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
+void rightapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets);
 
 
 // end de-mangler
@@ -723,8 +723,8 @@ void leftapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
 /// @notyetvalidated
 /// @notyetdoced
 /// @cppvectoroverload
-/// @see postapplyMultiQubitNot()
-void postapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
+/// @see rightapplyMultiQubitNot()
+void rightapplyMultiQubitNot(Qureg qureg, std::vector<int> targets);
 
 
 #endif
@@ -764,17 +764,17 @@ void leftapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int n
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyQubitProjector()
-void postapplyQubitProjector(Qureg qureg, int qubit, int outcome);
+void rightapplyQubitProjector(Qureg qureg, int qubit, int outcome);
 
 
 /// @notyetdoced
 /// @notyetvalidated
 /// @see
-/// - postapplyCompMatr1()
+/// - rightapplyCompMatr1()
 /// - applyMultiQubitProjector()
-void postapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
+void rightapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits);
 
 
 // end de-mangler
@@ -806,7 +806,7 @@ void leftapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 /// @notyetdoced
 /// @notyetvalidated
 /// @see leftapplyCompMatr1()
-void postapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
+void rightapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace);
 
 
 // end de-mangler

--- a/quest/include/multiplication.h
+++ b/quest/include/multiplication.h
@@ -7,8 +7,8 @@
  * 
  * @defgroup multiplication Multiplication
  * @ingroup api
- * @brief Functions for directly multiplying operators upon 
- *        density matrices.
+ * @brief Functions for directly pre- or post-multiplying operators 
+ *        upon density matrices.
  * @{
  */
 

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -115,7 +115,7 @@ digraph {
  * @see
  * - getCompMatr1()
  * - getInlineCompMatr1()
- * - multiplyCompMatr1()
+ * - preapplyCompMatr1()
  * - postMultiplyCompMatr1()
  * - applyControlledCompMatr1()
  * - applyCompMatr2()
@@ -322,7 +322,7 @@ digraph {
  *
  * @see
  * - applyCompMatr1()
- * - multiplyCompMatr2()
+ * - preapplyCompMatr2()
  * - postMultiplyCompMatr2()
  */
 void applyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
@@ -515,7 +515,7 @@ extern "C" {
  *
  * @see
  * - applyCompMatr1()
- * - multiplyCompMatr()
+ * - preapplyCompMatr()
  * - postMultiplyCompMatr()
  */
 void applyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matr);
@@ -600,7 +600,7 @@ extern "C" {
 /** @notyetdoced
  * @see 
  * - applyCompMatr1()
- * - multiplyCompMatr2()
+ * - preapplyCompMatr2()
  * - postMultiplyCompMatr2()
  */
 void applyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -116,7 +116,7 @@ digraph {
  * - getCompMatr1()
  * - getInlineCompMatr1()
  * - leftapplyCompMatr1()
- * - postapplyCompMatr1()
+ * - rightapplyCompMatr1()
  * - applyControlledCompMatr1()
  * - applyCompMatr2()
  * - applyCompMatr()
@@ -323,7 +323,7 @@ digraph {
  * @see
  * - applyCompMatr1()
  * - leftapplyCompMatr2()
- * - postapplyCompMatr2()
+ * - rightapplyCompMatr2()
  */
 void applyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
 
@@ -516,7 +516,7 @@ extern "C" {
  * @see
  * - applyCompMatr1()
  * - leftapplyCompMatr()
- * - postapplyCompMatr()
+ * - rightapplyCompMatr()
  */
 void applyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matr);
 
@@ -601,7 +601,7 @@ extern "C" {
  * @see 
  * - applyCompMatr1()
  * - leftapplyCompMatr2()
- * - postapplyCompMatr2()
+ * - rightapplyCompMatr2()
  */
 void applyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
 

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -115,7 +115,7 @@ digraph {
  * @see
  * - getCompMatr1()
  * - getInlineCompMatr1()
- * - preapplyCompMatr1()
+ * - leftapplyCompMatr1()
  * - postapplyCompMatr1()
  * - applyControlledCompMatr1()
  * - applyCompMatr2()
@@ -322,7 +322,7 @@ digraph {
  *
  * @see
  * - applyCompMatr1()
- * - preapplyCompMatr2()
+ * - leftapplyCompMatr2()
  * - postapplyCompMatr2()
  */
 void applyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
@@ -515,7 +515,7 @@ extern "C" {
  *
  * @see
  * - applyCompMatr1()
- * - preapplyCompMatr()
+ * - leftapplyCompMatr()
  * - postapplyCompMatr()
  */
 void applyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matr);
@@ -600,7 +600,7 @@ extern "C" {
 /** @notyetdoced
  * @see 
  * - applyCompMatr1()
- * - preapplyCompMatr2()
+ * - leftapplyCompMatr2()
  * - postapplyCompMatr2()
  */
 void applyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -116,7 +116,7 @@ digraph {
  * - getCompMatr1()
  * - getInlineCompMatr1()
  * - preapplyCompMatr1()
- * - postMultiplyCompMatr1()
+ * - postapplyCompMatr1()
  * - applyControlledCompMatr1()
  * - applyCompMatr2()
  * - applyCompMatr()
@@ -323,7 +323,7 @@ digraph {
  * @see
  * - applyCompMatr1()
  * - preapplyCompMatr2()
- * - postMultiplyCompMatr2()
+ * - postapplyCompMatr2()
  */
 void applyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix);
 
@@ -516,7 +516,7 @@ extern "C" {
  * @see
  * - applyCompMatr1()
  * - preapplyCompMatr()
- * - postMultiplyCompMatr()
+ * - postapplyCompMatr()
  */
 void applyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matr);
 
@@ -601,7 +601,7 @@ extern "C" {
  * @see 
  * - applyCompMatr1()
  * - preapplyCompMatr2()
- * - postMultiplyCompMatr2()
+ * - postapplyCompMatr2()
  */
 void applyDiagMatr1(Qureg qureg, int target, DiagMatr1 matr);
 

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -27,7 +27,7 @@ using std::vector;
 
 extern "C" {
 
-void multiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
+void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
     validate_matrixFields(matrix, __func__);
@@ -60,7 +60,7 @@ void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
 
 extern "C" {
 
-void multiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
+void preapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
     validate_matrixFields(matrix, __func__);
@@ -96,7 +96,7 @@ void postMultiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matr
 
 extern "C" {
 
-void multiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
+void preapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
     validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
@@ -123,9 +123,9 @@ void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr ma
 
 } // end de-mangler
 
-void multiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
+void preapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
-    multiplyCompMatr(qureg, targets.data(), targets.size(), matr);
+    preapplyCompMatr(qureg, targets.data(), targets.size(), matr);
 }
 
 void postMultiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
@@ -141,7 +141,7 @@ void postMultiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
 extern "C" {
 
-void multiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
+void preapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
     validate_matrixFields(matrix, __func__);
@@ -171,7 +171,7 @@ void postMultiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
 
 extern "C" {
 
-void multiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
+void preapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
     validate_matrixFields(matrix, __func__);
@@ -202,7 +202,7 @@ void postMultiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matr
 
 extern "C" {
 
-void multiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
+void preapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
     validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
@@ -227,9 +227,9 @@ void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr ma
 
 } // end de-mangler
 
-void multiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
+void preapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
-    multiplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
+    preapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
 }
 
 void postMultiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
@@ -245,7 +245,7 @@ void postMultiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
 extern "C" {
 
-void multiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
+void preapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
     validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
@@ -270,9 +270,9 @@ void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMa
 
 } // end de-mangler
 
-void multiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
+void preapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
 
-    multiplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
+    preapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
 }
 
 void postMultiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
@@ -288,15 +288,15 @@ void postMultiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix
 
 extern "C" {
 
-void multiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
+void preapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_matrixFields(matrix, __func__);
     validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
 
-    multiplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
+    preapplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
 }
 
-void multiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
+void preapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_matrixFields(matrix, __func__);
     validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
@@ -345,7 +345,7 @@ void postMultiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, q
 
 extern "C" {
 
-void multiplySwap(Qureg qureg, int qubit1, int qubit2) {
+void preapplySwap(Qureg qureg, int qubit1, int qubit2) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, qubit1, qubit2, __func__);
 
@@ -374,7 +374,7 @@ extern PauliStr paulis_getShiftedPauliStr(PauliStr str, int pauliShift);
 
 extern "C" {
 
-void multiplyPauliX(Qureg qureg, int target) {
+void preapplyPauliX(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
 
@@ -382,7 +382,7 @@ void multiplyPauliX(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void multiplyPauliY(Qureg qureg, int target) {
+void preapplyPauliY(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
 
@@ -390,7 +390,7 @@ void multiplyPauliY(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void multiplyPauliZ(Qureg qureg, int target) {
+void preapplyPauliZ(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
 
@@ -441,7 +441,7 @@ extern bool paulis_hasOddNumY(PauliStr str);
 
 extern "C" {
 
-void multiplyPauliStr(Qureg qureg, PauliStr str) {
+void preapplyPauliStr(Qureg qureg, PauliStr str) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
 
@@ -468,7 +468,7 @@ void postMultiplyPauliStr(Qureg qureg, PauliStr str) {
 
 extern "C" {
 
-void multiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
+void preapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
 
@@ -497,7 +497,7 @@ void postMultiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
 
 extern "C" {
 
-void multiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
+void preapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
@@ -518,9 +518,9 @@ void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal an
 
 } // end de-mangler
 
-void multiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
+void preapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
-    multiplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
+    preapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
 }
 
 void postMultiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
@@ -536,13 +536,13 @@ void postMultiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
 extern "C" {
 
-void multiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
+void preapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
     // harmlessly re-validates
     PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
-    multiplyPauliStr(qureg, str);
+    preapplyPauliStr(qureg, str);
 }
 
 void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
@@ -557,9 +557,9 @@ void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
 
 } // end de-mangler
 
-void multiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
+void preapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
 
-    multiplyMultiQubitNot(qureg, targets.data(), targets.size());
+    preapplyMultiQubitNot(qureg, targets.data(), targets.size());
 }
 
 void postMultiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
@@ -575,7 +575,7 @@ void postMultiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
 
 extern "C" {
 
-void multiplyQubitProjector(Qureg qureg, int qubit, int outcome) {
+void preapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, qubit, __func__);
     validate_measurementOutcomeIsValid(outcome, __func__); 
@@ -584,7 +584,7 @@ void multiplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     localiser_statevec_multiQubitProjector(qureg, {qubit}, {outcome}, prob);
 }
 
-void multiplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
+void preapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, qubits, numQubits, __func__);
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
@@ -619,10 +619,10 @@ void postMultiplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, in
 
 } // end de-mangler
 
-void multiplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+void preapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
     validate_measurementOutcomesMatchTargets(qubits.size(), outcomes.size(), __func__);
 
-    multiplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
+    preapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
 void postMultiplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
@@ -639,7 +639,7 @@ void postMultiplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int
 
 extern "C" {
 
-void multiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
+void preapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     validate_quregFields(qureg, __func__);
     validate_quregFields(workspace, __func__);
     validate_quregCanBeWorkspace(qureg, workspace, __func__);

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -37,7 +37,7 @@ void leftapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, target, matrix, conj, transp);
 }
 
-void postapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
+void rightapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -71,7 +71,7 @@ void leftapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix)
     localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, target1, target2, matrix, conj, transp);
 }
 
-void postapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
+void rightapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
@@ -107,7 +107,7 @@ void leftapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matri
     localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, util_getVector(targets, numTargets), matrix, conj, transp);
 }
 
-void postapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
+void rightapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -128,9 +128,9 @@ void leftapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
     leftapplyCompMatr(qureg, targets.data(), targets.size(), matr);
 }
 
-void postapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
+void rightapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
-    postapplyCompMatr(qureg, targets.data(), targets.size(), matr);
+    rightapplyCompMatr(qureg, targets.data(), targets.size(), matr);
 }
 
 
@@ -150,7 +150,7 @@ void leftapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, target, matrix, conj);
 }
 
-void postapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
+void rightapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -180,7 +180,7 @@ void leftapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix)
     localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, target1, target2, matrix, conj);
 }
 
-void postapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
+void rightapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
@@ -213,7 +213,7 @@ void leftapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matri
     localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
 }
 
-void postapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
+void rightapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -232,9 +232,9 @@ void leftapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
     leftapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
 }
 
-void postapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
+void rightapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
-    postapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
+    rightapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
 }
 
 
@@ -256,7 +256,7 @@ void leftapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr 
     localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
 }
 
-void postapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
+void rightapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -275,9 +275,9 @@ void leftapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, q
     leftapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
 }
 
-void postapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
+void rightapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
 
-    postapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
+    rightapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
 }
 
 
@@ -312,16 +312,16 @@ void leftapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcom
         localiser_statevec_allTargDiagMatr(qureg, matrix, exponent);
 }
 
-void postapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
+void rightapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_matrixFields(matrix, __func__);
     validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
 
-    postapplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
+    rightapplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
 }
 
-void postapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
+void rightapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_matrixFields(matrix, __func__);
@@ -352,7 +352,7 @@ void leftapplySwap(Qureg qureg, int qubit1, int qubit2) {
     localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
 }
 
-void postapplySwap(Qureg qureg, int qubit1, int qubit2) {
+void rightapplySwap(Qureg qureg, int qubit1, int qubit2) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_twoTargets(qureg, qubit1, qubit2, __func__);
@@ -398,7 +398,7 @@ void leftapplyPauliZ(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void postapplyPauliX(Qureg qureg, int target) {
+void rightapplyPauliX(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -408,7 +408,7 @@ void postapplyPauliX(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void postapplyPauliY(Qureg qureg, int target) {
+void rightapplyPauliY(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -419,7 +419,7 @@ void postapplyPauliY(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
 }
 
-void postapplyPauliZ(Qureg qureg, int target) {
+void rightapplyPauliZ(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -448,7 +448,7 @@ void leftapplyPauliStr(Qureg qureg, PauliStr str) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void postapplyPauliStr(Qureg qureg, PauliStr str) {
+void rightapplyPauliStr(Qureg qureg, PauliStr str) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
@@ -476,7 +476,7 @@ void leftapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
 }
 
-void postapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
+void rightapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
@@ -506,7 +506,7 @@ void leftapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle
     localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
 }
 
-void postapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
+void rightapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -523,9 +523,9 @@ void leftapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
     leftapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
 }
 
-void postapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
+void rightapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
-    postapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
+    rightapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
 }
 
 
@@ -545,14 +545,14 @@ void leftapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     leftapplyPauliStr(qureg, str);
 }
 
-void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
+void rightapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
     // harmlessly re-validates
     PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
-    postapplyPauliStr(qureg, str);
+    rightapplyPauliStr(qureg, str);
 }
 
 } // end de-mangler
@@ -562,9 +562,9 @@ void leftapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
     leftapplyMultiQubitNot(qureg, targets.data(), targets.size());
 }
 
-void postapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
+void rightapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
 
-    postapplyMultiQubitNot(qureg, targets.data(), targets.size());
+    rightapplyMultiQubitNot(qureg, targets.data(), targets.size());
 }
 
 
@@ -595,7 +595,7 @@ void leftapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int n
     localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, prob);
 }
 
-void postapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
+void rightapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, qubit, __func__);
@@ -605,7 +605,7 @@ void postapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     localiser_statevec_multiQubitProjector(qureg, {util_getBraQubit(qubit,qureg)}, {outcome}, prob);
 }
 
-void postapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
+void rightapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, qubits, numQubits, __func__);
@@ -625,10 +625,10 @@ void leftapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> o
     leftapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
-void postapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+void rightapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
     validate_measurementOutcomesMatchTargets(qubits.size(), outcomes.size(), __func__);
 
-    postapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
+    rightapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
 
@@ -660,7 +660,7 @@ void leftapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     // workspace -> qureg, and qureg -> sum * qureg
 }
 
-void postapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
+void rightapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     validate_quregFields(qureg, __func__);
     validate_quregFields(workspace, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -27,7 +27,7 @@ using std::vector;
 
 extern "C" {
 
-void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
+void leftapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
     validate_matrixFields(matrix, __func__);
@@ -60,7 +60,7 @@ void postapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
 
 extern "C" {
 
-void preapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
+void leftapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
     validate_matrixFields(matrix, __func__);
@@ -96,7 +96,7 @@ void postapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix)
 
 extern "C" {
 
-void preapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
+void leftapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
     validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
@@ -123,9 +123,9 @@ void postapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matri
 
 } // end de-mangler
 
-void preapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
+void leftapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
-    preapplyCompMatr(qureg, targets.data(), targets.size(), matr);
+    leftapplyCompMatr(qureg, targets.data(), targets.size(), matr);
 }
 
 void postapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
@@ -141,7 +141,7 @@ void postapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
 extern "C" {
 
-void preapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
+void leftapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
     validate_matrixFields(matrix, __func__);
@@ -171,7 +171,7 @@ void postapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
 
 extern "C" {
 
-void preapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
+void leftapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
     validate_matrixFields(matrix, __func__);
@@ -202,7 +202,7 @@ void postapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix)
 
 extern "C" {
 
-void preapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
+void leftapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
     validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync
@@ -227,9 +227,9 @@ void postapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matri
 
 } // end de-mangler
 
-void preapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
+void leftapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
-    preapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
+    leftapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
 }
 
 void postapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
@@ -245,7 +245,7 @@ void postapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
 extern "C" {
 
-void preapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
+void leftapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
     validate_matrixDimMatchesTargets(matrix, numTargets, __func__); // also validates fields and is-sync, but not unitarity
@@ -270,9 +270,9 @@ void postapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr 
 
 } // end de-mangler
 
-void preapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
+void leftapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
 
-    preapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
+    leftapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
 }
 
 void postapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
@@ -288,15 +288,15 @@ void postapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, q
 
 extern "C" {
 
-void preapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
+void leftapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_matrixFields(matrix, __func__);
     validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
 
-    preapplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
+    leftapplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
 }
 
-void preapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
+void leftapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_matrixFields(matrix, __func__);
     validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
@@ -345,7 +345,7 @@ void postapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcom
 
 extern "C" {
 
-void preapplySwap(Qureg qureg, int qubit1, int qubit2) {
+void leftapplySwap(Qureg qureg, int qubit1, int qubit2) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, qubit1, qubit2, __func__);
 
@@ -374,7 +374,7 @@ extern PauliStr paulis_getShiftedPauliStr(PauliStr str, int pauliShift);
 
 extern "C" {
 
-void preapplyPauliX(Qureg qureg, int target) {
+void leftapplyPauliX(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
 
@@ -382,7 +382,7 @@ void preapplyPauliX(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void preapplyPauliY(Qureg qureg, int target) {
+void leftapplyPauliY(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
 
@@ -390,7 +390,7 @@ void preapplyPauliY(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void preapplyPauliZ(Qureg qureg, int target) {
+void leftapplyPauliZ(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, target, __func__);
 
@@ -441,7 +441,7 @@ extern bool paulis_hasOddNumY(PauliStr str);
 
 extern "C" {
 
-void preapplyPauliStr(Qureg qureg, PauliStr str) {
+void leftapplyPauliStr(Qureg qureg, PauliStr str) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
 
@@ -468,7 +468,7 @@ void postapplyPauliStr(Qureg qureg, PauliStr str) {
 
 extern "C" {
 
-void preapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
+void leftapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
 
@@ -497,7 +497,7 @@ void postapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
 
 extern "C" {
 
-void preapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
+void leftapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
@@ -518,9 +518,9 @@ void postapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle
 
 } // end de-mangler
 
-void preapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
+void leftapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
-    preapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
+    leftapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
 }
 
 void postapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
@@ -536,13 +536,13 @@ void postapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
 extern "C" {
 
-void preapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
+void leftapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
     // harmlessly re-validates
     PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
-    preapplyPauliStr(qureg, str);
+    leftapplyPauliStr(qureg, str);
 }
 
 void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
@@ -557,9 +557,9 @@ void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
 
 } // end de-mangler
 
-void preapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
+void leftapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
 
-    preapplyMultiQubitNot(qureg, targets.data(), targets.size());
+    leftapplyMultiQubitNot(qureg, targets.data(), targets.size());
 }
 
 void postapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
@@ -575,7 +575,7 @@ void postapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
 
 extern "C" {
 
-void preapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
+void leftapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     validate_quregFields(qureg, __func__);
     validate_target(qureg, qubit, __func__);
     validate_measurementOutcomeIsValid(outcome, __func__); 
@@ -584,7 +584,7 @@ void preapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     localiser_statevec_multiQubitProjector(qureg, {qubit}, {outcome}, prob);
 }
 
-void preapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
+void leftapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
     validate_quregFields(qureg, __func__);
     validate_targets(qureg, qubits, numQubits, __func__);
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
@@ -619,10 +619,10 @@ void postapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int n
 
 } // end de-mangler
 
-void preapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+void leftapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
     validate_measurementOutcomesMatchTargets(qubits.size(), outcomes.size(), __func__);
 
-    preapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
+    leftapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
 void postapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
@@ -639,7 +639,7 @@ void postapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> o
 
 extern "C" {
 
-void preapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
+void leftapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     validate_quregFields(qureg, __func__);
     validate_quregFields(workspace, __func__);
     validate_quregCanBeWorkspace(qureg, workspace, __func__);

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -37,7 +37,7 @@ void preapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, target, matrix, conj, transp);
 }
 
-void postMultiplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
+void postapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -71,7 +71,7 @@ void preapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) 
     localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, target1, target2, matrix, conj, transp);
 }
 
-void postMultiplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
+void postapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
@@ -107,7 +107,7 @@ void preapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix
     localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, util_getVector(targets, numTargets), matrix, conj, transp);
 }
 
-void postMultiplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
+void postapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -128,9 +128,9 @@ void preapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
     preapplyCompMatr(qureg, targets.data(), targets.size(), matr);
 }
 
-void postMultiplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
+void postapplyCompMatr(Qureg qureg, vector<int> targets, CompMatr matr) {
 
-    postMultiplyCompMatr(qureg, targets.data(), targets.size(), matr);
+    postapplyCompMatr(qureg, targets.data(), targets.size(), matr);
 }
 
 
@@ -150,7 +150,7 @@ void preapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, target, matrix, conj);
 }
 
-void postMultiplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
+void postapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -180,7 +180,7 @@ void preapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) 
     localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, target1, target2, matrix, conj);
 }
 
-void postMultiplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
+void postapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_twoTargets(qureg, target1, target2, __func__);
@@ -213,7 +213,7 @@ void preapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix
     localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
 }
 
-void postMultiplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
+void postapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -232,9 +232,9 @@ void preapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
     preapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
 }
 
-void postMultiplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
+void postapplyDiagMatr(Qureg qureg, vector<int> targets, DiagMatr matrix) {
 
-    postMultiplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
+    postapplyDiagMatr(qureg, targets.data(), targets.size(), matrix);
 }
 
 
@@ -256,7 +256,7 @@ void preapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr m
     localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
 }
 
-void postMultiplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
+void postapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -275,9 +275,9 @@ void preapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qc
     preapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
 }
 
-void postMultiplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
+void postapplyDiagMatrPower(Qureg qureg, vector<int> targets, DiagMatr matrix, qcomp exponent) {
 
-    postMultiplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
+    postapplyDiagMatrPower(qureg, targets.data(), targets.size(), matrix, exponent);
 }
 
 
@@ -312,16 +312,16 @@ void preapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp
         localiser_statevec_allTargDiagMatr(qureg, matrix, exponent);
 }
 
-void postMultiplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
+void postapplyFullStateDiagMatr(Qureg qureg, FullStateDiagMatr matrix) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_matrixFields(matrix, __func__);
     validate_matrixAndQuregAreCompatible(matrix, qureg, false, __func__); // matrix can be non-unitary
 
-    postMultiplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
+    postapplyFullStateDiagMatrPower(qureg, matrix, 1); // harmlessly re-validates
 }
 
-void postMultiplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
+void postapplyFullStateDiagMatrPower(Qureg qureg, FullStateDiagMatr matrix, qcomp exponent) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_matrixFields(matrix, __func__);
@@ -352,7 +352,7 @@ void preapplySwap(Qureg qureg, int qubit1, int qubit2) {
     localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
 }
 
-void postMultiplySwap(Qureg qureg, int qubit1, int qubit2) {
+void postapplySwap(Qureg qureg, int qubit1, int qubit2) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_twoTargets(qureg, qubit1, qubit2, __func__);
@@ -398,7 +398,7 @@ void preapplyPauliZ(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void postMultiplyPauliX(Qureg qureg, int target) {
+void postapplyPauliX(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -408,7 +408,7 @@ void postMultiplyPauliX(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void postMultiplyPauliY(Qureg qureg, int target) {
+void postapplyPauliY(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -419,7 +419,7 @@ void postMultiplyPauliY(Qureg qureg, int target) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
 }
 
-void postMultiplyPauliZ(Qureg qureg, int target) {
+void postapplyPauliZ(Qureg qureg, int target) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, target, __func__);
@@ -448,7 +448,7 @@ void preapplyPauliStr(Qureg qureg, PauliStr str) {
     localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
 }
 
-void postMultiplyPauliStr(Qureg qureg, PauliStr str) {
+void postapplyPauliStr(Qureg qureg, PauliStr str) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
@@ -476,7 +476,7 @@ void preapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
 }
 
-void postMultiplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
+void postapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
@@ -506,7 +506,7 @@ void preapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle)
     localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
 }
 
-void postMultiplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
+void postapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
@@ -523,9 +523,9 @@ void preapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
     preapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
 }
 
-void postMultiplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
+void postapplyPhaseGadget(Qureg qureg, vector<int> targets, qreal angle) {
 
-    postMultiplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
+    postapplyPhaseGadget(qureg, targets.data(), targets.size(), angle);
 }
 
 
@@ -545,14 +545,14 @@ void preapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     preapplyPauliStr(qureg, str);
 }
 
-void postMultiplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
+void postapplyMultiQubitNot(Qureg qureg, int* targets, int numTargets) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, targets, numTargets, __func__);
 
     // harmlessly re-validates
     PauliStr str = getPauliStr(std::string(numTargets, 'X'), targets, numTargets);
-    postMultiplyPauliStr(qureg, str);
+    postapplyPauliStr(qureg, str);
 }
 
 } // end de-mangler
@@ -562,9 +562,9 @@ void preapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
     preapplyMultiQubitNot(qureg, targets.data(), targets.size());
 }
 
-void postMultiplyMultiQubitNot(Qureg qureg, vector<int> targets) {
+void postapplyMultiQubitNot(Qureg qureg, vector<int> targets) {
 
-    postMultiplyMultiQubitNot(qureg, targets.data(), targets.size());
+    postapplyMultiQubitNot(qureg, targets.data(), targets.size());
 }
 
 
@@ -595,7 +595,7 @@ void preapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int nu
     localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, prob);
 }
 
-void postMultiplyQubitProjector(Qureg qureg, int qubit, int outcome) {
+void postapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_target(qureg, qubit, __func__);
@@ -605,7 +605,7 @@ void postMultiplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     localiser_statevec_multiQubitProjector(qureg, {util_getBraQubit(qubit,qureg)}, {outcome}, prob);
 }
 
-void postMultiplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
+void postapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
     validate_quregFields(qureg, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);
     validate_targets(qureg, qubits, numQubits, __func__);
@@ -625,10 +625,10 @@ void preapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> ou
     preapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
-void postMultiplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+void postapplyMultiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
     validate_measurementOutcomesMatchTargets(qubits.size(), outcomes.size(), __func__);
 
-    postMultiplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
+    postapplyMultiQubitProjector(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
 
@@ -660,7 +660,7 @@ void preapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     // workspace -> qureg, and qureg -> sum * qureg
 }
 
-void postMultiplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
+void postapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     validate_quregFields(qureg, __func__);
     validate_quregFields(workspace, __func__);
     validate_quregIsDensityMatrix(qureg, __func__);

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -392,22 +392,22 @@ void accel_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qco
 }
 
 
-auto getDenseMatrAllTargDiagMatrFunc(bool isGpu, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight) {
+auto getDenseMatrAllTargDiagMatrFunc(bool isGpu, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight) {
 
     // this helper function exists, dissimilar from the function-agnostic macros used
     // by other functions, because densmatr_allTargDiagMatr_sub() does not accept every
     // possible combination of its boolean template parameters 
-    assert_fullStateDiagMatrTemplateParamsAreValid(multiplyLeft, multiplyRight, conjRight);
+    assert_fullStateDiagMatrTemplateParamsAreValid(applyLeft, applyRight, conjRight);
 
     bool hasPower = exponent != qcomp(1, 0);
 
-    if (multiplyLeft && multiplyRight && conjRight)
+    if (applyLeft && applyRight && conjRight)
         return GET_CPU_OR_GPU_FOUR_BOOL_FUNC_OPTIMISED_FOR_FIRST_BOOL( isGpu, densmatr_allTargDiagMatr_sub, hasPower, true,true,true );
 
-    if (multiplyLeft && ! multiplyRight && ! conjRight)
+    if (applyLeft && ! applyRight && ! conjRight)
         return GET_CPU_OR_GPU_FOUR_BOOL_FUNC_OPTIMISED_FOR_FIRST_BOOL( isGpu, densmatr_allTargDiagMatr_sub, hasPower, true,false,false );
 
-    if (! multiplyLeft && multiplyRight && ! conjRight)
+    if (! applyLeft && applyRight && ! conjRight)
         return GET_CPU_OR_GPU_FOUR_BOOL_FUNC_OPTIMISED_FOR_FIRST_BOOL( isGpu, densmatr_allTargDiagMatr_sub, hasPower, false,true,false );
 
     // unreachable
@@ -415,7 +415,7 @@ auto getDenseMatrAllTargDiagMatrFunc(bool isGpu, qcomp exponent, bool multiplyLe
 }
 
 
-void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight) {
+void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight) {
 
     // matr is always local, qureg can be local or distributed...
     assert_fullStateDiagMatrIsLocal(matr);
@@ -425,8 +425,8 @@ void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qc
     bool matrGPU = matr.isGpuAccelerated;
 
     // which determines which function is called
-    auto gpuFunc = getDenseMatrAllTargDiagMatrFunc(true,  exponent, multiplyLeft, multiplyRight, conjRight);
-    auto cpuFunc = getDenseMatrAllTargDiagMatrFunc(false, exponent, multiplyLeft, multiplyRight, conjRight);
+    auto gpuFunc = getDenseMatrAllTargDiagMatrFunc(true,  exponent, applyLeft, applyRight, conjRight);
+    auto cpuFunc = getDenseMatrAllTargDiagMatrFunc(false, exponent, applyLeft, applyRight, conjRight);
 
     // when deployments match, we trivially call the common backend
     if ( quregGPU &&  matrGPU) gpuFunc(qureg, matr, exponent);
@@ -476,7 +476,7 @@ void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qc
 }
 
 
-void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight) {
+void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight) {
 
     assert_fullStateDiagMatrIsDistributed(matr);
     assert_acceleratorQuregIsDistributed(qureg);
@@ -501,7 +501,7 @@ void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qc
     temp.cpuElems = qureg.cpuCommBuffer;
     temp.gpuElems = qureg.gpuCommBuffer;
 
-    accel_densmatr_allTargDiagMatr_subA(qureg, temp, exponent, multiplyLeft, multiplyRight, conjRight);
+    accel_densmatr_allTargDiagMatr_subA(qureg, temp, exponent, applyLeft, applyRight, conjRight);
 }
 
 

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -209,8 +209,8 @@ void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, v
 
 void accel_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
-void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight);
-void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight);
+void accel_densmatr_allTargDiagMatr_subA(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight);
+void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight);
 
 
 

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -467,12 +467,12 @@ void assert_fullStateDiagMatrIsDistributed(FullStateDiagMatr matr) {
         raiseInternalError("An accelerator function received a non-distributed FullStateDiagMatr where a distributed one was expected.");
 }
 
-void assert_fullStateDiagMatrTemplateParamsAreValid(bool multiplyLeft, bool multiplyRight, bool conjRight) {
+void assert_fullStateDiagMatrTemplateParamsAreValid(bool applyLeft, bool applyRight, bool conjRight) {
 
     bool valid = (
-        (  multiplyLeft &&   multiplyRight &&   conjRight) || // matr qureg conj(matr)
-        (  multiplyLeft && ! multiplyRight && ! conjRight) || // matr qureg
-        (! multiplyLeft &&   multiplyRight && ! conjRight)    //      qureg matr
+        (  applyLeft &&   applyRight &&   conjRight) || // matr qureg conj(matr)
+        (  applyLeft && ! applyRight && ! conjRight) || // matr qureg
+        (! applyLeft &&   applyRight && ! conjRight)    //      qureg matr
     );
 
     if (!valid)

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -168,7 +168,7 @@ void assert_fullStateDiagMatrIsLocal(FullStateDiagMatr matr);
 
 void assert_fullStateDiagMatrIsDistributed(FullStateDiagMatr matr);
 
-void assert_fullStateDiagMatrTemplateParamsAreValid(bool multiplyLeft, bool multiplyRight, bool conjRight);
+void assert_fullStateDiagMatrTemplateParamsAreValid(bool applyLeft, bool applyRight, bool conjRight);
 
 void assert_acceleratorQuregIsDistributed(Qureg qureg);
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -1171,7 +1171,7 @@ void localiser_statevec_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qco
 }
 
 
-void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight) {
+void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight) {
     assert_localiserGivenDensMatr(qureg);
 
     // the diagonal matr has quadratically fewer elements than the density-matrix
@@ -1197,7 +1197,7 @@ void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qco
     // when the matrix is not distributed, we call the same routine despite whether qureg 
     // is distributed or not; that merely changes how many qureg columns get updated
     if (!matrDist) {
-        accel_densmatr_allTargDiagMatr_subA(qureg, matr, exponent, multiplyLeft, multiplyRight, conjRight);
+        accel_densmatr_allTargDiagMatr_subA(qureg, matr, exponent, applyLeft, applyRight, conjRight);
         return;
     }
 
@@ -1206,7 +1206,7 @@ void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qco
 
     // matr elems are inside qureg buffer, but we still pass matr struct along to
     // accelerator, because it is going to perform mischief to re-use subA().
-    accel_densmatr_allTargDiagMatr_subB(qureg, matr, exponent, multiplyLeft, multiplyRight, conjRight); 
+    accel_densmatr_allTargDiagMatr_subB(qureg, matr, exponent, applyLeft, applyRight, conjRight); 
 }
 
 

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -101,7 +101,7 @@ void localiser_statevec_anyCtrlTwoTargDiagMatr(Qureg qureg, vector<int> ctrls, v
 void localiser_statevec_anyCtrlAnyTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent, bool conj);
 
 void localiser_statevec_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
-void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool multiplyLeft, bool multiplyRight, bool conjRight);
+void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight);
 
 
 /*

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -750,7 +750,7 @@ void cpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
 }
 
 
-template <bool HasPower, bool MultiplyLeft, bool MultiplyRight, bool ConjRight>
+template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight>
 void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent) {
 
     // unlike other functions, this function handles all scenarios of...
@@ -773,7 +773,7 @@ void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
         qcomp fac = 1;
 
         // update fac to effect rho -> (matr * rho) or (matr^exponent * rho)
-        if constexpr (MultiplyLeft) {
+        if constexpr (ApplyLeft) {
 
             // i = global row of nth local amp
             qindex i = fast_getQuregGlobalRowFromFlatIndex(n, matr.numElems);
@@ -789,7 +789,7 @@ void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
 
         // update fac to additional include rho -> (rho * matr) or 
         // (rho * conj(matr)), or the same exponentiated
-        if constexpr (MultiplyRight) {
+        if constexpr (ApplyRight) {
 
             // m = global index corresponding to n
             qindex m = concatenateBits(qureg.rank, n, qureg.logNumAmpsPerNode);

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -82,7 +82,7 @@ template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower> void cpu_st
 
 template <bool HasPower> void cpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
-template <bool HasPower, bool MultiplyLeft, bool MultiplyRight, bool ConjRight> void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
+template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight> void cpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
 
 /*

--- a/quest/src/gpu/gpu_kernels.cuh
+++ b/quest/src/gpu/gpu_kernels.cuh
@@ -563,7 +563,7 @@ __global__ void kernel_statevec_anyCtrlAnyTargDiagMatr_sub(
  */
 
 
-template <bool HasPower, bool MultiplyLeft, bool MultiplyRight, bool ConjRight> 
+template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight> 
 __global__ void kernel_densmatr_allTargDiagMatr_sub(
     cu_qcomp* amps, qindex numThreads, int rank, qindex logNumAmpsPerNode,
     cu_qcomp* elems, qindex numElems, cu_qcomp exponent
@@ -572,7 +572,7 @@ __global__ void kernel_densmatr_allTargDiagMatr_sub(
 
     cu_qcomp fac = getCuQcomp(1, 0);
 
-    if constexpr (MultiplyLeft) {
+    if constexpr (ApplyLeft) {
 
         qindex i = fast_getQuregGlobalRowFromFlatIndex(n, numElems);
         cu_qcomp term = elems[i];
@@ -583,7 +583,7 @@ __global__ void kernel_densmatr_allTargDiagMatr_sub(
         fac = term;
     }
 
-    if constexpr (MultiplyRight) {
+    if constexpr (ApplyRight) {
 
         qindex m = concatenateBits(rank, n, logNumAmpsPerNode);
         qindex j = fast_getQuregGlobalColFromFlatIndex(m, numElems);

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -749,7 +749,7 @@ void gpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
 }
 
 
-template <bool HasPower, bool MultiplyLeft, bool MultiplyRight, bool ConjRight>
+template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight>
 void gpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent) {
 
     assert_exponentMatchesTemplateParam(exponent, HasPower);
@@ -760,7 +760,7 @@ void gpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp
     qindex numBlocks = getNumBlocks(numThreads);
 
     kernel_densmatr_allTargDiagMatr_sub 
-        <HasPower, MultiplyLeft, MultiplyRight, ConjRight> 
+        <HasPower, ApplyLeft, ApplyRight, ConjRight> 
         <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
             toCuQcomps(qureg.gpuAmps), numThreads, qureg.rank, qureg.logNumAmpsPerNode,
             toCuQcomps(util_getGpuMemPtr(matr)), matr.numElems, toCuQcomp(exponent)

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -75,7 +75,7 @@ template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower> void gpu_st
 
 template <bool HasPower> void gpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
-template <bool HasPower, bool MultiplyLeft, bool MultiplyRight, bool ConjRight> void gpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
+template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight> void gpu_densmatr_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
 
 /*

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -594,17 +594,17 @@ qmatrix getReferenceMatrix(auto matrixRefGen, vector<int> targs, auto additional
  * Let |psi> be a statevector, rho be a density matrix, 
  * and matr be an operator matrix. The options perform:
  * 
- * apply:    |psi> -> matr |psi>,  rho -> matr rho adj(matr)
- * multiply: |psi> -> matr |psi>,  rho -> matr rho
- * postmultiply:                   rho -> rho matr
+ * apply:     |psi> -> matr |psi>,  rho -> matr rho adj(matr)
+ * leftapply: |psi> -> matr |psi>,  rho -> matr rho
+ * rightapply:                      rho -> rho matr
  * 
  * Note this is necessarily a template parameter (rather
  * than just a runtime parameter) only because the
- * postMultiplyReferenceOperator() function is defined
+ * rightapplyReferenceOperator() function is defined
  * only upon qmatrix (for density matrices)
  */
 
-enum ApplyFlag { apply, multiply, postmultiply };
+enum ApplyFlag { apply, leftapply, rightapply };
 
 
 /*
@@ -752,8 +752,8 @@ void testOperationCorrectness(auto operation, auto matrixRefGen) {
 
         // update reference state (ctrls & states happen to only ever be used by apply)
         if constexpr (Apply == apply)        applyReferenceOperator(       stateRef, ctrls, states, targs, matrixRef);
-        if constexpr (Apply == multiply)     leftapplyReferenceOperator(    stateRef, ctrls, states, targs, matrixRef);
-        if constexpr (Apply == postmultiply) rightapplyReferenceOperator(stateRef, ctrls, states, targs, matrixRef);
+        if constexpr (Apply == leftapply)     leftapplyReferenceOperator(    stateRef, ctrls, states, targs, matrixRef);
+        if constexpr (Apply == rightapply) rightapplyReferenceOperator(stateRef, ctrls, states, targs, matrixRef);
     };
 
     // report operation's input parameters if any subsequent test fails
@@ -761,7 +761,7 @@ void testOperationCorrectness(auto operation, auto matrixRefGen) {
 
     // test API operation on all available deployment combinations (e.g. OMP, MPI, MPI+GPU, etc),
     // though the postMultiply*() functions do not accept statevectors
-    if constexpr (Apply != postmultiply) {
+    if constexpr (Apply != rightapply) {
         SECTION( LABEL_STATEVEC ) { 
             TEST_ON_CACHED_QUREGS(statevecQuregs, statevecRef, testFunc); 
         }
@@ -1125,7 +1125,7 @@ void testOperationValidation(auto operation) {
     SECTION( "qureg type" ) {
 
         // only postMultiply*() functions discriminate Qureg
-        if (Apply != postmultiply)
+        if (Apply != rightapply)
             return;
 
         // use any statevector
@@ -1866,27 +1866,27 @@ TEST_CASE( "applyNonUnitaryPauliGadget", TEST_CATEGORY_OPS ) {
  */
 
 
-TEST_CASE( "leftapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,multiply>(leftapplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "leftapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(leftapplyPauliX, FixedMatrices::X); }
-TEST_CASE( "leftapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(leftapplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "leftapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(leftapplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "leftapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,multiply>(leftapplyPauliStr,    nullptr); }
-TEST_CASE( "leftapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,multiply>(leftapplyPauliGadget, nullptr); }
-TEST_CASE( "leftapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,multiply>(leftapplyCompMatr1,   nullptr); }
-TEST_CASE( "leftapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,multiply>(leftapplyCompMatr2,   nullptr); }
-TEST_CASE( "leftapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(leftapplyDiagMatr1,   nullptr); }
-TEST_CASE( "leftapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(leftapplyDiagMatr2,   nullptr); }
+TEST_CASE( "leftapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,leftapply>(leftapplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "leftapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,leftapply>(leftapplyPauliX, FixedMatrices::X); }
+TEST_CASE( "leftapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,leftapply>(leftapplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "leftapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,leftapply>(leftapplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "leftapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,leftapply>(leftapplyPauliStr,    nullptr); }
+TEST_CASE( "leftapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,leftapply>(leftapplyPauliGadget, nullptr); }
+TEST_CASE( "leftapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,leftapply>(leftapplyCompMatr1,   nullptr); }
+TEST_CASE( "leftapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,leftapply>(leftapplyCompMatr2,   nullptr); }
+TEST_CASE( "leftapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,leftapply>(leftapplyDiagMatr1,   nullptr); }
+TEST_CASE( "leftapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,leftapply>(leftapplyDiagMatr2,   nullptr); }
 
-TEST_CASE( "rightapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(rightapplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "rightapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(rightapplyPauliX, FixedMatrices::X); }
-TEST_CASE( "rightapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(rightapplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "rightapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(rightapplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "rightapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,postmultiply>(rightapplyPauliStr,    nullptr); }
-TEST_CASE( "rightapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,postmultiply>(rightapplyPauliGadget, nullptr); }
-TEST_CASE( "rightapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,postmultiply>(rightapplyCompMatr1,   nullptr); }
-TEST_CASE( "rightapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,postmultiply>(rightapplyCompMatr2,   nullptr); }
-TEST_CASE( "rightapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,postmultiply>(rightapplyDiagMatr1,   nullptr); }
-TEST_CASE( "rightapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,postmultiply>(rightapplyDiagMatr2,   nullptr); }
+TEST_CASE( "rightapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,rightapply>(rightapplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "rightapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,rightapply>(rightapplyPauliX, FixedMatrices::X); }
+TEST_CASE( "rightapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,rightapply>(rightapplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "rightapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,rightapply>(rightapplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "rightapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,rightapply>(rightapplyPauliStr,    nullptr); }
+TEST_CASE( "rightapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,rightapply>(rightapplyPauliGadget, nullptr); }
+TEST_CASE( "rightapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,rightapply>(rightapplyCompMatr1,   nullptr); }
+TEST_CASE( "rightapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,rightapply>(rightapplyCompMatr2,   nullptr); }
+TEST_CASE( "rightapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,rightapply>(rightapplyDiagMatr1,   nullptr); }
+TEST_CASE( "rightapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,rightapply>(rightapplyDiagMatr2,   nullptr); }
 
 
 /*
@@ -1898,53 +1898,53 @@ TEST_CASE( "rightapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zer
 
 TEST_CASE( "leftapplyCompMatr",  TEST_CATEGORY_MULT ) { 
     auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(leftapplyCompMatr);
-    testOperation<zero,any,compmatr,multiply>(func, nullptr); 
+    testOperation<zero,any,compmatr,leftapply>(func, nullptr); 
 }
 
 TEST_CASE( "leftapplyDiagMatr",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(leftapplyDiagMatr);
-    testOperation<zero,any,diagmatr,multiply>(func, nullptr);
+    testOperation<zero,any,diagmatr,leftapply>(func, nullptr);
 }
 
 TEST_CASE( "leftapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(leftapplyDiagMatrPower);
-    testOperation<zero,any,diagpower,multiply>(func, nullptr);
+    testOperation<zero,any,diagpower,leftapply>(func, nullptr);
 }
 
 TEST_CASE( "leftapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int)>(leftapplyMultiQubitNot);
-    testOperation<zero,any,none,multiply>(func, VariableSizeMatrices::X);
+    testOperation<zero,any,none,leftapply>(func, VariableSizeMatrices::X);
 }
 
 TEST_CASE( "leftapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(leftapplyPhaseGadget);
-    testOperation<zero,any,scalar,multiply>(func, VariableSizeParameterisedMatrices::Z);
+    testOperation<zero,any,scalar,leftapply>(func, VariableSizeParameterisedMatrices::Z);
 }
 
 
 TEST_CASE( "rightapplyCompMatr",  TEST_CATEGORY_MULT ) { 
     auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(rightapplyCompMatr);
-    testOperation<zero,any,compmatr,postmultiply>(func, nullptr); 
+    testOperation<zero,any,compmatr,rightapply>(func, nullptr); 
 }
 
 TEST_CASE( "rightapplyDiagMatr",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(rightapplyDiagMatr);
-    testOperation<zero,any,diagmatr,postmultiply>(func, nullptr);
+    testOperation<zero,any,diagmatr,rightapply>(func, nullptr);
 }
 
 TEST_CASE( "rightapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(rightapplyDiagMatrPower);
-    testOperation<zero,any,diagpower,postmultiply>(func, nullptr);
+    testOperation<zero,any,diagpower,rightapply>(func, nullptr);
 }
 
 TEST_CASE( "rightapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int)>(rightapplyMultiQubitNot);
-    testOperation<zero,any,none,postmultiply>(func, VariableSizeMatrices::X);
+    testOperation<zero,any,none,rightapply>(func, VariableSizeMatrices::X);
 }
 
 TEST_CASE( "rightapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
     auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(rightapplyPhaseGadget);
-    testOperation<zero,any,scalar,postmultiply>(func, VariableSizeParameterisedMatrices::Z);
+    testOperation<zero,any,scalar,rightapply>(func, VariableSizeParameterisedMatrices::Z);
 }
 
 

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1866,16 +1866,16 @@ TEST_CASE( "applyNonUnitaryPauliGadget", TEST_CATEGORY_OPS ) {
  */
 
 
-TEST_CASE( "multiplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,multiply>(multiplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "multiplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(multiplyPauliX, FixedMatrices::X); }
-TEST_CASE( "multiplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(multiplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "multiplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(multiplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "multiplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,multiply>(multiplyPauliStr,    nullptr); }
-TEST_CASE( "multiplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,multiply>(multiplyPauliGadget, nullptr); }
-TEST_CASE( "multiplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,multiply>(multiplyCompMatr1,   nullptr); }
-TEST_CASE( "multiplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,multiply>(multiplyCompMatr2,   nullptr); }
-TEST_CASE( "multiplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(multiplyDiagMatr1,   nullptr); }
-TEST_CASE( "multiplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(multiplyDiagMatr2,   nullptr); }
+TEST_CASE( "preapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,multiply>(preapplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "preapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(preapplyPauliX, FixedMatrices::X); }
+TEST_CASE( "preapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(preapplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "preapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(preapplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "preapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,multiply>(preapplyPauliStr,    nullptr); }
+TEST_CASE( "preapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,multiply>(preapplyPauliGadget, nullptr); }
+TEST_CASE( "preapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,multiply>(preapplyCompMatr1,   nullptr); }
+TEST_CASE( "preapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,multiply>(preapplyCompMatr2,   nullptr); }
+TEST_CASE( "preapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(preapplyDiagMatr1,   nullptr); }
+TEST_CASE( "preapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(preapplyDiagMatr2,   nullptr); }
 
 TEST_CASE( "postMultiplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(postMultiplySwap, FixedMatrices::SWAP); }
 TEST_CASE( "postMultiplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliX, FixedMatrices::X); }
@@ -1896,28 +1896,28 @@ TEST_CASE( "postMultiplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<z
  */
 
 
-TEST_CASE( "multiplyCompMatr",  TEST_CATEGORY_MULT ) { 
-    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(multiplyCompMatr);
+TEST_CASE( "preapplyCompMatr",  TEST_CATEGORY_MULT ) { 
+    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(preapplyCompMatr);
     testOperation<zero,any,compmatr,multiply>(func, nullptr); 
 }
 
-TEST_CASE( "multiplyDiagMatr",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(multiplyDiagMatr);
+TEST_CASE( "preapplyDiagMatr",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(preapplyDiagMatr);
     testOperation<zero,any,diagmatr,multiply>(func, nullptr);
 }
 
-TEST_CASE( "multiplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(multiplyDiagMatrPower);
+TEST_CASE( "preapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(preapplyDiagMatrPower);
     testOperation<zero,any,diagpower,multiply>(func, nullptr);
 }
 
-TEST_CASE( "multiplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int)>(multiplyMultiQubitNot);
+TEST_CASE( "preapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int)>(preapplyMultiQubitNot);
     testOperation<zero,any,none,multiply>(func, VariableSizeMatrices::X);
 }
 
-TEST_CASE( "multiplyPhaseGadget",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(multiplyPhaseGadget);
+TEST_CASE( "preapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(preapplyPhaseGadget);
     testOperation<zero,any,scalar,multiply>(func, VariableSizeParameterisedMatrices::Z);
 }
 
@@ -1953,7 +1953,7 @@ TEST_CASE( "postMultiplyPhaseGadget",  TEST_CATEGORY_MULT ) {
  */
 
 
-TEST_CASE( "multiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "preapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -1962,7 +1962,7 @@ TEST_CASE( "multiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TA
     SECTION( LABEL_CORRECTNESS ) {
 
         qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        auto apiFunc = multiplyFullStateDiagMatr;
+        auto apiFunc = preapplyFullStateDiagMatr;
 
         GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
 
@@ -2010,7 +2010,7 @@ TEST_CASE( "postMultiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLO
 }
 
 
-TEST_CASE( "multiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "preapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -2022,7 +2022,7 @@ TEST_CASE( "multiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPL
         qcomp exponent = getRandomComplex();
 
         auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
-            return multiplyFullStateDiagMatrPower(qureg, matr, exponent);
+            return preapplyFullStateDiagMatrPower(qureg, matr, exponent);
         };
 
         CAPTURE( exponent );
@@ -2088,7 +2088,7 @@ TEST_CASE( "postMultiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_
 }
 
 
-TEST_CASE( "multiplyQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "preapplyQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2101,7 +2101,7 @@ TEST_CASE( "multiplyQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(outcome);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            multiplyQubitProjector(qureg, target, outcome);
+            preapplyQubitProjector(qureg, target, outcome);
             multiplyReferenceOperator(ref, {target}, projector);
         };
 
@@ -2139,7 +2139,7 @@ TEST_CASE( "postMultiplyQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "multiplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "preapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2152,7 +2152,7 @@ TEST_CASE( "multiplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(targets, outcomes, numQubits);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            multiplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
+            preapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
             multiplyReferenceOperator(ref, projector);
         };
 
@@ -2190,7 +2190,7 @@ TEST_CASE( "postMultiplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "multiplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "preapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2205,7 +2205,7 @@ TEST_CASE( "multiplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
             // must use (and ergo make) an identically-deployed workspace
             Qureg workspace = createCloneQureg(qureg);
-            multiplyPauliStrSum(qureg, sum, workspace);
+            preapplyPauliStrSum(qureg, sum, workspace);
             destroyQureg(workspace);
 
             ref = getMatrix(sum, numQubits) * ref;

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1866,16 +1866,16 @@ TEST_CASE( "applyNonUnitaryPauliGadget", TEST_CATEGORY_OPS ) {
  */
 
 
-TEST_CASE( "preapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,multiply>(preapplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "preapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(preapplyPauliX, FixedMatrices::X); }
-TEST_CASE( "preapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(preapplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "preapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(preapplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "preapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,multiply>(preapplyPauliStr,    nullptr); }
-TEST_CASE( "preapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,multiply>(preapplyPauliGadget, nullptr); }
-TEST_CASE( "preapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,multiply>(preapplyCompMatr1,   nullptr); }
-TEST_CASE( "preapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,multiply>(preapplyCompMatr2,   nullptr); }
-TEST_CASE( "preapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(preapplyDiagMatr1,   nullptr); }
-TEST_CASE( "preapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(preapplyDiagMatr2,   nullptr); }
+TEST_CASE( "leftapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,multiply>(leftapplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "leftapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(leftapplyPauliX, FixedMatrices::X); }
+TEST_CASE( "leftapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(leftapplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "leftapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,multiply>(leftapplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "leftapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,multiply>(leftapplyPauliStr,    nullptr); }
+TEST_CASE( "leftapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,multiply>(leftapplyPauliGadget, nullptr); }
+TEST_CASE( "leftapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,multiply>(leftapplyCompMatr1,   nullptr); }
+TEST_CASE( "leftapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,multiply>(leftapplyCompMatr2,   nullptr); }
+TEST_CASE( "leftapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(leftapplyDiagMatr1,   nullptr); }
+TEST_CASE( "leftapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(leftapplyDiagMatr2,   nullptr); }
 
 TEST_CASE( "postapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(postapplySwap, FixedMatrices::SWAP); }
 TEST_CASE( "postapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliX, FixedMatrices::X); }
@@ -1896,28 +1896,28 @@ TEST_CASE( "postapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero
  */
 
 
-TEST_CASE( "preapplyCompMatr",  TEST_CATEGORY_MULT ) { 
-    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(preapplyCompMatr);
+TEST_CASE( "leftapplyCompMatr",  TEST_CATEGORY_MULT ) { 
+    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(leftapplyCompMatr);
     testOperation<zero,any,compmatr,multiply>(func, nullptr); 
 }
 
-TEST_CASE( "preapplyDiagMatr",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(preapplyDiagMatr);
+TEST_CASE( "leftapplyDiagMatr",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(leftapplyDiagMatr);
     testOperation<zero,any,diagmatr,multiply>(func, nullptr);
 }
 
-TEST_CASE( "preapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(preapplyDiagMatrPower);
+TEST_CASE( "leftapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(leftapplyDiagMatrPower);
     testOperation<zero,any,diagpower,multiply>(func, nullptr);
 }
 
-TEST_CASE( "preapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int)>(preapplyMultiQubitNot);
+TEST_CASE( "leftapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int)>(leftapplyMultiQubitNot);
     testOperation<zero,any,none,multiply>(func, VariableSizeMatrices::X);
 }
 
-TEST_CASE( "preapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(preapplyPhaseGadget);
+TEST_CASE( "leftapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(leftapplyPhaseGadget);
     testOperation<zero,any,scalar,multiply>(func, VariableSizeParameterisedMatrices::Z);
 }
 
@@ -1953,7 +1953,7 @@ TEST_CASE( "postapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
  */
 
 
-TEST_CASE( "preapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "leftapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -1962,7 +1962,7 @@ TEST_CASE( "preapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TA
     SECTION( LABEL_CORRECTNESS ) {
 
         qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        auto apiFunc = preapplyFullStateDiagMatr;
+        auto apiFunc = leftapplyFullStateDiagMatr;
 
         GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
 
@@ -2010,7 +2010,7 @@ TEST_CASE( "postapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_T
 }
 
 
-TEST_CASE( "preapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "leftapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -2022,7 +2022,7 @@ TEST_CASE( "preapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPL
         qcomp exponent = getRandomComplex();
 
         auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
-            return preapplyFullStateDiagMatrPower(qureg, matr, exponent);
+            return leftapplyFullStateDiagMatrPower(qureg, matr, exponent);
         };
 
         CAPTURE( exponent );
@@ -2088,7 +2088,7 @@ TEST_CASE( "postapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEP
 }
 
 
-TEST_CASE( "preapplyQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "leftapplyQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2101,7 +2101,7 @@ TEST_CASE( "preapplyQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(outcome);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            preapplyQubitProjector(qureg, target, outcome);
+            leftapplyQubitProjector(qureg, target, outcome);
             multiplyReferenceOperator(ref, {target}, projector);
         };
 
@@ -2139,7 +2139,7 @@ TEST_CASE( "postapplyQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "preapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "leftapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2152,7 +2152,7 @@ TEST_CASE( "preapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(targets, outcomes, numQubits);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            preapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
+            leftapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
             multiplyReferenceOperator(ref, projector);
         };
 
@@ -2190,7 +2190,7 @@ TEST_CASE( "postapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "preapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "leftapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2205,7 +2205,7 @@ TEST_CASE( "preapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
             // must use (and ergo make) an identically-deployed workspace
             Qureg workspace = createCloneQureg(qureg);
-            preapplyPauliStrSum(qureg, sum, workspace);
+            leftapplyPauliStrSum(qureg, sum, workspace);
             destroyQureg(workspace);
 
             ref = getMatrix(sum, numQubits) * ref;

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1877,16 +1877,16 @@ TEST_CASE( "leftapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero
 TEST_CASE( "leftapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(leftapplyDiagMatr1,   nullptr); }
 TEST_CASE( "leftapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(leftapplyDiagMatr2,   nullptr); }
 
-TEST_CASE( "postapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(postapplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "postapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliX, FixedMatrices::X); }
-TEST_CASE( "postapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "postapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "postapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,postmultiply>(postapplyPauliStr,    nullptr); }
-TEST_CASE( "postapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,postmultiply>(postapplyPauliGadget, nullptr); }
-TEST_CASE( "postapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,postmultiply>(postapplyCompMatr1,   nullptr); }
-TEST_CASE( "postapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,postmultiply>(postapplyCompMatr2,   nullptr); }
-TEST_CASE( "postapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,postmultiply>(postapplyDiagMatr1,   nullptr); }
-TEST_CASE( "postapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,postmultiply>(postapplyDiagMatr2,   nullptr); }
+TEST_CASE( "rightapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(rightapplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "rightapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(rightapplyPauliX, FixedMatrices::X); }
+TEST_CASE( "rightapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(rightapplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "rightapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(rightapplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "rightapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,postmultiply>(rightapplyPauliStr,    nullptr); }
+TEST_CASE( "rightapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,postmultiply>(rightapplyPauliGadget, nullptr); }
+TEST_CASE( "rightapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,postmultiply>(rightapplyCompMatr1,   nullptr); }
+TEST_CASE( "rightapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,postmultiply>(rightapplyCompMatr2,   nullptr); }
+TEST_CASE( "rightapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,postmultiply>(rightapplyDiagMatr1,   nullptr); }
+TEST_CASE( "rightapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,postmultiply>(rightapplyDiagMatr2,   nullptr); }
 
 
 /*
@@ -1922,28 +1922,28 @@ TEST_CASE( "leftapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
 }
 
 
-TEST_CASE( "postapplyCompMatr",  TEST_CATEGORY_MULT ) { 
-    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(postapplyCompMatr);
+TEST_CASE( "rightapplyCompMatr",  TEST_CATEGORY_MULT ) { 
+    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(rightapplyCompMatr);
     testOperation<zero,any,compmatr,postmultiply>(func, nullptr); 
 }
 
-TEST_CASE( "postapplyDiagMatr",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(postapplyDiagMatr);
+TEST_CASE( "rightapplyDiagMatr",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(rightapplyDiagMatr);
     testOperation<zero,any,diagmatr,postmultiply>(func, nullptr);
 }
 
-TEST_CASE( "postapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(postapplyDiagMatrPower);
+TEST_CASE( "rightapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(rightapplyDiagMatrPower);
     testOperation<zero,any,diagpower,postmultiply>(func, nullptr);
 }
 
-TEST_CASE( "postapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int)>(postapplyMultiQubitNot);
+TEST_CASE( "rightapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int)>(rightapplyMultiQubitNot);
     testOperation<zero,any,none,postmultiply>(func, VariableSizeMatrices::X);
 }
 
-TEST_CASE( "postapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(postapplyPhaseGadget);
+TEST_CASE( "rightapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(rightapplyPhaseGadget);
     testOperation<zero,any,scalar,postmultiply>(func, VariableSizeParameterisedMatrices::Z);
 }
 
@@ -1985,7 +1985,7 @@ TEST_CASE( "leftapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_T
 }
 
 
-TEST_CASE( "postapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "rightapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -1994,7 +1994,7 @@ TEST_CASE( "postapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_T
     SECTION( LABEL_CORRECTNESS ) {
 
         qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        auto apiFunc = postapplyFullStateDiagMatr;
+        auto apiFunc = rightapplyFullStateDiagMatr;
 
         GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
 
@@ -2054,7 +2054,7 @@ TEST_CASE( "leftapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEP
 }
 
 
-TEST_CASE( "postapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "rightapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -2066,7 +2066,7 @@ TEST_CASE( "postapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEP
         qcomp exponent = getRandomComplex();
 
         auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
-            return postapplyFullStateDiagMatrPower(qureg, matr, exponent);
+            return rightapplyFullStateDiagMatrPower(qureg, matr, exponent);
         };
 
         CAPTURE( exponent );
@@ -2114,7 +2114,7 @@ TEST_CASE( "leftapplyQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "postapplyQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "rightapplyQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2127,7 +2127,7 @@ TEST_CASE( "postapplyQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(outcome);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            postapplyQubitProjector(qureg, target, outcome);
+            rightapplyQubitProjector(qureg, target, outcome);
             postMultiplyReferenceOperator(ref, {target}, projector);
         };
 
@@ -2165,7 +2165,7 @@ TEST_CASE( "leftapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "postapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "rightapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2178,7 +2178,7 @@ TEST_CASE( "postapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(targets, outcomes, numQubits);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            postapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
+            rightapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
             postMultiplyReferenceOperator(ref, projector);
         };
 
@@ -2220,7 +2220,7 @@ TEST_CASE( "leftapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 }
 
 
-TEST_CASE( "postapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "rightapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2235,7 +2235,7 @@ TEST_CASE( "postapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
             // must use (and ergo make) an identically-deployed workspace
             Qureg workspace = createCloneQureg(qureg);
-            postapplyPauliStrSum(qureg, sum, workspace);
+            rightapplyPauliStrSum(qureg, sum, workspace);
             destroyQureg(workspace);
 
             ref = ref * getMatrix(sum, numQubits);

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -1877,16 +1877,16 @@ TEST_CASE( "preapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,
 TEST_CASE( "preapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,multiply>(preapplyDiagMatr1,   nullptr); }
 TEST_CASE( "preapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,multiply>(preapplyDiagMatr2,   nullptr); }
 
-TEST_CASE( "postMultiplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(postMultiplySwap, FixedMatrices::SWAP); }
-TEST_CASE( "postMultiplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliX, FixedMatrices::X); }
-TEST_CASE( "postMultiplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliY, FixedMatrices::Y); }
-TEST_CASE( "postMultiplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postMultiplyPauliZ, FixedMatrices::Z); }
-TEST_CASE( "postMultiplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,postmultiply>(postMultiplyPauliStr,    nullptr); }
-TEST_CASE( "postMultiplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,postmultiply>(postMultiplyPauliGadget, nullptr); }
-TEST_CASE( "postMultiplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,postmultiply>(postMultiplyCompMatr1,   nullptr); }
-TEST_CASE( "postMultiplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,postmultiply>(postMultiplyCompMatr2,   nullptr); }
-TEST_CASE( "postMultiplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,postmultiply>(postMultiplyDiagMatr1,   nullptr); }
-TEST_CASE( "postMultiplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,postmultiply>(postMultiplyDiagMatr2,   nullptr); }
+TEST_CASE( "postapplySwap",            TEST_CATEGORY_MULT ) { testOperation<zero,two,none,postmultiply>(postapplySwap, FixedMatrices::SWAP); }
+TEST_CASE( "postapplyPauliX",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliX, FixedMatrices::X); }
+TEST_CASE( "postapplyPauliY",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliY, FixedMatrices::Y); }
+TEST_CASE( "postapplyPauliZ",          TEST_CATEGORY_MULT ) { testOperation<zero,one,none,postmultiply>(postapplyPauliZ, FixedMatrices::Z); }
+TEST_CASE( "postapplyPauliStr",        TEST_CATEGORY_MULT ) { testOperation<zero,any,paulistr,postmultiply>(postapplyPauliStr,    nullptr); }
+TEST_CASE( "postapplyPauliGadget",     TEST_CATEGORY_MULT ) { testOperation<zero,any,pauligad,postmultiply>(postapplyPauliGadget, nullptr); }
+TEST_CASE( "postapplyCompMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,compmatr,postmultiply>(postapplyCompMatr1,   nullptr); }
+TEST_CASE( "postapplyCompMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,compmatr,postmultiply>(postapplyCompMatr2,   nullptr); }
+TEST_CASE( "postapplyDiagMatr1",       TEST_CATEGORY_MULT ) { testOperation<zero,one,diagmatr,postmultiply>(postapplyDiagMatr1,   nullptr); }
+TEST_CASE( "postapplyDiagMatr2",       TEST_CATEGORY_MULT ) { testOperation<zero,two,diagmatr,postmultiply>(postapplyDiagMatr2,   nullptr); }
 
 
 /*
@@ -1922,28 +1922,28 @@ TEST_CASE( "preapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
 }
 
 
-TEST_CASE( "postMultiplyCompMatr",  TEST_CATEGORY_MULT ) { 
-    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(postMultiplyCompMatr);
+TEST_CASE( "postapplyCompMatr",  TEST_CATEGORY_MULT ) { 
+    auto func = static_cast<void(*)(Qureg, int*, int, CompMatr)>(postapplyCompMatr);
     testOperation<zero,any,compmatr,postmultiply>(func, nullptr); 
 }
 
-TEST_CASE( "postMultiplyDiagMatr",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(postMultiplyDiagMatr);
+TEST_CASE( "postapplyDiagMatr",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr)>(postapplyDiagMatr);
     testOperation<zero,any,diagmatr,postmultiply>(func, nullptr);
 }
 
-TEST_CASE( "postMultiplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(postMultiplyDiagMatrPower);
+TEST_CASE( "postapplyDiagMatrPower",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, DiagMatr, qcomp)>(postapplyDiagMatrPower);
     testOperation<zero,any,diagpower,postmultiply>(func, nullptr);
 }
 
-TEST_CASE( "postMultiplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int)>(postMultiplyMultiQubitNot);
+TEST_CASE( "postapplyMultiQubitNot",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int)>(postapplyMultiQubitNot);
     testOperation<zero,any,none,postmultiply>(func, VariableSizeMatrices::X);
 }
 
-TEST_CASE( "postMultiplyPhaseGadget",  TEST_CATEGORY_MULT ) {
-    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(postMultiplyPhaseGadget);
+TEST_CASE( "postapplyPhaseGadget",  TEST_CATEGORY_MULT ) {
+    auto func = static_cast<void(*)(Qureg, int*, int, qreal)>(postapplyPhaseGadget);
     testOperation<zero,any,scalar,postmultiply>(func, VariableSizeParameterisedMatrices::Z);
 }
 
@@ -1985,7 +1985,7 @@ TEST_CASE( "preapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TA
 }
 
 
-TEST_CASE( "postMultiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "postapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -1994,7 +1994,7 @@ TEST_CASE( "postMultiplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLO
     SECTION( LABEL_CORRECTNESS ) {
 
         qmatrix refMatr = getRandomDiagonalMatrix(getPow2(numQubits));
-        auto apiFunc = postMultiplyFullStateDiagMatr;
+        auto apiFunc = postapplyFullStateDiagMatr;
 
         GENERATE( range(0, getNumTestedMixedDeploymentRepetitions()) );
 
@@ -2054,7 +2054,7 @@ TEST_CASE( "preapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPL
 }
 
 
-TEST_CASE( "postMultiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "postapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, cachedSV, cachedDM, refSV, refDM );
 
@@ -2066,7 +2066,7 @@ TEST_CASE( "postMultiplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_
         qcomp exponent = getRandomComplex();
 
         auto apiFunc = [&](Qureg qureg, FullStateDiagMatr matr) { 
-            return postMultiplyFullStateDiagMatrPower(qureg, matr, exponent);
+            return postapplyFullStateDiagMatrPower(qureg, matr, exponent);
         };
 
         CAPTURE( exponent );
@@ -2114,7 +2114,7 @@ TEST_CASE( "preapplyQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "postMultiplyQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "postapplyQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2127,7 +2127,7 @@ TEST_CASE( "postMultiplyQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(outcome);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            postMultiplyQubitProjector(qureg, target, outcome);
+            postapplyQubitProjector(qureg, target, outcome);
             postMultiplyReferenceOperator(ref, {target}, projector);
         };
 
@@ -2165,7 +2165,7 @@ TEST_CASE( "preapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 }
 
 
-TEST_CASE( "postMultiplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
+TEST_CASE( "postapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2178,7 +2178,7 @@ TEST_CASE( "postMultiplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
         qmatrix projector = getProjector(targets, outcomes, numQubits);
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
-            postMultiplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
+            postapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
             postMultiplyReferenceOperator(ref, projector);
         };
 
@@ -2220,7 +2220,7 @@ TEST_CASE( "preapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 }
 
 
-TEST_CASE( "postMultiplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
+TEST_CASE( "postapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) {
 
     PREPARE_TEST( numQubits, statevecQuregs, densmatrQuregs, statevecRef, densmatrRef );
 
@@ -2235,7 +2235,7 @@ TEST_CASE( "postMultiplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG 
 
             // must use (and ergo make) an identically-deployed workspace
             Qureg workspace = createCloneQureg(qureg);
-            postMultiplyPauliStrSum(qureg, sum, workspace);
+            postapplyPauliStrSum(qureg, sum, workspace);
             destroyQureg(workspace);
 
             ref = ref * getMatrix(sum, numQubits);

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -752,8 +752,8 @@ void testOperationCorrectness(auto operation, auto matrixRefGen) {
 
         // update reference state (ctrls & states happen to only ever be used by apply)
         if constexpr (Apply == apply)        applyReferenceOperator(       stateRef, ctrls, states, targs, matrixRef);
-        if constexpr (Apply == multiply)     multiplyReferenceOperator(    stateRef, ctrls, states, targs, matrixRef);
-        if constexpr (Apply == postmultiply) postMultiplyReferenceOperator(stateRef, ctrls, states, targs, matrixRef);
+        if constexpr (Apply == multiply)     leftapplyReferenceOperator(    stateRef, ctrls, states, targs, matrixRef);
+        if constexpr (Apply == postmultiply) rightapplyReferenceOperator(stateRef, ctrls, states, targs, matrixRef);
     };
 
     // report operation's input parameters if any subsequent test fails
@@ -1968,14 +1968,14 @@ TEST_CASE( "leftapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_T
 
         SECTION( LABEL_STATEVEC ) {
 
-            auto refFunc = [&] (qvector& state, qmatrix matr) { multiplyReferenceOperator(state, matr); };
+            auto refFunc = [&] (qvector& state, qmatrix matr) { leftapplyReferenceOperator(state, matr); };
 
             TEST_ON_CACHED_QUREG_AND_MATRIX( cachedSV, cachedMatrs, apiFunc, refSV, refMatr, refFunc);
         }
 
         SECTION( LABEL_DENSMATR ) {
 
-            auto refFunc = [&] (qmatrix& state, qmatrix matr) { multiplyReferenceOperator(state, matr); };
+            auto refFunc = [&] (qmatrix& state, qmatrix matr) { leftapplyReferenceOperator(state, matr); };
 
             TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
         }
@@ -2000,7 +2000,7 @@ TEST_CASE( "rightapplyFullStateDiagMatr", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_
 
         SECTION( LABEL_DENSMATR ) {
 
-            auto refFunc = [&] (qmatrix& state, qmatrix matr) { postMultiplyReferenceOperator(state, matr); };
+            auto refFunc = [&] (qmatrix& state, qmatrix matr) { rightapplyReferenceOperator(state, matr); };
 
             TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
         }
@@ -2033,7 +2033,7 @@ TEST_CASE( "leftapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEP
 
             auto refFunc = [&] (qvector& state, qmatrix matr) { 
                 matr = getPowerOfDiagonalMatrix(matr, exponent);
-                multiplyReferenceOperator(state, matr);
+                leftapplyReferenceOperator(state, matr);
             };
 
             TEST_ON_CACHED_QUREG_AND_MATRIX( cachedSV, cachedMatrs, apiFunc, refSV, refMatr, refFunc);
@@ -2043,7 +2043,7 @@ TEST_CASE( "leftapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DEP
 
             auto refFunc = [&] (qmatrix& state, qmatrix matr) { 
                 matr = getPowerOfDiagonalMatrix(matr, exponent);
-                multiplyReferenceOperator(state, matr);
+                leftapplyReferenceOperator(state, matr);
             };
 
             TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
@@ -2077,7 +2077,7 @@ TEST_CASE( "rightapplyFullStateDiagMatrPower", TEST_CATEGORY_MULT LABEL_MIXED_DE
 
             auto refFunc = [&] (qmatrix& state, qmatrix matr) { 
                 matr = getPowerOfDiagonalMatrix(matr, exponent);
-                postMultiplyReferenceOperator(state, matr);
+                rightapplyReferenceOperator(state, matr);
             };
 
             TEST_ON_CACHED_QUREG_AND_MATRIX( cachedDM, cachedMatrs, apiFunc, refDM, refMatr, refFunc);
@@ -2102,7 +2102,7 @@ TEST_CASE( "leftapplyQubitProjector", TEST_CATEGORY_OPS ) {
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
             leftapplyQubitProjector(qureg, target, outcome);
-            multiplyReferenceOperator(ref, {target}, projector);
+            leftapplyReferenceOperator(ref, {target}, projector);
         };
 
         CAPTURE( target, outcome );
@@ -2128,7 +2128,7 @@ TEST_CASE( "rightapplyQubitProjector", TEST_CATEGORY_OPS ) {
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
             rightapplyQubitProjector(qureg, target, outcome);
-            postMultiplyReferenceOperator(ref, {target}, projector);
+            rightapplyReferenceOperator(ref, {target}, projector);
         };
 
         CAPTURE( target, outcome );
@@ -2153,7 +2153,7 @@ TEST_CASE( "leftapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
             leftapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
-            multiplyReferenceOperator(ref, projector);
+            leftapplyReferenceOperator(ref, projector);
         };
 
         CAPTURE( targets, outcomes );
@@ -2179,7 +2179,7 @@ TEST_CASE( "rightapplyMultiQubitProjector", TEST_CATEGORY_OPS ) {
 
         auto testFunc = [&](Qureg qureg, auto& ref) {
             rightapplyMultiQubitProjector(qureg, targets.data(), outcomes.data(), numTargs);
-            postMultiplyReferenceOperator(ref, projector);
+            rightapplyReferenceOperator(ref, projector);
         };
 
         CAPTURE( targets, outcomes );

--- a/tests/utils/evolve.cpp
+++ b/tests/utils/evolve.cpp
@@ -166,21 +166,21 @@ void applyReferenceOperator(qmatrix& state, qmatrix matrix) {
     state = matrix * state * getConjugateTranspose(matrix);
 }
 
-void multiplyReferenceOperator(qvector& state, qmatrix matrix) {
+void leftapplyReferenceOperator(qvector& state, qmatrix matrix) {
     DEMAND( state.size() == matrix.size() );
 
     // for statevectors, multiplying is the same as applying
     applyReferenceOperator(state, matrix);
 }
 
-void multiplyReferenceOperator(qmatrix& state, qmatrix matrix) {
+void leftapplyReferenceOperator(qmatrix& state, qmatrix matrix) {
     DEMAND( state.size() == matrix.size() );
 
     // we left-multiply upon density matrices only
     state = matrix * state;
 }
 
-void postMultiplyReferenceOperator(qmatrix& state, qmatrix matrix) {
+void rightapplyReferenceOperator(qmatrix& state, qmatrix matrix) {
     DEMAND( state.size() == matrix.size() );
 
     // we right-multiply upon density matrices only
@@ -202,21 +202,21 @@ void applyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> ctrlS
     applyReferenceOperator(state, fullOp);
 }
 
-void multiplyReferenceOperator(qvector& state, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qmatrix matrix) {
+void leftapplyReferenceOperator(qvector& state, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qmatrix matrix) {
     
     applyReferenceOperator(state, ctrls, ctrlStates, targs, matrix);
 }
 
-void multiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qmatrix matrix) {
+void leftapplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qmatrix matrix) {
     
     qmatrix left = getFullStateOperator(ctrls, ctrlStates, targs, matrix, getLog2(state.size()));
-    multiplyReferenceOperator(state, left);
+    leftapplyReferenceOperator(state, left);
 }
 
-void postMultiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qmatrix matrix) {
+void rightapplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qmatrix matrix) {
     
     qmatrix left = getFullStateOperator(ctrls, ctrlStates, targs, matrix, getLog2(state.size()));
-    postMultiplyReferenceOperator(state, left);
+    rightapplyReferenceOperator(state, left);
 }
 
 
@@ -230,17 +230,17 @@ void applyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs
     
     applyReferenceOperator(state, ctrls, {}, targs, matrix);
 }
-void multiplyReferenceOperator(qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
+void leftapplyReferenceOperator(qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
     
-    multiplyReferenceOperator(state, ctrls, {}, targs, matrix);
+    leftapplyReferenceOperator(state, ctrls, {}, targs, matrix);
 }
-void multiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
+void leftapplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
     
-    multiplyReferenceOperator(state, ctrls, {}, targs, matrix);
+    leftapplyReferenceOperator(state, ctrls, {}, targs, matrix);
 }
-void postMultiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
+void rightapplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix) {
     
-    postMultiplyReferenceOperator(state, ctrls, {}, targs, matrix);
+    rightapplyReferenceOperator(state, ctrls, {}, targs, matrix);
 }
 
 
@@ -254,17 +254,17 @@ void applyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix) {
 
     applyReferenceOperator(state, {}, {}, targs, matrix);
 }
-void multiplyReferenceOperator(qvector& state, vector<int> targs, qmatrix matrix) {
+void leftapplyReferenceOperator(qvector& state, vector<int> targs, qmatrix matrix) {
 
-    multiplyReferenceOperator(state, {}, {}, targs, matrix);
+    leftapplyReferenceOperator(state, {}, {}, targs, matrix);
 }
-void multiplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix) {
+void leftapplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix) {
 
-    multiplyReferenceOperator(state, {}, {}, targs, matrix);
+    leftapplyReferenceOperator(state, {}, {}, targs, matrix);
 }
-void postMultiplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix) {
+void rightapplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix) {
 
-    postMultiplyReferenceOperator(state, {}, {}, targs, matrix);
+    rightapplyReferenceOperator(state, {}, {}, targs, matrix);
 }
 
 

--- a/tests/utils/evolve.hpp
+++ b/tests/utils/evolve.hpp
@@ -21,29 +21,29 @@
 using std::vector;
 
 
-void applyReferenceOperator(       qvector& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
-void applyReferenceOperator(       qmatrix& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
-void multiplyReferenceOperator(    qvector& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
-void multiplyReferenceOperator(    qmatrix& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
-void postMultiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator     (qvector& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator     (qmatrix& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
+void leftapplyReferenceOperator (qvector& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
+void leftapplyReferenceOperator (qmatrix& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
+void rightapplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> states, vector<int> targs, qmatrix matrix);
 
-void applyReferenceOperator(       qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
-void applyReferenceOperator(       qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
-void multiplyReferenceOperator(    qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
-void multiplyReferenceOperator(    qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
-void postMultiplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator     (qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator     (qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void leftapplyReferenceOperator (qvector& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void leftapplyReferenceOperator (qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
+void rightapplyReferenceOperator(qmatrix& state, vector<int> ctrls, vector<int> targs, qmatrix matrix);
 
-void applyReferenceOperator(       qvector& state, vector<int> targs, qmatrix matrix);
-void applyReferenceOperator(       qmatrix& state, vector<int> targs, qmatrix matrix);
-void multiplyReferenceOperator(    qvector& state, vector<int> targs, qmatrix matrix);
-void multiplyReferenceOperator(    qmatrix& state, vector<int> targs, qmatrix matrix);
-void postMultiplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator     (qvector& state, vector<int> targs, qmatrix matrix);
+void applyReferenceOperator     (qmatrix& state, vector<int> targs, qmatrix matrix);
+void leftapplyReferenceOperator (qvector& state, vector<int> targs, qmatrix matrix);
+void leftapplyReferenceOperator (qmatrix& state, vector<int> targs, qmatrix matrix);
+void rightapplyReferenceOperator(qmatrix& state, vector<int> targs, qmatrix matrix);
 
-void applyReferenceOperator(       qvector& state, qmatrix matrix);
-void applyReferenceOperator(       qmatrix& state, qmatrix matrix);
-void multiplyReferenceOperator(    qvector& state, qmatrix matrix);
-void multiplyReferenceOperator(    qmatrix& state, qmatrix matrix);
-void postMultiplyReferenceOperator(qmatrix& state, qmatrix matrix);
+void applyReferenceOperator     (qvector& state, qmatrix matrix);
+void applyReferenceOperator     (qmatrix& state, qmatrix matrix);
+void leftapplyReferenceOperator (qvector& state, qmatrix matrix);
+void leftapplyReferenceOperator (qmatrix& state, qmatrix matrix);
+void rightapplyReferenceOperator(qmatrix& state, qmatrix matrix);
 
 void applyReferenceOperator(qmatrix& state, vector<int> targs, vector<qmatrix> matrices);
 


### PR DESCRIPTION
This is a premature PR just to run unit-tests while actual renames are deliberated. It is now easier to all-replace `preapply` and `postapply` than it was to replace `multiply` and `postMultiply` (since the former collided with generic usage in comments)