### PR TITLE
Fix applyMultiStateControlledSqrtSwap argument list

### DIFF
--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -1219,7 +1219,7 @@ void applyMultiControlledSqrtSwap(Qureg qureg, std::vector<int> controls, int qu
 /// @notyetdoced
 /// @cppvectoroverload
 /// @see applyMultiStateControlledSqrtSwap()
-void applyMultiStateControlledSqrtSwap(Qureg qureg, std::vector<int> controls, std::vector<int> states, int numControls, int qubit1, int qubit2);
+void applyMultiStateControlledSqrtSwap(Qureg qureg, std::vector<int> controls, std::vector<int> states, int qubit1, int qubit2);
 
 
 #endif // __cplusplus


### PR DESCRIPTION
Remove numControls argument from applyMultiStateControlledSqrtSwap overloaded definition taking std::vector<int>

(cherry picked from commit 9c20792dce9e6a432c50b081028c717af1ff9f3d)