### PR TITLE
Patch MSVC + OpenMP + double-or-quad precision + tests

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -28,7 +28,7 @@ on:
     branches:
       - main
       - devel
-      - unifying-base-qcomp
+      - msvc-patch
   pull_request:
     branches:
       - main

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -28,7 +28,6 @@ on:
     branches:
       - main
       - devel
-      - msvc-patch
   pull_request:
     branches:
       - main

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -938,12 +938,16 @@ template void cpu_densmatr_allTargDiagMatr_sub<true,  false, true,  false> (Qure
 
 template <int NumTargs>
 INLINE void applyPauliUponAmpPair(
-    cpu_qcomp* amps, qindex v, qindex i0, int* indXY, int numXY, 
-    qindex maskXY, qindex maskYZ, cpu_qcomp& ampFac, cpu_qcomp& pairAmpFac
+    cpu_qcomp* amps, qindex& v, qindex& i0, int* indXY, int& numXY, 
+    qindex& maskXY, qindex& maskYZ, cpu_qcomp& ampFac, cpu_qcomp& pairAmpFac
 ) {
-    // this is a subroutine of cpu_statevector_anyCtrlPauliTensorOrGadget_subA() below
+    // This is a subroutine of cpu_statevector_anyCtrlPauliTensorOrGadget_subA() below
     // called in a hot-loop (hence it is here inlined) which exists because the caller
-    // chooses one of two possible OpenMP parallelisation granularities
+    // chooses one of two possible OpenMP parallelisation granularities. All args are
+    // pass-by-reference for performance, and because passing the cpu_qcomp types by-
+    // value causes a stack overflow during compilation with MSVC with OpenMP enabled;
+    // but only at double and quad precision (single is fine), and only when Catch2 is
+    // also being compiled (through the tests)... Hours of my life forever lost!
 
     // remind compiler when NumTargs is compile-time to unroll loop in setBits()
     SET_VAR_AT_COMPILE_TIME(int, numTargBits, NumTargs, numXY);

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -939,7 +939,7 @@ template void cpu_densmatr_allTargDiagMatr_sub<true,  false, true,  false> (Qure
 template <int NumTargs>
 INLINE void applyPauliUponAmpPair(
     cpu_qcomp* amps, qindex v, qindex i0, int* indXY, int numXY, 
-    qindex maskXY, qindex maskYZ, cpu_qcomp ampFac, cpu_qcomp pairAmpFac
+    qindex maskXY, qindex maskYZ, cpu_qcomp& ampFac, cpu_qcomp& pairAmpFac
 ) {
     // this is a subroutine of cpu_statevector_anyCtrlPauliTensorOrGadget_subA() below
     // called in a hot-loop (hence it is here inlined) which exists because the caller

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -3,7 +3,9 @@
  * as mirrored by gpu_subroutines.cpp, and called by accelerator.cpp. 
  * 
  * These 'hot-loop' functions use cpu_qcomp arithmetic operators, in lieu of qcomp
- * (i.e. std::complex) which has compiler-specific performance pitfalls.
+ * (i.e. std::complex) which has compiler-specific performance pitfalls. BEWARE
+ * that passing a cpu_qcomp by-value to a function inside an OpenMP parallel region
+ * can cause MSVC to crash during compilation, so be sure to pass by reference!
  * 
  * Some of these definitions are templated, defining multiple versions optimised 
  * (at compile-time) for handling different numbers of input qubits; such functions


### PR DESCRIPTION
MSVC compilation crashed due to passing a `cpu_qcomp`-by-value to a function within an OpenMP parallel region, but only when all the below conditions were satisfied.
- `cpu_qcomp` precision was `double` or `quad` (`single` is fine), i.e. `cpu_qcomp` >= 16 bytes
- OpenMP is enabled
- Catch2 tests are being compiled