### PR TITLE
Support FetchContent and rationalise config.h location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ target_include_directories(QuEST
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/quest/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 set_target_properties(QuEST PROPERTIES
@@ -650,7 +650,7 @@ install(FILES
 )
 
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/include/quest/include/config.h"
+  "${CMAKE_CURRENT_BINARY_DIR}/quest/include/config.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/quest/include"
 )
 

--- a/quest/include/CMakeLists.txt
+++ b/quest/include/CMakeLists.txt
@@ -9,4 +9,4 @@
 # through compiler flags and the associated conflicts arising when
 # installing QuEST. Note that config.h must be manually created when
 # not compiling via CMake, e.g. when using a custom build script 
-configure_file(config.h.in "${CMAKE_BINARY_DIR}/include/quest/include/config.h" @ONLY)
+configure_file(config.h.in config.h @ONLY)


### PR DESCRIPTION
CMake now drops `config.h` in the standard location, which simplifies the call to `configure_file`, and also means our build includes match the example given in the [configure_file docs](https://cmake.org/cmake/help/latest/command/configure_file.html). 

Should fix #689. Possibly fixes #690.