### PR TITLE
Implement Pauli sorting

### DIFF
--- a/quest/include/paulis.h
+++ b/quest/include/paulis.h
@@ -99,6 +99,9 @@ typedef struct {
  * 
  * @defgroup paulis_reporters Reporters
  * @brief Functions for printing Pauli data structures.
+ *
+ * @defgroup paulis_setters Setters
+ * @brief Functions for overwriting the elements of Pauli data structures.
  */
 
 
@@ -411,6 +414,91 @@ extern "C" {
      *   [C++](https://github.com/QuEST-Kit/QuEST/blob/devel/examples/isolated/reporting_paulis.cpp) examples
      */
     void reportPauliStrSum(PauliStrSum str);
+
+
+// end de-mangler
+#ifdef __cplusplus
+}
+#endif
+
+
+
+/*
+ * SETTERS
+ */
+
+// enable invocation by both C and C++ binaries
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+    /** @ingroup paulis_setters
+     *
+     * Reorders the terms within a @p sum of weighted Pauli strings to sort Pauli
+     * strings into lexicographic (dictionary) ordering.
+     *
+     * @formulae
+     * Let @f$ H = @f$ @p sum, which can be represented as
+     * @f[
+          H = \sum\limits_j c_j \, \hat{\sigma}_j
+     * @f]
+     * where @f$ c_j @f$ is the coefficient of the @f$ j @f$-th PauliStr @f$ \hat{\sigma}_j @f$.
+     *
+     * This function constructs and applies the permutation @f$ \pi @f$ to @f$ H @f$
+     * @f[
+          H = \sum\limits_j c_{\pi(j)} \, \hat{\sigma}_{\pi(j)}
+     * @f]
+     * such that
+     * @f[
+     *   \hat{\sigma}_{\pi(i)} <_{lex} \hat{\sigma}_{\pi(j)} \  \forall \  \pi(i) < \pi(j).
+     * @f]
+     *
+     *
+     * @param[in,out] sum  a weighted sum of Pauli strings to reorder.
+     *
+     * @throws @validationerror
+     * - if @p sum is not initialised.
+     *
+     * @see
+     * - sortPauliStrSumMagnitude()
+     * @author Vasco Ferreira
+     */
+    void sortPauliStrSumLexicographic(PauliStrSum sum);
+
+
+    /** @ingroup paulis_setters
+     *
+     * Reorders the terms within a @p sum of weighted Pauli strings to sort Pauli
+     * strings into decreasing magnitude weights.
+     *
+     * @formulae
+     * Let @f$ H = @f$ @p sum, represented as the weighted sum
+     * @f[
+          H = \sum\limits_j c_j \, \hat{\sigma}_j
+     * @f]
+     * where @f$ c_j @f$ is the coefficient of the @f$ j @f$-th PauliStr @f$ \hat{\sigma}_j @f$.
+     *
+     * This function constructs and applies the permutation @f$ \pi @f$ to @f$ H @f$
+     * @f[
+          H = \sum\limits_j c_{\pi(j)} \, \hat{\sigma}_{\pi(j)}
+     * @f]
+     * such that
+     * @f[
+     *    |c_{\pi(i)}| > |c_{\pi(j)}| \, \forall \,  \pi(i) < \pi(j).
+     * @f]
+     *
+     * @param[in,out] sum  a weighted sum of Pauli strings to reorder.
+     *
+     * @throws @validationerror
+     * - if @p sum is not initialised.
+     *
+     * @see
+     * - sortPauliStrSumLexicographic()
+     *
+     * @author Vasco Ferreira
+     */
+    void sortPauliStrSumMagnitude(PauliStrSum sum);
 
 
 // end de-mangler

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -291,3 +291,32 @@ extern "C" void reportPauliStrSum(PauliStrSum sum) {
     // exclude mandatory newline above
     print_oneFewerNewlines();
 }
+
+
+
+/*
+ * SETTERS
+ */
+
+extern "C" void sortPauliStrSumLexicographic(PauliStrSum sum) {
+    validate_pauliStrSumFields(sum, __func__);
+
+    auto lexSort = [&](qindex i, qindex j) {
+        PauliStr strI = sum.strings[i];
+        PauliStr strJ = sum.strings[j];
+        return std::tie(strI.highPaulis, strI.lowPaulis) < std::tie(strJ.highPaulis, strJ.lowPaulis);
+    };
+
+    paulis_sortGeneric(sum, lexSort);
+}
+
+extern "C" void sortPauliStrSumMagnitude(PauliStrSum sum) {
+    validate_pauliStrSumFields(sum, __func__);
+
+    auto magSort = [&](qindex i, qindex j) {
+        return std::norm(sum.coeffs[i]) > std::norm(sum.coeffs[j]);
+    };
+
+    paulis_sortGeneric(sum, magSort);
+}
+

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -308,7 +308,7 @@ extern "C" void sortPauliStrSumLexicographic(PauliStrSum sum) {
         return std::tie(strI.highPaulis, strI.lowPaulis) < std::tie(strJ.highPaulis, strJ.lowPaulis);
     };
 
-    paulis_sortGeneric(sum, lexSort);
+    paulis_sortTermsViaComparator(sum, lexSort);
 }
 
 
@@ -319,5 +319,5 @@ extern "C" void sortPauliStrSumMagnitude(PauliStrSum sum) {
         return std::norm(sum.coeffs[i]) > std::norm(sum.coeffs[j]);
     };
 
-    paulis_sortGeneric(sum, magSort);
+    paulis_sortTermsViaComparator(sum, magSort);
 }

--- a/quest/src/api/paulis.cpp
+++ b/quest/src/api/paulis.cpp
@@ -295,8 +295,9 @@ extern "C" void reportPauliStrSum(PauliStrSum sum) {
 
 
 /*
- * SETTERS
+ * SORTING
  */
+
 
 extern "C" void sortPauliStrSumLexicographic(PauliStrSum sum) {
     validate_pauliStrSumFields(sum, __func__);
@@ -310,6 +311,7 @@ extern "C" void sortPauliStrSumLexicographic(PauliStrSum sum) {
     paulis_sortGeneric(sum, lexSort);
 }
 
+
 extern "C" void sortPauliStrSumMagnitude(PauliStrSum sum) {
     validate_pauliStrSumFields(sum, __func__);
 
@@ -319,4 +321,3 @@ extern "C" void sortPauliStrSumMagnitude(PauliStrSum sum) {
 
     paulis_sortGeneric(sum, magSort);
 }
-

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -322,7 +322,11 @@ void paulis_applyPermutation(PauliStrSum sum, vector<qindex> scatterPermutation)
     }
 }
 
+
 void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator) {
+
+    // TODO: below is an unguarded vector alloc, forgiven since a subsequent
+    // change (giving PauliStrSum an 'ordering' list) supersedes it
 
     // gatherPermutation[j] = source index of element placed at j
     vector<qindex> gatherPermutation(sum.numTerms);
@@ -333,6 +337,7 @@ void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> com
     vector<qindex> scatterPermutation = util_getInversePermutation(gatherPermutation);
     paulis_applyPermutation(sum, scatterPermutation);
 }
+
 
 void paulis_setPauliStrSumToScaledTensorProdOfConjWithSelf(PauliStrSum out, qreal factor, PauliStrSum in, int numQubits) {
 

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 #include <array>
+#include <functional>
 
 using std::vector;
 

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -308,7 +308,7 @@ qindex paulis_getTargetBitMask(PauliStrSum sum) {
 }
 
 
-void paulis_applyPermutation(PauliStrSum sum, vector<qindex> scatterPermutation) {
+void paulis_applyPermutationToTerms(PauliStrSum sum, vector<qindex> scatterPermutation) {
     // permutation passed by value since we modify it
 
     // scatterPermutation[i] = destination index for element originally at i
@@ -323,7 +323,7 @@ void paulis_applyPermutation(PauliStrSum sum, vector<qindex> scatterPermutation)
 }
 
 
-void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator) {
+void paulis_sortTermsViaComparator(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator) {
 
     // TODO: below is an unguarded vector alloc, forgiven since a subsequent
     // change (giving PauliStrSum an 'ordering' list) supersedes it
@@ -335,7 +335,7 @@ void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> com
 
     // invert permutation and apply
     vector<qindex> scatterPermutation = util_getInversePermutation(gatherPermutation);
-    paulis_applyPermutation(sum, scatterPermutation);
+    paulis_applyPermutationToTerms(sum, scatterPermutation);
 }
 
 

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -13,6 +13,7 @@
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/errors.hpp"
 
+#include <numeric>
 #include <utility>
 #include <vector>
 #include <array>
@@ -306,6 +307,32 @@ qindex paulis_getTargetBitMask(PauliStrSum sum) {
     return mask;
 }
 
+
+void paulis_applyPermutation(PauliStrSum sum, vector<qindex> scatterPermutation) {
+    // permutation passed by value since we modify it
+
+    // scatterPermutation[i] = destination index for element originally at i
+    for (qindex i = 0; i < sum.numTerms; i++) {
+        while (scatterPermutation[i] != i) {
+            qindex j = scatterPermutation[i];
+            std::swap(sum.strings[i], sum.strings[j]);
+            std::swap(sum.coeffs[i], sum.coeffs[j]);
+            std::swap(scatterPermutation[i], scatterPermutation[j]);
+        }
+    }
+}
+
+void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator) {
+
+    // gatherPermutation[j] = source index of element placed at j
+    vector<qindex> gatherPermutation(sum.numTerms);
+    std::iota(gatherPermutation.begin(), gatherPermutation.end(), 0);
+    std::stable_sort(gatherPermutation.begin(), gatherPermutation.end(), comparator);
+
+    // invert permutation and apply
+    vector<qindex> scatterPermutation = util_invertPermutation(gatherPermutation);
+    paulis_applyPermutation(sum, scatterPermutation);
+}
 
 void paulis_setPauliStrSumToScaledTensorProdOfConjWithSelf(PauliStrSum out, qreal factor, PauliStrSum in, int numQubits) {
 

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -330,7 +330,7 @@ void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> com
     std::stable_sort(gatherPermutation.begin(), gatherPermutation.end(), comparator);
 
     // invert permutation and apply
-    vector<qindex> scatterPermutation = util_invertPermutation(gatherPermutation);
+    vector<qindex> scatterPermutation = util_getInversePermutation(gatherPermutation);
     paulis_applyPermutation(sum, scatterPermutation);
 }
 

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <array>
 #include <functional>
+#include <algorithm>
 
 using std::vector;
 

--- a/quest/src/core/paulilogic.hpp
+++ b/quest/src/core/paulilogic.hpp
@@ -76,6 +76,10 @@ int paulis_getIndOfLefmostNonIdentityPauli(PauliStrSum sum);
 
 qindex paulis_getTargetBitMask(PauliStrSum sum);
 
+void paulis_applyPermutation(PauliStrSum sum, vector<qindex> permutation);
+
+void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator);
+
 
 // below are used exclusively by Trotterisation
 

--- a/quest/src/core/paulilogic.hpp
+++ b/quest/src/core/paulilogic.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 #include <array>
+#include <functional>
 
 using std::vector;
 

--- a/quest/src/core/paulilogic.hpp
+++ b/quest/src/core/paulilogic.hpp
@@ -76,9 +76,9 @@ int paulis_getIndOfLefmostNonIdentityPauli(PauliStrSum sum);
 
 qindex paulis_getTargetBitMask(PauliStrSum sum);
 
-void paulis_applyPermutation(PauliStrSum sum, vector<qindex> permutation);
+void paulis_applyPermutationToTerms(PauliStrSum sum, vector<qindex> permutation);
 
-void paulis_sortGeneric(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator);
+void paulis_sortTermsViaComparator(PauliStrSum sum, std::function<bool(qindex, qindex)> comparator);
 
 
 // below are used exclusively by Trotterisation

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -1229,3 +1229,21 @@ void util_tryAllocMatrix(vector<vector<qcomp>> &matr, qindex numRows, qindex num
         errFunc();
     }
 }
+
+
+
+/*
+ * OTHER
+ */
+
+vector<qindex> util_invertPermutation(const vector<qindex>& permutation) {
+    qindex numTerms = permutation.size();
+    vector<qindex> out(numTerms);
+
+    // invert permutation
+    for (qindex i = 0; i < numTerms; i++) {
+        out[permutation[i]] = i;
+    }
+
+    return out;
+}

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -368,7 +368,7 @@ bool util_willSumOverflow(vector<qindex> terms) {
 
 
 /*
- * VECTOR REDUCTION
+ * LIST PROCESSING
  */
 
 qreal util_getSum(vector<qreal> list) {
@@ -385,6 +385,16 @@ qreal util_getSum(vector<qreal> list) {
     }
 
     return sum;
+}
+
+vector<qindex> util_getInversePermutation(vector<qindex> permutation) {
+    qindex numTerms = permutation.size();
+    vector<qindex> out(numTerms);
+
+    for (qindex i = 0; i < numTerms; i++)
+        out[permutation[i]] = i;
+
+    return out;
 }
 
 
@@ -1228,22 +1238,4 @@ void util_tryAllocMatrix(vector<vector<qcomp>> &matr, qindex numRows, qindex num
     } catch (std::length_error &e) {
         errFunc();
     }
-}
-
-
-
-/*
- * OTHER
- */
-
-vector<qindex> util_invertPermutation(const vector<qindex>& permutation) {
-    qindex numTerms = permutation.size();
-    vector<qindex> out(numTerms);
-
-    // invert permutation
-    for (qindex i = 0; i < numTerms; i++) {
-        out[permutation[i]] = i;
-    }
-
-    return out;
 }

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -388,6 +388,10 @@ qreal util_getSum(vector<qreal> list) {
 }
 
 vector<qindex> util_getInversePermutation(vector<qindex> permutation) {
+    
+    // TODO: below is an unguarded vector alloc, forgiven since a subsequent
+    // change (giving PauliStrSum an 'ordering' list) supersedes it
+
     qindex numTerms = permutation.size();
     vector<qindex> out(numTerms);
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -430,4 +430,10 @@ void util_tryAllocMatrix(vector<vector<qcomp>> &vec, qindex numRows, qindex numC
 
 
 
+/*
+ * OTHER
+ */
+
+vector<qindex> util_invertPermutation(const vector<qindex>& permutation);
+
 #endif // UTILITIES_HPP

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -240,10 +240,12 @@ qcomp* util_getGpuMemPtr(T matr) {
 
 
 /*
- * VECTOR REDUCTION
+ * LIST PROCESSING
  */
 
 qreal util_getSum(vector<qreal> list);
+
+vector<qindex> util_getInversePermutation(vector<qindex> permutation);
 
 
 
@@ -429,11 +431,5 @@ void util_tryAllocVector(vector<PauliStr> &vec, qindex size, std::function<void(
 void util_tryAllocMatrix(vector<vector<qcomp>> &vec, qindex numRows, qindex numCols, std::function<void()> errFunc);
 
 
-
-/*
- * OTHER
- */
-
-vector<qindex> util_invertPermutation(const vector<qindex>& permutation);
 
 #endif // UTILITIES_HPP

--- a/tests/unit/paulis.cpp
+++ b/tests/unit/paulis.cpp
@@ -587,6 +587,61 @@ TEST_CASE( "destroyPauliStrSum", TEST_CATEGORY ) {
     }
 }
 
+TEST_CASE( "sortPauliStrSumLexicographic", TEST_CATEGORY ) {
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        vector<qcomp> coeffs = {0.1_i, 2+1_i, 5, 3+4_i};
+        vector<PauliStr> strings = {
+            getPauliStr("XY", {31,32}),
+            getPauliStr("YX", {0,1}),
+            getPauliStr("II", {0,1}),
+            getPauliStr("YY", {31,32})
+        };
+
+        PauliStrSum sum = createPauliStrSum(strings, coeffs);
+        sortPauliStrSumLexicographic(sum);
+
+        REQUIRE(sum.coeffs[0] == 5+0_i);
+        REQUIRE(sum.coeffs[1] == 2+1_i);
+        REQUIRE(sum.coeffs[3] == 3+4_i);
+
+        REQUIRE(sum.strings[0].lowPaulis == 0);
+        REQUIRE(sum.strings[1].lowPaulis == 2 + 1*4);
+        REQUIRE(sum.strings[3].highPaulis == 2);
+        REQUIRE(sum.strings[3].lowPaulis == 2*std::pow(4, 31));
+
+        destroyPauliStrSum(sum);
+    }
+}
+
+TEST_CASE( "sortPauliStrSumMagnitude", TEST_CATEGORY ) {
+
+    SECTION( LABEL_CORRECTNESS ) {
+
+        vector<qcomp> coeffs = {0.1_i, 2+1_i, 5, 3+4_i};
+        vector<PauliStr> strings = {
+            getPauliStr("XY", {0,1}),
+            getPauliStr("ZX", {0,1}),
+            getPauliStr("II", {0,1}),
+            getPauliStr("YZ", {0,1})
+        };
+
+        PauliStrSum sum = createPauliStrSum(strings, coeffs);
+        sortPauliStrSumMagnitude(sum);
+
+        REQUIRE(sum.coeffs[0] == 5+0_i);
+        REQUIRE(sum.coeffs[1] == 3+4_i);
+        REQUIRE(sum.coeffs[3] == 0+0.1_i);
+
+        REQUIRE(sum.strings[0].lowPaulis == 0);
+        REQUIRE(sum.strings[1].lowPaulis == 2 + 3*4);
+        REQUIRE(sum.strings[3].lowPaulis == 1 + 2*4);
+
+        destroyPauliStrSum(sum);
+    }
+}
+
 
 /** @} (end defgroup) */
 


### PR DESCRIPTION
Howdy! This is the first of two PRs on transformations of `PauliStrSums` mainly focusing on improving the accuracy of Trotter methods. This PR specifically introduces methods to sort the terms within a `PauliStrSum`.

Main changes:
- Core: added methods to **calculate and apply permutations** to sort a `PauliStrSum`.
- API: Added methods to **sort lexicographically and by magnitude** (along with tests).
- Documentation: added a `Setters` section for Pauli docs, for the sorting methods and future methods that transform Pauli strings.

Key details:
- Since the sorting logic is only expected to be used outside hot loops, I have tried to keep the permutation logic as simple as possible and not reinvent the wheel, e.g. using `std::sort` rather than some custom implementation.
- When applying the permutations we require both some temporary storage to construct and invert the permutation, however since the number of terms in a `PauliStrSum` generally only scales polynomially, this shouldn't be an issue (e.g. even for extremely large chemical systems this additional memory would be negligible)

I think that about covers it. As always happy to tweak, move or update stuff if anything jumps out at you.

Cheers!