### PR TITLE
removed setQuregToSuperposition()

### DIFF
--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -868,13 +868,15 @@ static inline void _applyGateSubDiagonalOp(Qureg qureg, int* targets, int numTar
 #define setWeightedQureg(f1, q1, f2, q2, fOut, qOut) \
     _WARN_GENERAL_MSG( \
         "The QuEST function 'setWeightedQureg(f1,q1, f2,q2, fOut,qOut)' is deprecated, and replaced with " \
-        "'setQuregToSuperposition(fOut,qOut, f1,q1, f2,q2)' which has been automatically invoked. The new " \
-        "fucntion however accepts only statevectors, not density matrices, so may error at runtime. Beware " \
-        "that the order of the arguments has changed, so that the first supplied Qureg is modified." ) \
-    setQuregToSuperposition( \
-        getQcomp(fOut.real, fOut.imag), qOut, \
-        getQcomp(f1.real, f1.imag), q1, \
-        getQcomp(f2.real, f2.imag), q2)
+        "'setQuregToWeightedSum(qOut, {f1,f2,...}, {q1,q2,..}, len)' which has been automatically invoked. " \
+        "Beware that the order of the arguments has changed, so that the first supplied Qureg is modified." ) \
+    setQuregToWeightedSum(qOut,             \
+        (qcomp[]) {                         \
+            getQcomp(fOut.real, fOut.imag), \
+            getQcomp(f1  .real, f1  .imag), \
+            getQcomp(f2  .real, f2  .imag)  \
+        },                                  \
+        (Qureg[]) {qOut, q1, q2}, 3)
 
 
 

--- a/quest/include/deprecated.h
+++ b/quest/include/deprecated.h
@@ -865,18 +865,23 @@ static inline void _applyGateSubDiagonalOp(Qureg qureg, int* targets, int numTar
     _WARN_FUNC_RENAMED("cloneQureg()", "setQuregToClone()") \
     setQuregToClone(__VA_ARGS__)
 
+
+
+static inline void _setWeightedQureg(qcomp f1, Qureg q1, qcomp f2, Qureg q2, qcomp fOut, Qureg qOut) {
+    qcomp coeffs[] = {fOut, f1, f2};
+    Qureg quregs[] = {qOut, q1, q2};
+    setQuregToWeightedSum(qOut, coeffs, quregs, 3);
+}
+
 #define setWeightedQureg(f1, q1, f2, q2, fOut, qOut) \
     _WARN_GENERAL_MSG( \
         "The QuEST function 'setWeightedQureg(f1,q1, f2,q2, fOut,qOut)' is deprecated, and replaced with " \
         "'setQuregToWeightedSum(qOut, {f1,f2,...}, {q1,q2,..}, len)' which has been automatically invoked. " \
         "Beware that the order of the arguments has changed, so that the first supplied Qureg is modified." ) \
-    setQuregToWeightedSum(qOut,             \
-        (qcomp[]) {                         \
-            getQcomp(fOut.real, fOut.imag), \
-            getQcomp(f1  .real, f1  .imag), \
-            getQcomp(f2  .real, f2  .imag)  \
-        },                                  \
-        (Qureg[]) {qOut, q1, q2}, 3)
+    _setWeightedQureg( \
+        _GET_QCOMP_FROM_COMPLEX_STRUCT(f1) ,q1, \
+        _GET_QCOMP_FROM_COMPLEX_STRUCT(f2) ,q2, \
+        _GET_QCOMP_FROM_COMPLEX_STRUCT(fOut), qOut)
 
 
 

--- a/quest/include/initialisations.h
+++ b/quest/include/initialisations.h
@@ -126,28 +126,6 @@ void setQuregToWeightedSum(Qureg out, qcomp* coeffs, Qureg* in, int numIn);
 void setQuregToMixture(Qureg out, qreal* probs, Qureg* in, int numIn);
 
 
-/** @notyetdoced
- * @notyettested
- * 
- * @formulae
- * 
- * Let @f$ f_{\text{out}} = @f$ @p facOut, @f$ f_1 = @f$ @p fac1 and @f$ f_2 = @f$ @p fac2.
- * Similarly, let @f$ \psi_{\text{out}} = @f$ @p out, @f$ \psi_{1} = @f$ @p qureg1 and @f$ \psi_{2} = @f$ @p qureg2.
- * 
- * This function modifies only @p facOut to become
- * @f[
-     |\psi_{\text{out}}\rangle \; \rightarrow \;
-        f_{\text{out}} |\psi_{\text{out}}\rangle \, + \,
-        f_1 |\psi_1\rangle \, + \,
-        f_2 |\psi_2\rangle.
- * @f]
- *
- * All factors are unconstrained and are permitted to be zero, and the same @p Qureg can be duplicated among
- * all arguments.
- */
-void setQuregToSuperposition(qcomp facOut, Qureg out, qcomp fac1, Qureg qureg1, qcomp fac2, Qureg qureg2);
-
-
 /// @notyetdoced
 /// @notyetvalidated
 qreal setQuregToRenormalized(Qureg qureg);

--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -1670,14 +1670,16 @@ extern "C" {
           - \iu  \sin\left( \frac{\theta}{2} \right) \, \hat{\sigma},
  *   @f]
  *   this function is equivalent to (but much faster than) effecting @f$ \hat{\sigma} @f$
- *   upon a clone which is subsequently superposed.
+ *   upon a clone which is subsequently combined.
  *   ```
      // prepare |temp> = str |qureg>
      Qureg temp = createCloneQureg(qureg);
      applyPauliStr(temp, str);
 
      // set |qureg> = cos(theta/2) |qureg> - i sin(theta/2) str |qureg>
-     setQuregToSuperposition(cos(theta/2), qureg, - 1.0i * sin(theta/2), temp, 0, temp);
+     qcomp coeffs[] = {cos(theta/2), -1i * sin(theta/2)};
+     Qureg quregs[] = {qureg, temp};
+     setQuregToWeightedSum(qureg, coeffs, quregs, 2);
  *   ```
  * - When @p str contains only @f$ \hat{Z} @f$ or @f$ \id @f$ Paulis, this function will
  *   automatically invoke applyPhaseGadget() which leverages an optimised implementation.
@@ -1686,7 +1688,7 @@ extern "C" {
  *   unchanged.
  *   ```
      qcomp factor = cexp(- theta / 2 * 1.i);
-     setQuregToSuperposition(factor, qureg, 0,qureg,0,qureg);
+     setQuregToWeightedSum(qureg, &factor, &qureg, 1);
  *   ```
  * - Passing @p angle=0 is equivalent to effecting the identity, leaving the state unchanged.
  *

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -647,13 +647,13 @@ void leftapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     validate_pauliStrSumTargets(sum, qureg, __func__);
 
     // clone qureg to workspace, set qureg to blank
-    localiser_statevec_setQuregToSuperposition(0, workspace, 1, qureg, 0, qureg);
+    localiser_statevec_setQuregToClone(workspace, qureg);
     localiser_statevec_initUniformState(qureg, 0);
 
     // left-multiply each term in-turn, mixing into output qureg, then undo using idempotency
     for (qindex i=0; i<sum.numTerms; i++) {
         localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
-        localiser_statevec_setQuregToSuperposition(1, qureg, sum.coeffs[i], workspace, 0, workspace);
+        localiser_statevec_setQuregToWeightedSum(qureg, {1, sum.coeffs[i]}, {qureg, workspace});
         localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
     }
 
@@ -669,7 +669,7 @@ void rightapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
     validate_pauliStrSumTargets(sum, qureg, __func__);
 
     // clone qureg to workspace, set qureg to blank
-    localiser_statevec_setQuregToSuperposition(0, workspace, 1, qureg, 0, qureg);
+    localiser_statevec_setQuregToClone(workspace, qureg);
     localiser_statevec_initUniformState(qureg, 0);
 
     // post-multiply each term in-turn, mixing into output qureg, then undo using idempotency
@@ -678,7 +678,7 @@ void rightapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
         qcomp factor = paulis_hasOddNumY(str)? -1 : 1; // undoes transpose
 
         localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
-        localiser_statevec_setQuregToSuperposition(1, qureg, sum.coeffs[i], workspace, 0, workspace);
+        localiser_statevec_setQuregToWeightedSum(qureg, {1, sum.coeffs[i]}, {qureg, workspace});
         localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
     }
 

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -556,15 +556,6 @@ void accel_statevec_setQuregToWeightedSum_sub(Qureg outQureg, vector<qcomp> coef
 }
 
 
-void accel_statevec_setQuregToSuperposition_sub(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2) {
-
-    // consult outQureg's deployment (other quregs should match, though we dangerously do not assert this post-validation)
-    (outQureg.isGpuAccelerated)?
-        gpu_statevec_setQuregToSuperposition_sub(facOut, outQureg, fac1, inQureg1, fac2, inQureg2):
-        cpu_statevec_setQuregToSuperposition_sub(facOut, outQureg, fac1, inQureg1, fac2, inQureg2); 
-}
-
-
 void accel_densmatr_mixQureg_subA(qreal outProb, Qureg out, qreal inProb, Qureg in) {
 
     // quregs are equally-sized density matrices and are equally-distributed... 

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -234,8 +234,6 @@ void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> 
 
 void accel_statevec_setQuregToWeightedSum_sub(Qureg outQureg, vector<qcomp> coeffs, vector<Qureg> inQuregs);
 
-void accel_statevec_setQuregToSuperposition_sub(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2);
-
 void accel_densmatr_mixQureg_subA(qreal outProb, Qureg out, qreal inProb, Qureg in);
 void accel_densmatr_mixQureg_subB(qreal outProb, Qureg out, qreal inProb, Qureg in);
 void accel_densmatr_mixQureg_subC(qreal outProb, Qureg out, qreal inProb);

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -563,17 +563,6 @@ void assert_quregDistribAndFullStateDiagMatrLocal(Qureg qureg, FullStateDiagMatr
         raiseInternalError("The FullStateDiagMatr was unexpectedly distributed.");
 }
 
-void assert_superposedQuregDimsAndDeploysMatch(Qureg facOut, Qureg in1, Qureg in2) {
-
-    if (
-        facOut.isDistributed    != in1.isDistributed    || in1.isDistributed    != in2.isDistributed    ||
-        facOut.isDensityMatrix  != in1.isDensityMatrix  || in1.isDensityMatrix  != in2.isDensityMatrix  ||
-        facOut.isGpuAccelerated != in1.isGpuAccelerated || in1.isGpuAccelerated != in2.isGpuAccelerated ||
-        facOut.numQubits        != in1.numQubits        || in1.numQubits        != in2.numQubits
-    )
-        raiseInternalError("An internal function *_setQuregToSuperposition() received Quregs of mismatching dimensions and/or deployments.");
-}
-
 
 
 /*

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -204,9 +204,6 @@ void assert_quregAndFullStateDiagMatrHaveSameDistrib(Qureg qureg, FullStateDiagM
 
 void assert_quregDistribAndFullStateDiagMatrLocal(Qureg qureg, FullStateDiagMatr matr);
 
-void assert_superposedQuregDimsAndDeploysMatch(Qureg facOut, Qureg in1, Qureg in2);
-
-
 
 /*
  * CPU ERRORS

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -675,6 +675,11 @@ void localiser_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, Pa
     accel_fullstatediagmatr_setElemsToPauliStrSum(out, in);
 }
 
+void localiser_statevec_scaleAmps(Qureg qureg, qcomp factor) {
+
+    localiser_statevec_setQuregToWeightedSum(qureg, {factor}, {qureg});
+}
+
 
 
 /*
@@ -1390,17 +1395,15 @@ void localiser_statevec_setQuregToWeightedSum(Qureg outQureg, vector<qcomp> coef
 }
 
 
-void localiser_statevec_setQuregToSuperposition(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2) {
+void localiser_statevec_setQuregToClone(Qureg out, Qureg in) {
 
     /// @todo
-    /// this function requires (as validated) distributions are identical.
-    /// It would be trivial to generalise this so that Qureg distributions
-    /// can differ (we merely spoof local Quregs, offsetting their memory).
-    /// They must still however be identically GPU-accelerated; this is a
-    /// low priority because this situation is non-sensical
+    /// we lazily re-use setQuregToWeightedSum(), inducing a gratuitous
+    /// x1 multiplication per element which we expected is completely
+    /// occluded by memory movement costs. We should check this and
+    /// potentially replace this function with (NUMA-aware?) memory copying!
 
-    // given Qureg dimensions must match, this is always embarrassingly parallel
-    accel_statevec_setQuregToSuperposition_sub(facOut, outQureg, fac1, inQureg1, fac2, inQureg2);
+    localiser_statevec_setQuregToWeightedSum(out, {1}, {in});
 }
 
 
@@ -2333,7 +2336,7 @@ void localiser_statevec_multiQubitProjector(Qureg qureg, vector<int> qubits, vec
     // all other nodes has some or all states consistent with suffix outcomes
     removePrefixQubitsAndStates(qureg, qubits, outcomes);
     (qubits.empty())?
-        accel_statevec_setQuregToSuperposition_sub(1/std::sqrt(prob), qureg,0,qureg, 0,qureg): // scale by norm
+        localiser_statevec_scaleAmps(qureg, 1/std::sqrt(prob)):
         accel_statevec_multiQubitProjector_sub(qureg, qubits, outcomes, prob);
 }
 

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -48,6 +48,8 @@ void localiser_fullstatediagmatr_setElems(FullStateDiagMatr matr, qindex startIn
 
 void localiser_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliStrSum in);
 
+void localiser_statevec_scaleAmps(Qureg qureg, qcomp factor);
+
 
 /*
  * STATE INITIALISATION
@@ -127,9 +129,9 @@ void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, vector<int> ctrls, vecto
  * QUREG COMBINATION
  */
 
-void localiser_statevec_setQuregToWeightedSum(Qureg outQureg, vector<qcomp> coeffs, vector<Qureg> inQuregs);
+void localiser_statevec_setQuregToClone(Qureg out, Qureg in);
 
-void localiser_statevec_setQuregToSuperposition(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2);
+void localiser_statevec_setQuregToWeightedSum(Qureg outQureg, vector<qcomp> coeffs, vector<Qureg> inQuregs);
 
 void localiser_densmatr_mixQureg(qreal outProb, Qureg out, qreal inProb, Qureg in);
 

--- a/quest/src/core/validation.cpp
+++ b/quest/src/core/validation.cpp
@@ -978,19 +978,6 @@ namespace report {
         "The given density matrix was local, but the statevector was distributed; this configuration is unsupported (and is ridiculous!).";
 
 
-    string SUPERPOSED_QUREGS_ARE_NOT_ALL_STATEVECTORS =
-        "Cannot superpose a density matrix. All quregs must be statevectors.";
-
-    string SUPERPOSED_QUREGS_HAVE_INCONSISTENT_NUM_QUBITS =
-        "Cannot superpose Quregs with differing numbers of qubits.";
-
-    string SUPERPOSED_QUREGS_HAVE_INCONSISTENT_GPU_DEPLOYMENT =
-        "Cannot superpose Quregs with inconsistent GPU deployments. All or no Quregs must be GPU-accelerated.";
-
-    string SUPERPOSED_QUREGS_HAVE_INCONSISTENT_DISTRIBUTION =
-        "Cannot superpose Quregs which are inconsistently distributed. All or no Quregs must be distributed.";
-
-
     string INIT_PURE_STATE_IS_DENSMATR =
         "The pure-state Qureg (the second argument) must be a statevector, not a density matrix.";
 
@@ -4084,31 +4071,6 @@ void validate_numQuregsMatchesProbs(size_t numQuregs, size_t numProbs, const cha
         {"${NUM_PROBS}",  numProbs}
     };
     assertThat(numQuregs == numProbs, report::DIFFERENT_NUM_QUREGS_AND_PROBS, vars, caller);
-}
-
-void validate_quregsCanBeSuperposed(Qureg qureg1, Qureg qureg2, Qureg qureg3, const char* caller) {
-
-    // all quregs must be statevectors
-    assertThat(
-        !qureg1.isDensityMatrix && !qureg2.isDensityMatrix && !qureg3.isDensityMatrix,
-        report::SUPERPOSED_QUREGS_ARE_NOT_ALL_STATEVECTORS, caller);
-
-    // and the same dimension
-    int nQb = qureg1.numQubits;
-    assertThat(
-        qureg2.numQubits == nQb && qureg3.numQubits == nQb, 
-        report::SUPERPOSED_QUREGS_HAVE_INCONSISTENT_NUM_QUBITS, caller);
-
-    // and all the same deployment (GPU & distribution; multithreading doesn't matter)
-    int isGpu = qureg1.isGpuAccelerated;
-    assertThat(
-        qureg2.isGpuAccelerated == isGpu && qureg3.isGpuAccelerated == isGpu, 
-        report::SUPERPOSED_QUREGS_HAVE_INCONSISTENT_GPU_DEPLOYMENT, caller);
-
-    int isDis = qureg1.isDistributed;
-    assertThat(
-        qureg2.isDistributed == isDis && qureg3.isDistributed == isDis, 
-        report::SUPERPOSED_QUREGS_HAVE_INCONSISTENT_DISTRIBUTION, caller);
 }
 
 void validateDensMatrCanBeInitialisedToPureState(Qureg qureg, Qureg pure, const char* caller) {

--- a/quest/src/core/validation.hpp
+++ b/quest/src/core/validation.hpp
@@ -474,8 +474,6 @@ void validate_numQuregsMatchesCoeffs(size_t numQuregs, size_t numCoeffs, const c
 
 void validate_numQuregsMatchesProbs(size_t numQuregs, size_t numProbs, const char* caller);
 
-void validate_quregsCanBeSuperposed(Qureg qureg1, Qureg qureg2, Qureg qureg3, const char* caller);
-
 void validate_quregCanBeInitialisedToPureState(Qureg qureg, Qureg pure, const char* caller);
 
 void validate_quregsCanBeCloned(Qureg quregA, Qureg quregB, const char* caller);

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -1057,21 +1057,6 @@ void cpu_statevec_setQuregToWeightedSum_sub(Qureg outQureg, vector<qcomp> coeffs
 }
 
 
-void cpu_statevec_setQuregToSuperposition_sub(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2) {
-
-    assert_superposedQuregDimsAndDeploysMatch(outQureg, inQureg1, inQureg2);
-
-    qindex numIts = outQureg.numAmpsPerNode;
-    qcomp* out = outQureg.cpuAmps;
-    qcomp* in1 = inQureg1.cpuAmps;
-    qcomp* in2 = inQureg2.cpuAmps;
-
-    #pragma omp parallel for if(outQureg.isMultithreaded)
-    for (qindex n=0; n<numIts; n++)
-        out[n] = (facOut * out[n]) + (fac1 * in1[n]) + (fac2 * in2[n]);
-}
-
-
 void cpu_densmatr_mixQureg_subA(qreal outProb, Qureg outQureg, qreal inProb, Qureg inDensMatr) {
 
     qindex numIts = outQureg.numAmpsPerNode;

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -102,8 +102,6 @@ template <int NumCtrls> void cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qu
 
 template <int NumQuregs> void cpu_statevec_setQuregToWeightedSum_sub(Qureg outQureg, vector<qcomp> coeffs, vector<Qureg> inQuregs);
 
-void cpu_statevec_setQuregToSuperposition_sub(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2);
-
 void cpu_densmatr_mixQureg_subA(qreal outProb, Qureg outQureg, qreal inProb, Qureg inDensMatr);
 void cpu_densmatr_mixQureg_subB(qreal outProb, Qureg outQureg, qreal inProb, Qureg inStateVec);
 void cpu_densmatr_mixQureg_subC(qreal outProb, Qureg outQureg, qreal inProb);

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -938,18 +938,6 @@ void gpu_statevec_setQuregToWeightedSum_sub(Qureg outQureg, vector<qcomp> coeffs
 }
 
 
-void gpu_statevec_setQuregToSuperposition_sub(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2) {
-
-#if COMPILE_CUDA || COMPILE_CUQUANTUM
-
-    thrust_statevec_setQuregToSuperposition_sub(toCuQcomp(facOut), outQureg, toCuQcomp(fac1), inQureg1, toCuQcomp(fac2), inQureg2);
-
-#else
-    error_gpuSimButGpuNotCompiled();
-#endif
-}
-
-
 void gpu_densmatr_mixQureg_subA(qreal outProb, Qureg outQureg, qreal inProb, Qureg inQureg) {
 
 #if COMPILE_CUDA || COMPILE_CUQUANTUM

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -95,8 +95,6 @@ template <int NumCtrls> void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qu
 
 template <int NumQuregs> void gpu_statevec_setQuregToWeightedSum_sub(Qureg outQureg, vector<qcomp> coeffs, vector<Qureg> inQuregs);
 
-void gpu_statevec_setQuregToSuperposition_sub(qcomp facOut, Qureg outQureg, qcomp fac1, Qureg inQureg1, qcomp fac2, Qureg inQureg2);
-
 void gpu_densmatr_mixQureg_subA(qreal outProb, Qureg outQureg, qreal inProb, Qureg inDensMatr);
 void gpu_densmatr_mixQureg_subB(qreal outProb, Qureg outQureg, qreal inProb, Qureg inStateVec);
 void gpu_densmatr_mixQureg_subC(qreal outProb, Qureg outQureg, qreal inProb);

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -386,21 +386,6 @@ struct functor_mixAmps : public thrust::binary_function<cu_qcomp,cu_qcomp,cu_qco
 };
 
 
-struct functor_superposeAmps {
-
-    // this functor linearly combines the given trio
-    // of amplitudes, weighted by fixed qcomps, and is
-    // used by setQuregToSuperposition
-
-    cu_qcomp fac0, fac1, fac2;
-    functor_superposeAmps(cu_qcomp f0, cu_qcomp f1, cu_qcomp f2) : fac0(f0), fac1(f1), fac2(f2) {}
-
-    template <typename Tuple> __host__ __device__ void operator()(Tuple t) {
-        thrust::get<0>(t) = fac0*thrust::get<0>(t) + fac1*thrust::get<1>(t) + fac2*thrust::get<2>(t);
-    }
-};
-
-
 template <bool HasPower, bool UseRealPow, bool Norm>
 struct functor_multiplyElemPowerWithAmpOrNorm : public thrust::binary_function<cu_qcomp,cu_qcomp,cu_qcomp> {
 
@@ -734,15 +719,6 @@ void thrust_densmatr_mixQureg_subA(qreal outProb, Qureg outQureg, qreal inProb, 
         getStartPtr(outQureg), getEndPtr(outQureg), 
         getStartPtr(inQureg),  getStartPtr(outQureg), // 4th arg is output pointer
         functor_mixAmps(outProb, inProb));
-}
-
-
-void thrust_statevec_setQuregToSuperposition_sub(cu_qcomp facOut, Qureg outQureg, cu_qcomp fac1, Qureg inQureg1, cu_qcomp fac2, Qureg inQureg2) {
-
-    thrust::for_each(
-        thrust::make_zip_iterator(thrust::make_tuple(getStartPtr(outQureg), getStartPtr(inQureg1), getStartPtr(inQureg2))),
-        thrust::make_zip_iterator(thrust::make_tuple(getEndPtr(outQureg),   getEndPtr(inQureg1),   getEndPtr(inQureg2))),
-        functor_superposeAmps(facOut, fac1, fac2));
 }
 
 

--- a/tests/deprecated/test_state_initialisations.cpp
+++ b/tests/deprecated/test_state_initialisations.cpp
@@ -743,14 +743,14 @@ TEST_CASE( "setWeightedQureg", "[state_initialisations]" ) {
             Complex f; f.real = 0; f.imag = 0;
             
             // two state-vecs, one density-matrix
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, mat, f, vec, f, vec), ContainsSubstring("Cannot superpose a density matrix. All quregs must be statevectors") );
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, vec, f, mat, f, vec), ContainsSubstring("Cannot superpose a density matrix. All quregs must be statevectors") );
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, vec, f, vec, f, mat), ContainsSubstring("Cannot superpose a density matrix. All quregs must be statevectors") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, mat, f, vec, f, vec), ContainsSubstring("inconsistent attributes") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, vec, f, mat, f, vec), ContainsSubstring("inconsistent attributes") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, vec, f, vec, f, mat), ContainsSubstring("inconsistent attributes") );
 
             // one state-vec, two density-matrices
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, vec, f, mat, f, mat), ContainsSubstring("Cannot superpose a density matrix. All quregs must be statevectors") );
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, mat, f, vec, f, mat), ContainsSubstring("Cannot superpose a density matrix. All quregs must be statevectors") );
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, mat, f, mat, f, vec), ContainsSubstring("Cannot superpose a density matrix. All quregs must be statevectors") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, vec, f, mat, f, mat), ContainsSubstring("inconsistent attributes") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, mat, f, vec, f, mat), ContainsSubstring("inconsistent attributes") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, mat, f, mat, f, vec), ContainsSubstring("inconsistent attributes") );
         
             destroyQureg(vec);
             destroyQureg(mat);
@@ -764,9 +764,9 @@ TEST_CASE( "setWeightedQureg", "[state_initialisations]" ) {
             Complex f; f.real = 0; f.imag = 0;
             
             // state-vecs
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, vecA, f, vecB, f, vecB), ContainsSubstring("differing numbers of qubits") );
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, vecB, f, vecA, f, vecB), ContainsSubstring("differing numbers of qubits") );
-            REQUIRE_THROWS_WITH( setWeightedQureg(f, vecB, f, vecB, f, vecA), ContainsSubstring("differing numbers of qubits") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, vecA, f, vecB, f, vecB), ContainsSubstring("inconsistent attributes") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, vecB, f, vecA, f, vecB), ContainsSubstring("inconsistent attributes") );
+            REQUIRE_THROWS_WITH( setWeightedQureg(f, vecB, f, vecB, f, vecA), ContainsSubstring("inconsistent attributes") );
             
             // v4 does not permit superposing density matrices
 

--- a/tests/unit/initialisations.cpp
+++ b/tests/unit/initialisations.cpp
@@ -848,8 +848,6 @@ void initPureState(Qureg qureg, Qureg pure);
 
 void setQuregToClone(Qureg targetQureg, Qureg copyQureg);
 
-void setQuregToSuperposition(qcomp facOut, Qureg out, qcomp fac1, Qureg qureg1, qcomp fac2, Qureg qureg2);
-
 void setQuregToPartialTrace(Qureg out, Qureg in, int* traceOutQubits, int numTraceQubits);
 
 void setQuregToReducedDensityMatrix(Qureg out, Qureg in, int* retainQubits, int numRetainQubits);


### PR DESCRIPTION
since superseded by setQuregToWeightedSum().

Additionally defined internal convenience functions...
- localiser_statevec_scaleAmps
- localiser_statevec_setQuregToClone which merely call localiser_statevec_setQuregToWeightedSum, for code clarity