### PR TITLE
Replace vector<int> with stack-list

### DIFF
--- a/quest/src/api/calculations.cpp
+++ b/quest/src/api/calculations.cpp
@@ -12,6 +12,7 @@
 #include "quest/include/calculations.h"
 
 #include "quest/src/core/validation.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/localiser.hpp"
 #include "quest/src/core/bitwise.hpp"
@@ -253,12 +254,12 @@ qreal calcProbOfMultiQubitOutcome(Qureg qureg, int* qubits, int* outcomes, int n
     validate_targets(qureg, qubits, numQubits, __func__);
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
 
-    auto qubitVec = util_getVector(qubits, numQubits);
-    auto outcomeVec = util_getVector(outcomes, numQubits);
+    auto qubitList = list_getSmallList(qubits, numQubits);
+    auto outcomeList = list_getSmallList(outcomes, numQubits);
 
     return (qureg.isDensityMatrix)?
-        localiser_densmatr_calcProbOfMultiQubitOutcome(qureg, qubitVec, outcomeVec):
-        localiser_statevec_calcProbOfMultiQubitOutcome(qureg, qubitVec, outcomeVec);
+        localiser_densmatr_calcProbOfMultiQubitOutcome(qureg, qubitList, outcomeList):
+        localiser_statevec_calcProbOfMultiQubitOutcome(qureg, qubitList, outcomeList);
 }
 
 
@@ -267,11 +268,11 @@ void calcProbsOfAllMultiQubitOutcomes(qreal* outcomeProbs, Qureg qureg, int* qub
     validate_targets(qureg, qubits, numQubits, __func__);
     validate_measurementOutcomesFitInGpuMem(qureg, numQubits, __func__);
 
-    auto qubitVec = util_getVector(qubits, numQubits);
+    auto qubitList = list_getSmallList(qubits, numQubits);
 
     (qureg.isDensityMatrix)?
-        localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(outcomeProbs, qureg, qubitVec):
-        localiser_statevec_calcProbsOfAllMultiQubitOutcomes(outcomeProbs, qureg, qubitVec);
+        localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(outcomeProbs, qureg, qubitList):
+        localiser_statevec_calcProbsOfAllMultiQubitOutcomes(outcomeProbs, qureg, qubitList);
 }
 
 
@@ -383,7 +384,7 @@ Qureg calcPartialTrace(Qureg qureg, int* traceOutQubits, int numTraceQubits) {
         qureg.isGpuAccelerated, qureg.isMultithreaded, __func__);
 
     // set it to reduced density matrix
-    auto targets = util_getVector(traceOutQubits, numTraceQubits);
+    auto targets = list_getSmallList(traceOutQubits, numTraceQubits);
     localiser_densmatr_partialTrace(qureg, out, targets);
 
     return out;
@@ -396,7 +397,7 @@ Qureg calcReducedDensityMatrix(Qureg qureg, int* retainQubits, int numRetainQubi
     validate_targets(qureg, retainQubits, numRetainQubits, __func__);
     validate_quregCanBeReduced(qureg, qureg.numQubits - numRetainQubits, __func__);
 
-    auto traceQubits = util_getNonTargetedQubits(retainQubits, numRetainQubits, qureg.numQubits);
+    auto traceQubits = util_getNonTargetedQubits(list_getSmallList(retainQubits, numRetainQubits), qureg.numQubits);
 
     // harmlessly re-validates
     return calcPartialTrace(qureg, traceQubits.data(), traceQubits.size());

--- a/quest/src/api/decoherence.cpp
+++ b/quest/src/api/decoherence.cpp
@@ -126,7 +126,7 @@ void mixKrausMap(Qureg qureg, int* qubits, int numQubits, KrausMap map) {
     validate_krausMapIsCPTP(map, __func__); // also checks fields and is-sync
     validate_krausMapMatchesTargets(map, numQubits, __func__);
 
-    localiser_densmatr_krausMap(qureg, map, util_getVector(qubits, numQubits));
+    localiser_densmatr_krausMap(qureg, map, list_getSmallList(qubits, numQubits));
 }
 
 
@@ -149,7 +149,7 @@ void mixSuperOp(Qureg qureg, int* targets, int numTargets, SuperOp superop) {
     validate_superOpDimMatchesTargs(superop, numTargets, __func__);
     validate_mixedAmpsFitInNode(qureg, 2*numTargets, __func__); // superop acts on 2x
 
-    localiser_densmatr_superoperator(qureg, superop, util_getVector(targets, numTargets));
+    localiser_densmatr_superoperator(qureg, superop, list_getSmallList(targets, numTargets));
 }
 
 

--- a/quest/src/api/initialisations.cpp
+++ b/quest/src/api/initialisations.cpp
@@ -13,6 +13,7 @@
 
 #include "quest/src/core/validation.hpp"
 #include "quest/src/core/localiser.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
@@ -220,7 +221,7 @@ void setQuregToPartialTrace(Qureg out, Qureg in, int* traceOutQubits, int numTra
     validate_targets(in, traceOutQubits, numTraceQubits, __func__);
     validate_quregCanBeSetToReducedDensMatr(out, in, numTraceQubits, __func__);
 
-    auto targets = util_getVector(traceOutQubits, numTraceQubits);
+    auto targets = list_getSmallList(traceOutQubits, numTraceQubits);
     localiser_densmatr_partialTrace(in, out, targets);
 }
 
@@ -233,7 +234,7 @@ void setQuregToReducedDensityMatrix(Qureg out, Qureg in, int* retainQubits, int 
     validate_targets(in, retainQubits, numRetainQubits, __func__);
     validate_quregCanBeSetToReducedDensMatr(out, in, in.numQubits - numRetainQubits, __func__);
 
-    auto traceQubits = util_getNonTargetedQubits(retainQubits, numRetainQubits, in.numQubits);
+    auto traceQubits = util_getNonTargetedQubits(list_getSmallList(retainQubits, numRetainQubits), in.numQubits);
     localiser_densmatr_partialTrace(in, out, traceQubits);
 }
 

--- a/quest/src/api/multiplication.cpp
+++ b/quest/src/api/multiplication.cpp
@@ -12,6 +12,7 @@
 #include "quest/include/multiplication.h"
 
 #include "quest/src/core/validation.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/localiser.hpp"
 #include "quest/src/core/paulilogic.hpp"
@@ -19,6 +20,14 @@
 #include <vector>
 
 using std::vector;
+
+
+
+// The multiplication API doesn't accept control qubits
+// (which don't have much relevance to non-unitaries),
+// so passes ctrls={} to most internal functions; we
+// spare ourselves some keystrokes by this shortcut
+SmallList none = list_getEmptySmallList();
 
 
 
@@ -35,7 +44,7 @@ void leftapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
 
     bool conj = false;
     bool transp = false;
-    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, target, matrix, conj, transp);
+    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, none, none, target, matrix, conj, transp);
 }
 
 void rightapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
@@ -48,7 +57,7 @@ void rightapplyCompMatr1(Qureg qureg, int target, CompMatr1 matrix) {
     bool conj = false;
     bool transp = true;
     int qubit = util_getBraQubit(target, qureg);
-    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, {}, {}, qubit, matrix, conj, transp);
+    localiser_statevec_anyCtrlOneTargDenseMatr(qureg, none, none, qubit, matrix, conj, transp);
 }
 
 } // end de-mangler
@@ -69,7 +78,7 @@ void leftapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix)
 
     bool conj = false;
     bool transp = false;
-    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, target1, target2, matrix, conj, transp);
+    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, none, none, target1, target2, matrix, conj, transp);
 }
 
 void rightapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix) {
@@ -84,7 +93,7 @@ void rightapplyCompMatr2(Qureg qureg, int target1, int target2, CompMatr2 matrix
     bool transp = true;
     int qubit1 = util_getBraQubit(target1, qureg);
     int qubit2 = util_getBraQubit(target2, qureg);
-    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, {}, {}, qubit1, qubit2, matrix, conj, transp);
+    localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, none, none, qubit1, qubit2, matrix, conj, transp);
 }
 
 } // end de-mangler
@@ -105,7 +114,7 @@ void leftapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matri
 
     bool conj = false;
     bool transp = false;
-    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, util_getVector(targets, numTargets), matrix, conj, transp);
+    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, none, none, list_getSmallList(targets, numTargets), matrix, conj, transp);
 }
 
 void rightapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matrix) {
@@ -118,8 +127,8 @@ void rightapplyCompMatr(Qureg qureg, int* targets, int numTargets, CompMatr matr
     // rho matrix ~ transpose(rho) (x) I ||rho>>
     bool conj = false;
     bool transp = true;
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, qubits, matrix, conj, transp);
+    auto qubits = util_getBraQubits(list_getSmallList(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, none, none, qubits, matrix, conj, transp);
 }
 
 } // end de-mangler
@@ -148,7 +157,7 @@ void leftapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
     validate_matrixFields(matrix, __func__);
 
     bool conj = false;
-    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, target, matrix, conj);
+    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, none, none, target, matrix, conj);
 }
 
 void rightapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
@@ -159,7 +168,7 @@ void rightapplyDiagMatr1(Qureg qureg, int target, DiagMatr1 matrix) {
 
     bool conj = false;
     int qubit = util_getBraQubit(target, qureg);
-    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, {}, {}, qubit, matrix, conj);
+    localiser_statevec_anyCtrlOneTargDiagMatr(qureg, none, none, qubit, matrix, conj);
 }
 
 } // end de-mangler
@@ -178,7 +187,7 @@ void leftapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix)
     validate_matrixFields(matrix, __func__);
 
     bool conj = false;
-    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, target1, target2, matrix, conj);
+    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, none, none, target1, target2, matrix, conj);
 }
 
 void rightapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix) {
@@ -190,7 +199,7 @@ void rightapplyDiagMatr2(Qureg qureg, int target1, int target2, DiagMatr2 matrix
     bool conj = false;
     int qubit1 = util_getBraQubit(target1, qureg);
     int qubit2 = util_getBraQubit(target2, qureg);
-    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, {}, {}, qubit1, qubit2, matrix, conj);
+    localiser_statevec_anyCtrlTwoTargDiagMatr(qureg, none, none, qubit1, qubit2, matrix, conj);
 }
 
 } // end de-mangler
@@ -210,8 +219,8 @@ void leftapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matri
 
     bool conj = false;
     qcomp exponent = 1;
-    auto qubits = util_getVector(targets, numTargets);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+    auto qubits = list_getSmallList(targets, numTargets);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, none, none, qubits, matrix, exponent, conj);
 }
 
 void rightapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matrix) {
@@ -222,8 +231,8 @@ void rightapplyDiagMatr(Qureg qureg, int* targets, int numTargets, DiagMatr matr
 
     bool conj = false;
     qcomp exponent = 1;
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+    auto qubits = util_getBraQubits(list_getSmallList(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, none, none, qubits, matrix, exponent, conj);
 }
 
 } // end de-mangler
@@ -253,8 +262,8 @@ void leftapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr 
     validate_matrixExpIsNonDiverging(matrix, exponent, __func__); // harmlessly re-validates fields and is-sync
 
     bool conj = false;
-    auto qubits = util_getVector(targets, numTargets);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+    auto qubits = list_getSmallList(targets, numTargets);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, none, none, qubits, matrix, exponent, conj);
 }
 
 void rightapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr matrix, qcomp exponent) {
@@ -265,8 +274,8 @@ void rightapplyDiagMatrPower(Qureg qureg, int* targets, int numTargets, DiagMatr
     validate_matrixExpIsNonDiverging(matrix, exponent, __func__); // harmlessly re-validates fields and is-sync
 
     bool conj = false;
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, {}, {}, qubits, matrix, exponent, conj);
+    auto qubits = util_getBraQubits(list_getSmallList(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, none, none, qubits, matrix, exponent, conj);
 }
 
 } // end de-mangler
@@ -350,7 +359,7 @@ void leftapplySwap(Qureg qureg, int qubit1, int qubit2) {
     validate_quregFields(qureg, __func__);
     validate_twoTargets(qureg, qubit1, qubit2, __func__);
 
-    localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
+    localiser_statevec_anyCtrlSwap(qureg, none, none, qubit1, qubit2);
 }
 
 void rightapplySwap(Qureg qureg, int qubit1, int qubit2) {
@@ -360,7 +369,7 @@ void rightapplySwap(Qureg qureg, int qubit1, int qubit2) {
 
     qubit1 = util_getBraQubit(qubit1, qureg);
     qubit2 = util_getBraQubit(qubit2, qureg);
-    localiser_statevec_anyCtrlSwap(qureg, {}, {}, qubit1, qubit2);
+    localiser_statevec_anyCtrlSwap(qureg, none, none, qubit1, qubit2);
 }
 
 } // end de-mangler
@@ -378,7 +387,7 @@ void leftapplyPauliX(Qureg qureg, int target) {
     validate_target(qureg, target, __func__);
 
     PauliStr str = getPauliStr("X", {target});
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str);
 }
 
 void leftapplyPauliY(Qureg qureg, int target) {
@@ -386,7 +395,7 @@ void leftapplyPauliY(Qureg qureg, int target) {
     validate_target(qureg, target, __func__);
 
     PauliStr str = getPauliStr("Y", {target});
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str);
 }
 
 void leftapplyPauliZ(Qureg qureg, int target) {
@@ -394,7 +403,7 @@ void leftapplyPauliZ(Qureg qureg, int target) {
     validate_target(qureg, target, __func__);
 
     PauliStr str = getPauliStr("Z", {target});
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str);
 }
 
 void rightapplyPauliX(Qureg qureg, int target) {
@@ -404,7 +413,7 @@ void rightapplyPauliX(Qureg qureg, int target) {
 
     PauliStr str = getPauliStr("X", {target});
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str);
 }
 
 void rightapplyPauliY(Qureg qureg, int target) {
@@ -415,7 +424,7 @@ void rightapplyPauliY(Qureg qureg, int target) {
     qcomp factor = -1; // undo transpose
     PauliStr str = getPauliStr("Y", {target});
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str, factor);
 }
 
 void rightapplyPauliZ(Qureg qureg, int target) {
@@ -425,7 +434,7 @@ void rightapplyPauliZ(Qureg qureg, int target) {
 
     PauliStr str = getPauliStr("Z", {target});
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str);
 }
 
 } // end de-mangler
@@ -442,7 +451,7 @@ void leftapplyPauliStr(Qureg qureg, PauliStr str) {
     validate_quregFields(qureg, __func__);
     validate_pauliStrTargets(qureg, str, __func__);
 
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str);
 }
 
 void rightapplyPauliStr(Qureg qureg, PauliStr str) {
@@ -452,7 +461,7 @@ void rightapplyPauliStr(Qureg qureg, PauliStr str) {
 
     qcomp factor = paulis_getSignOfPauliStrConj(str); // undo transpose
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliTensor(qureg, {}, {}, str, factor);
+    localiser_statevec_anyCtrlPauliTensor(qureg, none, none, str, factor);
 }
 
 } // end de-mangler
@@ -470,7 +479,7 @@ void leftapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     validate_pauliStrTargets(qureg, str, __func__);
 
     qreal phase = util_getPhaseFromGateAngle(angle);
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
+    localiser_statevec_anyCtrlPauliGadget(qureg, none, none, str, phase);
 }
 
 void rightapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
@@ -481,7 +490,7 @@ void rightapplyPauliGadget(Qureg qureg, PauliStr str, qreal angle) {
     qreal factor = paulis_getSignOfPauliStrConj(str);
     qreal phase = factor * util_getPhaseFromGateAngle(angle);
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
+    localiser_statevec_anyCtrlPauliGadget(qureg, none, none, str, phase);
 }
 
 } // end de-mangler
@@ -499,8 +508,8 @@ void leftapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle
     validate_targets(qureg, targets, numTargets, __func__);
 
     qreal phase = util_getPhaseFromGateAngle(angle);
-    auto qubits = util_getVector(targets, numTargets);
-    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
+    auto qubits = list_getSmallList(targets, numTargets);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, none, none, qubits, phase);
 }
 
 void rightapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angle) {
@@ -509,8 +518,8 @@ void rightapplyPhaseGadget(Qureg qureg, int* targets, int numTargets, qreal angl
     validate_targets(qureg, targets, numTargets, __func__);
 
     qreal phase = util_getPhaseFromGateAngle(angle);
-    auto qubits = util_getBraQubits(util_getVector(targets, numTargets), qureg);
-    localiser_statevec_anyCtrlPhaseGadget(qureg, {}, {}, qubits, phase);
+    auto qubits = util_getBraQubits(list_getSmallList(targets, numTargets), qureg);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, none, none, qubits, phase);
 }
 
 } // end de-mangler
@@ -578,7 +587,7 @@ void leftapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     validate_measurementOutcomeIsValid(outcome, __func__); 
 
     qreal prob = 1;
-    localiser_statevec_multiQubitProjector(qureg, {qubit}, {outcome}, prob);
+    localiser_statevec_multiQubitProjector(qureg, list_getSmallList({qubit}), list_getSmallList({outcome}), prob);
 }
 
 void leftapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
@@ -587,8 +596,8 @@ void leftapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int n
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
 
     qreal prob = 1;
-    auto qubitVec = util_getVector(qubits, numQubits);
-    auto outcomeVec = util_getVector(outcomes, numQubits);
+    auto qubitVec = list_getSmallList(qubits, numQubits);
+    auto outcomeVec = list_getSmallList(outcomes, numQubits);
     localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, prob);
 }
 
@@ -599,7 +608,8 @@ void rightapplyQubitProjector(Qureg qureg, int qubit, int outcome) {
     validate_measurementOutcomeIsValid(outcome, __func__); 
     
     qreal prob = 1;
-    localiser_statevec_multiQubitProjector(qureg, {util_getBraQubit(qubit,qureg)}, {outcome}, prob);
+    auto qubitList = list_getSmallList({util_getBraQubit(qubit,qureg)});
+    localiser_statevec_multiQubitProjector(qureg, qubitList, list_getSmallList({outcome}), prob);
 }
 
 void rightapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
@@ -609,8 +619,8 @@ void rightapplyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int 
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
 
     qreal prob = 1;
-    auto qubitVec = util_getBraQubits(util_getVector(qubits, numQubits), qureg);
-    auto outcomeVec = util_getVector(outcomes, numQubits);
+    auto qubitVec = util_getBraQubits(list_getSmallList(qubits, numQubits), qureg);
+    auto outcomeVec = list_getSmallList(outcomes, numQubits);
     localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, prob);
 }
 
@@ -649,9 +659,9 @@ void leftapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
 
     // left-multiply each term in-turn, mixing into output qureg, then undo using idempotency
     for (qindex i=0; i<sum.numTerms; i++) {
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
+        localiser_statevec_anyCtrlPauliTensor(workspace, none, none, sum.strings[i]);
         localiser_statevec_setQuregToWeightedSum(qureg, {1, sum.coeffs[i]}, {qureg, workspace});
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, sum.strings[i]);
+        localiser_statevec_anyCtrlPauliTensor(workspace, none, none, sum.strings[i]);
     }
 
     // workspace -> qureg, and qureg -> sum * qureg
@@ -674,9 +684,9 @@ void rightapplyPauliStrSum(Qureg qureg, PauliStrSum sum, Qureg workspace) {
         PauliStr str =  paulis_getShiftedPauliStr(sum.strings[i], qureg.numQubits);
         qcomp factor = paulis_getSignOfPauliStrConj(str); // undoes transpose
 
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
+        localiser_statevec_anyCtrlPauliTensor(workspace, none, none, str, factor);
         localiser_statevec_setQuregToWeightedSum(qureg, {1, sum.coeffs[i]}, {qureg, workspace});
-        localiser_statevec_anyCtrlPauliTensor(workspace, {}, {}, str, factor);
+        localiser_statevec_anyCtrlPauliTensor(workspace, none, none, str, factor);
     }
 
     // workspace -> qureg, and qureg -> sum * qureg

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -42,20 +42,20 @@ void validateAndApplyAnyCtrlAnyTargUnitaryMatrix(Qureg qureg, int* ctrls, int* s
     if (util_isDenseMatrixType<T>())
         validate_mixedAmpsFitInNode(qureg, numTargs, caller);
 
-    auto ctrlVec  = util_getVector(ctrls,  numCtrls);
-    auto stateVec = util_getVector(states, numCtrls);
-    auto targVec  = util_getVector(targs,  numTargs);
+    SmallList ctrlList  = list_getSmallList(ctrls,  numCtrls);
+    SmallList stateList = list_getSmallList(states, numCtrls);
+    SmallList targList  = list_getSmallList(targs,  numTargs);
 
     bool conj = false;
-    localiser_statevec_anyCtrlAnyTargAnyMatr(qureg, ctrlVec, stateVec, targVec, matr, conj);
+    localiser_statevec_anyCtrlAnyTargAnyMatr(qureg, ctrlList, stateList, targList, matr, conj);
 
     if (!qureg.isDensityMatrix)
         return;
 
     conj = true;
-    ctrlVec = util_getBraQubits(ctrlVec, qureg);
-    targVec = util_getBraQubits(targVec, qureg);
-    localiser_statevec_anyCtrlAnyTargAnyMatr(qureg, ctrlVec, stateVec, targVec, matr, conj);
+    ctrlList = util_getBraQubits(ctrlList, qureg);
+    targList = util_getBraQubits(targList, qureg);
+    localiser_statevec_anyCtrlAnyTargAnyMatr(qureg, ctrlList, stateList, targList, matr, conj);
 
     /// @todo
     /// the above logic always performs two in-turn operations upon density matrices, 
@@ -410,18 +410,18 @@ void applyMultiStateControlledDiagMatrPower(Qureg qureg, int* controls, int* sta
     // when numerical validation is disabled without a separate func.
 
     bool conj = false;
-    auto ctrlVec = util_getVector(controls, numControls);
-    auto stateVec = util_getVector(states,  numControls); // empty if states==nullptr
-    auto targVec = util_getVector(targets,  numTargets);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, ctrlVec, stateVec, targVec, matrix, exponent, conj);
+    auto ctrlList = list_getSmallList(controls, numControls);
+    auto stateList = list_getSmallList(states,  numControls); // empty if states==nullptr
+    auto targList = list_getSmallList(targets,  numTargets);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, ctrlList, stateList, targList, matrix, exponent, conj);
 
     if (!qureg.isDensityMatrix)
         return;
 
     conj = true;
-    ctrlVec = util_getBraQubits(ctrlVec, qureg);
-    targVec = util_getBraQubits(targVec, qureg);
-    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, ctrlVec, stateVec, targVec, matrix, exponent, conj);
+    ctrlList = util_getBraQubits(ctrlList, qureg);
+    targList = util_getBraQubits(targList, qureg);
+    localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, ctrlList, stateList, targList, matrix, exponent, conj);
 }
 
 } // end de-mangler
@@ -678,17 +678,17 @@ void applyMultiStateControlledSwap(Qureg qureg, int* controls, int* states, int 
     validate_controlsAndTwoTargets(qureg, controls, numControls, qubit1, qubit2, __func__);
     validate_controlStates(states, numControls, __func__); // permits states==nullptr
 
-    auto ctrlVec = util_getVector(controls, numControls);
-    auto stateVec = util_getVector(states, numControls); // empty if states==nullptr
-    localiser_statevec_anyCtrlSwap(qureg, ctrlVec, stateVec, qubit1, qubit2);
+    auto ctrlList = list_getSmallList(controls, numControls);
+    auto stateList = list_getSmallList(states, numControls); // empty if states==nullptr
+    localiser_statevec_anyCtrlSwap(qureg, ctrlList, stateList, qubit1, qubit2);
 
     if (!qureg.isDensityMatrix)
         return;
 
-    ctrlVec = util_getBraQubits(ctrlVec, qureg);
+    ctrlList = util_getBraQubits(ctrlList, qureg);
     qubit1 = util_getBraQubit(qubit1, qureg);
     qubit2 = util_getBraQubit(qubit2, qureg);
-    localiser_statevec_anyCtrlSwap(qureg, ctrlVec, stateVec, qubit1, qubit2);
+    localiser_statevec_anyCtrlSwap(qureg, ctrlList, stateList, qubit1, qubit2);
 }
 
 } // end de-mangler
@@ -966,27 +966,27 @@ void applyMultiStateControlledPauliStr(Qureg qureg, int* controls, int* states, 
     validate_controlStates(states, numControls, __func__); // permits states==nullptr
 
     qcomp factor = 1;
-    auto ctrlVec = util_getVector(controls, numControls);
-    auto stateVec = util_getVector(states, numControls); // empty if states==nullptr
+    auto ctrlList = list_getSmallList(controls, numControls);
+    auto stateList = list_getSmallList(states, numControls); // empty if states==nullptr
 
     // when there are no control qubits, we can merge the density matrix's 
     // operation sinto a single tensor, i.e. +- (shift(str) (x) str), to 
     // avoid superfluous re-enumeration of the state
     if (qureg.isDensityMatrix && numControls == 0) {
         factor = paulis_getSignOfPauliStrConj(str);
-        ctrlVec = util_getConcatenated(ctrlVec, util_getBraQubits(ctrlVec, qureg));
-        stateVec = util_getConcatenated(stateVec, stateVec); 
+        ctrlList = util_getConcatenated(ctrlList, util_getBraQubits(ctrlList, qureg));
+        stateList = util_getConcatenated(stateList, stateList); 
         str = paulis_getKetAndBraPauliStr(str, qureg);
     }
 
-    localiser_statevec_anyCtrlPauliTensor(qureg, ctrlVec, stateVec, str, factor);
+    localiser_statevec_anyCtrlPauliTensor(qureg, ctrlList, stateList, str, factor);
 
     // but density-matrix control qubits require two distinct operations
     if (qureg.isDensityMatrix && numControls > 0) {
         factor = paulis_getSignOfPauliStrConj(str);
-        ctrlVec = util_getBraQubits(ctrlVec, qureg);
+        ctrlList = util_getBraQubits(ctrlList, qureg);
         str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-        localiser_statevec_anyCtrlPauliTensor(qureg, ctrlVec, stateVec, str, factor);
+        localiser_statevec_anyCtrlPauliTensor(qureg, ctrlList, stateList, str, factor);
     }
 }
 
@@ -1250,7 +1250,8 @@ void applyNonUnitaryPauliGadget(Qureg qureg, PauliStr str, qcomp angle) {
     validate_pauliStrTargets(qureg, str, __func__);
 
     qcomp phase = util_getPhaseFromGateAngle(angle);
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
+    auto none = list_getEmptySmallList();
+    localiser_statevec_anyCtrlPauliGadget(qureg, none, none, str, phase);
 
     if (!qureg.isDensityMatrix)
         return;
@@ -1258,7 +1259,7 @@ void applyNonUnitaryPauliGadget(Qureg qureg, PauliStr str, qcomp angle) {
     // conj(e^i(a)P) = e^(-i s conj(a) P)
     phase = - std::conj(phase) * paulis_getSignOfPauliStrConj(str);
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliGadget(qureg, {}, {}, str, phase);
+    localiser_statevec_anyCtrlPauliGadget(qureg, none, none, str, phase);
 }
 
 void applyControlledPauliGadget(Qureg qureg, int control, PauliStr str, qreal angle) {
@@ -1291,18 +1292,18 @@ void applyMultiStateControlledPauliGadget(Qureg qureg, int* controls, int* state
     // which is sufficiently efficient using the existing gadget backend function
 
     qreal phase = util_getPhaseFromGateAngle(angle);
-    auto ctrlVec = util_getVector(controls, numControls);
-    auto stateVec = util_getVector(states, numControls); // empty if states==nullptr
-    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlVec, stateVec, str, phase);
+    auto ctrlList = list_getSmallList(controls, numControls);
+    auto stateList = list_getSmallList(states, numControls); // empty if states==nullptr
+    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlList, stateList, str, phase);
 
     if (!qureg.isDensityMatrix)
         return;
 
     // conj(e^(i a P)) = e^(-i s a P)
     phase *= - paulis_getSignOfPauliStrConj(str);
-    ctrlVec = util_getBraQubits(ctrlVec, qureg);
+    ctrlList = util_getBraQubits(ctrlList, qureg);
     str = paulis_getShiftedPauliStr(str, qureg.numQubits);
-    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlVec, stateVec, str, phase);
+    localiser_statevec_anyCtrlPauliGadget(qureg, ctrlList, stateList, str, phase);
 }
 
 } // end de-mangler
@@ -1356,18 +1357,18 @@ void applyMultiStateControlledPhaseGadget(Qureg qureg, int* controls, int* state
     validate_controlStates(states, numControls, __func__);
 
     qreal phase = util_getPhaseFromGateAngle(angle);
-    auto ctrlVec = util_getVector(controls, numControls);
-    auto targVec = util_getVector(targets,  numTargets);
-    auto stateVec = util_getVector(states,  numControls); // empty if states==nullptr
-    localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlVec, stateVec, targVec, phase);
+    auto ctrlList = list_getSmallList(controls, numControls);
+    auto targList = list_getSmallList(targets,  numTargets);
+    auto stateList = list_getSmallList(states,  numControls); // empty if states==nullptr
+    localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlList, stateList, targList, phase);
 
     if (!qureg.isDensityMatrix)
         return;
 
     phase *= -1;
-    ctrlVec = util_getBraQubits(ctrlVec, qureg);
-    targVec = util_getBraQubits(targVec, qureg);
-    localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlVec, stateVec, targVec, phase);
+    ctrlList = util_getBraQubits(ctrlList, qureg);
+    targList = util_getBraQubits(targList, qureg);
+    localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlList, stateList, targList, phase);
 }
 
 } // end de-mangler
@@ -1561,10 +1562,13 @@ void applyQubitProjector(Qureg qureg, int target, int outcome) {
     
     qreal prob = 1;
 
+    auto targList    = list_getSmallList({target});
+    auto outcomeList = list_getSmallList({outcome});
+
     // density matrix has an optimised func in lieu of calling the statevector func twice
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, {target}, {outcome}, prob):
-        localiser_statevec_multiQubitProjector(qureg, {target}, {outcome}, prob);
+        localiser_densmatr_multiQubitProjector(qureg, targList, outcomeList, prob):
+        localiser_statevec_multiQubitProjector(qureg, targList, outcomeList, prob);
 }
 
 void applyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQubits) {
@@ -1573,13 +1577,13 @@ void applyMultiQubitProjector(Qureg qureg, int* qubits, int* outcomes, int numQu
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
 
     qreal prob = 1;
-    auto qubitVec = util_getVector(qubits, numQubits);
-    auto outcomeVec = util_getVector(outcomes, numQubits);
+    auto qubitList = list_getSmallList(qubits, numQubits);
+    auto outcomeList = list_getSmallList(outcomes, numQubits);
 
     // density matrix has an optimised func in lieu of calling the statevector func twice
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, qubitVec, outcomeVec, prob):
-        localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, prob);
+        localiser_densmatr_multiQubitProjector(qureg, qubitList, outcomeList, prob):
+        localiser_statevec_multiQubitProjector(qureg, qubitList, outcomeList, prob);
 }
 
 } // end de-mangler
@@ -1623,10 +1627,13 @@ int applyQubitMeasurementAndGetProb(Qureg qureg, int target, qreal* probability)
     int outcome = rand_getRandomSingleQubitOutcome(probs[0]);
     *probability = probs[outcome];
 
+    auto targList    = list_getSmallList({target});
+    auto outcomeList = list_getSmallList({outcome});
+
     // collapse to the outcome
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, {target}, {outcome}, *probability):
-        localiser_statevec_multiQubitProjector(qureg, {target}, {outcome}, *probability);
+        localiser_densmatr_multiQubitProjector(qureg, targList, outcomeList, *probability):
+        localiser_statevec_multiQubitProjector(qureg, targList, outcomeList, *probability);
 
     return outcome;
 }
@@ -1642,10 +1649,13 @@ qreal applyForcedQubitMeasurement(Qureg qureg, int target, int outcome) {
     qreal prob = calcProbOfQubitOutcome(qureg, target, outcome); // harmlessly re-validates
     validate_measurementOutcomeProbNotZero(outcome, prob, __func__);
 
+    auto targList    = list_getSmallList({target});
+    auto outcomeList = list_getSmallList({outcome});
+
     // project to the outcome, renormalising the surviving states
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, {target}, {outcome}, prob):
-        localiser_statevec_multiQubitProjector(qureg, {target}, {outcome}, prob);
+        localiser_densmatr_multiQubitProjector(qureg, targList, outcomeList, prob):
+        localiser_statevec_multiQubitProjector(qureg, targList, outcomeList, prob);
 
     return prob;
 }
@@ -1683,14 +1693,14 @@ qindex applyMultiQubitMeasurementAndGetProb(Qureg qureg, int* qubits, int numQub
     *probability = probs[outcome];
 
     // map outcome to individual qubit outcomes
-    auto qubitVec = util_getVector(qubits, numQubits);
-    auto outcomeVec = vector<int>(numQubits);
-    getBitsFromInteger(outcomeVec.data(), outcome, numQubits);
+    auto qubitList = list_getSmallList(qubits, numQubits);
+    auto outcomeList = list_getEmptySmallList();
+    getBitsFromInteger(outcomeList.data(), outcome, numQubits);
 
     // project to the outcomes, renormalising the surviving states
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, qubitVec, outcomeVec, *probability):
-        localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, *probability);
+        localiser_densmatr_multiQubitProjector(qureg, qubitList, outcomeList, *probability):
+        localiser_statevec_multiQubitProjector(qureg, qubitList, outcomeList, *probability);
 
     return outcome;
 }
@@ -1700,8 +1710,8 @@ qreal applyForcedMultiQubitMeasurement(Qureg qureg, int* qubits, int* outcomes, 
     validate_targets(qureg, qubits, numQubits, __func__);
     validate_measurementOutcomesAreValid(outcomes, numQubits, __func__);
 
-    auto qubitVec = util_getVector(qubits, numQubits);
-    auto outcomeVec = util_getVector(outcomes, numQubits);
+    auto qubitList = list_getSmallList(qubits, numQubits);
+    auto outcomeList = list_getSmallList(outcomes, numQubits);
 
     // ensure probability of the forced measurement outcome is not negligible
     qreal prob = calcProbOfMultiQubitOutcome(qureg, qubits, outcomes, numQubits); // harmlessly re-validates
@@ -1709,8 +1719,8 @@ qreal applyForcedMultiQubitMeasurement(Qureg qureg, int* qubits, int* outcomes, 
 
     // project to the outcome, renormalising the surviving states
     (qureg.isDensityMatrix)?
-        localiser_densmatr_multiQubitProjector(qureg, qubitVec, outcomeVec, prob):
-        localiser_statevec_multiQubitProjector(qureg, qubitVec, outcomeVec, prob);
+        localiser_densmatr_multiQubitProjector(qureg, qubitList, outcomeList, prob):
+        localiser_statevec_multiQubitProjector(qureg, qubitList, outcomeList, prob);
 
     return prob;
 }
@@ -1782,11 +1792,7 @@ void applyQuantumFourierTransform(Qureg qureg, int* targets, int numTargets, boo
 void applyFullQuantumFourierTransform(Qureg qureg, bool inverse) {
     validate_quregFields(qureg, __func__);
 
-    // tiny; no need to validate alloc
-    vector<int> targets(qureg.numQubits);
-    for (size_t i=0; i<targets.size(); i++)
-        targets[i] = i;
-
+    auto targets = util_getRange(qureg.numQubits);
     applyQuantumFourierTransform(qureg, targets.data(), targets.size(), inverse);
 }
 

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1694,7 +1694,7 @@ qindex applyMultiQubitMeasurementAndGetProb(Qureg qureg, int* qubits, int numQub
 
     // map outcome to individual qubit outcomes
     auto qubitList = list_getSmallList(qubits, numQubits);
-    auto outcomeList = list_getEmptySmallList();
+    auto outcomeList = util_getConstantList(-1, numQubits);
     getBitsFromInteger(outcomeList.data(), outcome, numQubits);
 
     // project to the outcomes, renormalising the surviving states

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -43,7 +43,7 @@ void validateAndApplyAnyCtrlAnyTargUnitaryMatrix(Qureg qureg, int* ctrls, int* s
         validate_mixedAmpsFitInNode(qureg, numTargs, caller);
 
     SmallList ctrlList  = list_getSmallList(ctrls,  numCtrls);
-    SmallList stateList = list_getSmallList(states, numCtrls);
+    SmallList stateList = list_getSmallList(states, numCtrls * (states != nullptr));
     SmallList targList  = list_getSmallList(targs,  numTargs);
 
     bool conj = false;
@@ -411,7 +411,7 @@ void applyMultiStateControlledDiagMatrPower(Qureg qureg, int* controls, int* sta
 
     bool conj = false;
     auto ctrlList = list_getSmallList(controls, numControls);
-    auto stateList = list_getSmallList(states,  numControls); // empty if states==nullptr
+    auto stateList = list_getSmallList(states,  numControls * (states != nullptr));
     auto targList = list_getSmallList(targets,  numTargets);
     localiser_statevec_anyCtrlAnyTargDiagMatr(qureg, ctrlList, stateList, targList, matrix, exponent, conj);
 
@@ -679,7 +679,7 @@ void applyMultiStateControlledSwap(Qureg qureg, int* controls, int* states, int 
     validate_controlStates(states, numControls, __func__); // permits states==nullptr
 
     auto ctrlList = list_getSmallList(controls, numControls);
-    auto stateList = list_getSmallList(states, numControls); // empty if states==nullptr
+    auto stateList = list_getSmallList(states, numControls * (states != nullptr));
     localiser_statevec_anyCtrlSwap(qureg, ctrlList, stateList, qubit1, qubit2);
 
     if (!qureg.isDensityMatrix)
@@ -967,7 +967,7 @@ void applyMultiStateControlledPauliStr(Qureg qureg, int* controls, int* states, 
 
     qcomp factor = 1;
     auto ctrlList = list_getSmallList(controls, numControls);
-    auto stateList = list_getSmallList(states, numControls); // empty if states==nullptr
+    auto stateList = list_getSmallList(states, numControls * (states != nullptr));
 
     // when there are no control qubits, we can merge the density matrix's 
     // operation sinto a single tensor, i.e. +- (shift(str) (x) str), to 
@@ -1293,7 +1293,7 @@ void applyMultiStateControlledPauliGadget(Qureg qureg, int* controls, int* state
 
     qreal phase = util_getPhaseFromGateAngle(angle);
     auto ctrlList = list_getSmallList(controls, numControls);
-    auto stateList = list_getSmallList(states, numControls); // empty if states==nullptr
+    auto stateList = list_getSmallList(states, numControls * (states != nullptr));
     localiser_statevec_anyCtrlPauliGadget(qureg, ctrlList, stateList, str, phase);
 
     if (!qureg.isDensityMatrix)
@@ -1358,8 +1358,8 @@ void applyMultiStateControlledPhaseGadget(Qureg qureg, int* controls, int* state
 
     qreal phase = util_getPhaseFromGateAngle(angle);
     auto ctrlList = list_getSmallList(controls, numControls);
+    auto stateList = list_getSmallList(states,  numControls * (states != nullptr));
     auto targList = list_getSmallList(targets,  numTargets);
-    auto stateList = list_getSmallList(states,  numControls); // empty if states==nullptr
     localiser_statevec_anyCtrlPhaseGadget(qureg, ctrlList, stateList, targList, phase);
 
     if (!qureg.isDensityMatrix)

--- a/quest/src/api/trotterisation.cpp
+++ b/quest/src/api/trotterisation.cpp
@@ -11,6 +11,7 @@
 #include "quest/include/matrices.h"
 
 #include "quest/src/core/validation.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/localiser.hpp"
 #include "quest/src/core/paulilogic.hpp"
@@ -29,8 +30,8 @@ using std::vector;
  */
 
 void internal_applyFirstOrderTrotterRepetition(
-    Qureg qureg, vector<int>& ketCtrls, vector<int>& braCtrls,
-    vector<int>& states, PauliStrSum sum, vector<qindex>& sumOrdering,
+    Qureg qureg, SmallList& ketCtrls, SmallList& braCtrls,
+    SmallList& states, PauliStrSum sum, vector<qindex>& sumOrdering,
     qcomp angle, bool onlyLeftApply, bool reverse
 ) {
     // apply each sum term as a gadget, in forward or reverse order
@@ -62,8 +63,8 @@ void internal_applyFirstOrderTrotterRepetition(
 }
 
 void internal_applyHigherOrderTrotterRepetition(
-    Qureg qureg, vector<int>& ketCtrls, vector<int>& braCtrls,
-    vector<int>& states, PauliStrSum sum, vector<qindex>& sumOrdering, 
+    Qureg qureg, SmallList& ketCtrls, SmallList& braCtrls,
+    SmallList& states, PauliStrSum sum, vector<qindex>& sumOrdering, 
     qcomp angle, int order, bool onlyLeftApply
 ) {
     if (order == 1) {
@@ -107,9 +108,9 @@ void internal_applyAllTrotterRepetitions(
     }
 
     // prepare control-qubit lists once for all invoked gadgets below
-    auto ketCtrlsVec = util_getVector(controls, numControls);
-    auto braCtrlsVec = (qureg.isDensityMatrix)? util_getBraQubits(ketCtrlsVec, qureg) : vector<int>{};
-    auto statesVec = util_getVector(states, numControls);
+    auto ketCtrlsList = list_getSmallList(controls, numControls);
+    auto braCtrlsList = (qureg.isDensityMatrix)? util_getBraQubits(ketCtrlsList, qureg) : list_getEmptySmallList();
+    auto statesList = list_getSmallList(states, numControls);
 
     qcomp arg = angle / reps;
 
@@ -120,7 +121,7 @@ void internal_applyAllTrotterRepetitions(
             rand_setListToShuffled(sumOrdering);
 
         internal_applyHigherOrderTrotterRepetition(
-            qureg, ketCtrlsVec, braCtrlsVec, statesVec, sum, sumOrdering, arg, order, onlyLeftApply);
+            qureg, ketCtrlsList, braCtrlsList, statesList, sum, sumOrdering, arg, order, onlyLeftApply);
     }
 }
 

--- a/quest/src/api/trotterisation.cpp
+++ b/quest/src/api/trotterisation.cpp
@@ -110,7 +110,7 @@ void internal_applyAllTrotterRepetitions(
     // prepare control-qubit lists once for all invoked gadgets below
     auto ketCtrlsList = list_getSmallList(controls, numControls);
     auto braCtrlsList = (qureg.isDensityMatrix)? util_getBraQubits(ketCtrlsList, qureg) : list_getEmptySmallList();
-    auto statesList = list_getSmallList(states, numControls);
+    auto statesList = list_getSmallList(states, numControls * (states != nullptr));
 
     qcomp arg = angle / reps;
 

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -23,6 +23,7 @@
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/memory.hpp"
 #include "quest/src/core/bitwise.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/cpu/cpu_config.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
 #include "quest/src/cpu/cpu_subroutines.hpp"
@@ -244,7 +245,7 @@ void accel_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliS
  */
 
 
-qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubits, vector<int> qubitStates) {
+qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubits, SmallList qubitStates) {
 
     // we can never pack and swap buffers when there are no constrained qubit states, because we'd 
     // then fill the entire buffer andhave no room to receive the other node's buffer; caller would 
@@ -274,17 +275,17 @@ qindex accel_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int 
  */
 
 
-void accel_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
+void accel_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlSwap_subA, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, targ1, targ2);
 }
-void accel_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) {
+void accel_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlSwap_subB, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates);
 }
-void accel_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) {
+void accel_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlSwap_subC, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, targ, targState);
@@ -297,26 +298,26 @@ void accel_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int>
  */
 
 
-void accel_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr) {
+void accel_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlOneTargDenseMatr_subA, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, targ, matr);
 }
-void accel_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1) {
+void accel_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, qcomp fac0, qcomp fac1) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlOneTargDenseMatr_subB, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, fac0, fac1);
 }
 
 
-void accel_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr) {
+void accel_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlTwoTargDenseMatr_sub, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, targ1, targ2, matr);
 }
 
 
-void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr, bool conj, bool transp) {
+void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr, bool conj, bool transp) {
 
     auto func = GET_CPU_OR_GPU_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( statevec_anyCtrlAnyTargDenseMatr_sub, qureg, ctrls.size(), targs.size(), conj, transp );
     func(qureg, ctrls, ctrlStates, targs, matr);
@@ -329,21 +330,21 @@ void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, 
  */
 
 
-void accel_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr) {
+void accel_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlOneTargDiagMatr_sub, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, targ, matr);
 }
 
 
-void accel_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr) {
+void accel_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevec_anyCtrlTwoTargDiagMatr_sub, qureg, ctrls.size() );
     func(qureg, ctrls, ctrlStates, targ1, targ2, matr);
 }
 
 
-void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent, bool conj) {
+void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent, bool conj) {
 
     bool hasPower = exponent != qcomp(1, 0);
 
@@ -520,7 +521,7 @@ void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qc
  */
 
 
-void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> states, vector<int> x, vector<int> y, vector<int> z, qcomp f0, qcomp f1) {
+void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, SmallList ctrls, SmallList states, SmallList x, SmallList y, SmallList z, qcomp f0, qcomp f1) {
 
     // only X and Y constitute target qubits (Z merely induces a phase)
     int numTargs = x.size() + y.size();
@@ -528,14 +529,14 @@ void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( statevector_anyCtrlPauliTensorOrGadget_subA, qureg, ctrls.size(), numTargs );
     func(qureg, ctrls, states, x, y, z, f0, f1);
 }
-void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> states, vector<int> x, vector<int> y, vector<int> z, qcomp f0, qcomp f1, qindex mask) {
+void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, SmallList ctrls, SmallList states, SmallList x, SmallList y, SmallList z, qcomp f0, qcomp f1, qindex mask) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevector_anyCtrlPauliTensorOrGadget_subB, qureg, ctrls.size() );
     func(qureg, ctrls, states, x, y, z, f0, f1, mask);
 }
 
 
-void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> states, vector<int> targs, qcomp f0, qcomp f1) {
+void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, SmallList ctrls, SmallList states, SmallList targs, qcomp f0, qcomp f1) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_CTRLS( statevector_anyCtrlAnyTargZOrPhaseGadget_sub, qureg, ctrls.size() );
     func(qureg, ctrls, states, targs, f0, f1);
@@ -845,7 +846,7 @@ void accel_densmatr_oneQubitDamping_subD(Qureg qureg, int qubit, qreal prob) {
  */
 
 
-void accel_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> targs, vector<int> pairTargs) {
+void accel_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targs, SmallList pairTargs) {
     assert_partialTraceQuregsAreIdenticallyDeployed(inQureg, outQureg);
 
     auto cpuFunc = GET_FUNC_OPTIMISED_FOR_NUM_TARGS( cpu_densmatr_partialTrace_sub, targs.size() );
@@ -877,24 +878,24 @@ qreal accel_densmatr_calcTotalProb_sub(Qureg qureg) {
 }
 
 
-qreal accel_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal accel_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_TARGS( statevec_calcProbOfMultiQubitOutcome_sub, qureg, qubits.size() );
     return func(qureg, qubits, outcomes);
 }
-qreal accel_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal accel_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_TARGS( densmatr_calcProbOfMultiQubitOutcome_sub, qureg, qubits.size() );
     return func(qureg, qubits, outcomes);
 }
 
 
-void accel_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void accel_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_TARGS( statevec_calcProbsOfAllMultiQubitOutcomes_sub, qureg, qubits.size() );
     func(outProbs, qureg, qubits);
 }
-void accel_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void accel_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_TARGS( densmatr_calcProbsOfAllMultiQubitOutcomes_sub, qureg, qubits.size() );
     func(outProbs, qureg, qubits);
@@ -982,13 +983,13 @@ qcomp accel_densmatr_calcFidelityWithPureState_sub(Qureg rho, Qureg psi, bool co
  */
 
 
-qreal accel_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qreal accel_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
     return (qureg.isGpuAccelerated)?
         gpu_statevec_calcExpecAnyTargZ_sub(qureg, targs):
         cpu_statevec_calcExpecAnyTargZ_sub(qureg, targs);
 }
-qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
     return (qureg.isGpuAccelerated)?
         gpu_densmatr_calcExpecAnyTargZ_sub(qureg, targs):
@@ -996,19 +997,19 @@ qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     return (qureg.isGpuAccelerated)?
         gpu_statevec_calcExpecPauliStr_subA(qureg, x, y, z):
         cpu_statevec_calcExpecPauliStr_subA(qureg, x, y, z);
 }
-qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     return (qureg.isGpuAccelerated)?
         gpu_statevec_calcExpecPauliStr_subB(qureg, x, y, z):
         cpu_statevec_calcExpecPauliStr_subB(qureg, x, y, z);
 }
-qcomp accel_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp accel_densmatr_calcExpecPauliStr_sub(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     return (qureg.isGpuAccelerated)?
         gpu_densmatr_calcExpecPauliStr_sub(qureg, x, y, z):
@@ -1110,12 +1111,12 @@ qcomp accel_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMa
  */
 
 
-void accel_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void accel_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_TARGS( statevec_multiQubitProjector_sub, qureg, qubits.size() );
     func(qureg, qubits, outcomes, prob);
 }
-void accel_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void accel_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     auto func = GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_NUM_TARGS( densmatr_multiQubitProjector_sub, qureg, qubits.size() );
     func(qureg, qubits, outcomes, prob);

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -24,6 +24,8 @@
 #include "quest/include/qureg.h"
 #include "quest/include/matrices.h"
 
+#include "quest/src/core/small_list.hpp"
+
 #include <vector>
 
 using std::vector;
@@ -175,7 +177,7 @@ void accel_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliS
  * COMMUNICATION BUFFER PACKING
  */
 
-qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubits, vector<int> qubitStates);
+qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubits, SmallList qubitStates);
 
 qindex accel_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 
@@ -184,32 +186,32 @@ qindex accel_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int 
  * SWAPS
  */
 
-void accel_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2);
-void accel_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates);
-void accel_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState);
+void accel_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2);
+void accel_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates);
+void accel_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState);
 
 
 /*
  * DENSE MATRICES
  */
 
-void accel_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr);
-void accel_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1);
+void accel_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr);
+void accel_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, qcomp fac0, qcomp fac1);
 
-void accel_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr);
+void accel_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr);
 
-void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr, bool conj, bool transp);
+void accel_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr, bool conj, bool transp);
 
 
 /*
  * DIAGONAL MATRICES
  */
 
-void accel_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr);
+void accel_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr);
 
-void accel_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr);
+void accel_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr);
 
-void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent, bool conj);
+void accel_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent, bool conj);
 
 void accel_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
@@ -222,10 +224,10 @@ void accel_densmatr_allTargDiagMatr_subB(Qureg qureg, FullStateDiagMatr matr, qc
  * PAULI TENSOR AND GADGET
  */
 
-void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
+void accel_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList z, qcomp ampFac, qcomp pairAmpFac);
 
-void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
-void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
+void accel_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac);
+void accel_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
 
 
 /*
@@ -273,7 +275,7 @@ void accel_densmatr_oneQubitDamping_subD(Qureg qureg, int qubit, qreal prob);
  * PARTIAL TRACE
  */
 
-void accel_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> targs, vector<int> pairTargs);
+void accel_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targs, SmallList pairTargs);
 
 
 /*
@@ -283,11 +285,11 @@ void accel_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> 
 qreal accel_statevec_calcTotalProb_sub(Qureg qureg);
 qreal accel_densmatr_calcTotalProb_sub(Qureg qureg);
 
-qreal accel_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes);
-qreal accel_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes);
+qreal accel_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes);
+qreal accel_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes);
 
-void accel_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits);
-void accel_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits);
+void accel_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits);
+void accel_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits);
 
 
 /*
@@ -305,12 +307,12 @@ qreal accel_densmatr_calcHilbertSchmidtDistance_sub(Qureg quregA, Qureg quregB);
  * EXPECTATION VALUES
  */
 
-qreal accel_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> sufTargs);
-qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> allTargs);;
+qreal accel_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList sufTargs);
+qcomp accel_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList allTargs);;
 
-qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
-qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
-qcomp accel_densmatr_calcExpecPauliStr_sub (Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp accel_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z);
+qcomp accel_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z);
+qcomp accel_densmatr_calcExpecPauliStr_sub (Qureg qureg, SmallList x, SmallList y, SmallList z);
 
 qcomp accel_statevec_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool useRealPow);
 qcomp accel_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool useRealPow);
@@ -320,8 +322,8 @@ qcomp accel_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMa
  * PROJECTORS 
  */
 
-void accel_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
-void accel_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
+void accel_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
+void accel_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
 
 
 /*

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -777,6 +777,11 @@ void error_smallListWasEmpty() {
     raiseInternalError("A SmallList was unexpectedly empty.");
 }
 
+void error_smallListNullPtrWithPositiveLength() {
+
+    raiseInternalError("The SmallList constructor was given a nullptr yet a non-zero length.");
+}
+
 
 
 /*

--- a/quest/src/core/errors.cpp
+++ b/quest/src/core/errors.cpp
@@ -754,6 +754,32 @@ void error_pauliStrSumConjHasIncorrectNumTerms() {
 
 
 /*
+ * LIST ERRORS 
+ */
+
+void error_smallListLengthExceededMax() {
+
+    raiseInternalError("A SmallList was attemptedly allocated or grown to an illegally large size.");
+}
+
+void error_smallListIndexWasNegative() {
+
+    raiseInternalError("A SmallList index was negative.");
+}
+
+void error_smallListIndexExceededLength() {
+
+    raiseInternalError("A SmallList index equalled or exceeded the list length.");
+}
+
+void error_smallListWasEmpty() {
+
+    raiseInternalError("A SmallList was unexpectedly empty.");
+}
+
+
+
+/*
  * UTILITY ERRORS 
  */
 

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -302,6 +302,20 @@ void error_pauliStrSumConjHasIncorrectNumTerms();
 
 
 /*
+ * LIST ERRORS 
+ */
+
+void error_smallListLengthExceededMax();
+
+void error_smallListIndexWasNegative();
+
+void error_smallListIndexExceededLength();
+
+void error_smallListWasEmpty();
+
+
+
+/*
  * UTILITY ERRORS 
  */
 

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -313,6 +313,8 @@ void error_smallListIndexExceededLength();
 
 void error_smallListWasEmpty();
 
+void error_smallListNullPtrWithPositiveLength();
+
 
 
 /*

--- a/quest/src/core/errors.hpp
+++ b/quest/src/core/errors.hpp
@@ -4,6 +4,12 @@
  * hardware accelerators are behaving as expected, and that runtime
  * deployment is consistent with the compiled deployment modes.
  * 
+ * Some error() functions are explicitly marked as [[noreturn]] so that
+ * the compiler knows code after their invocation is never executed,
+ * avoiding warnings about (e.g.) invalid static array indexing. In
+ * theory, all error() functions can be [[noreturn]], but we only
+ * bother with the ones that make a compile-time difference.
+ * 
  * @author Tyson Jones
  * @author Luc Jaulmes (NUMA & pagesize errors)
  */
@@ -305,15 +311,15 @@ void error_pauliStrSumConjHasIncorrectNumTerms();
  * LIST ERRORS 
  */
 
-void error_smallListLengthExceededMax();
+[[noreturn]] void error_smallListLengthExceededMax();
 
-void error_smallListIndexWasNegative();
+[[noreturn]] void error_smallListIndexWasNegative();
 
-void error_smallListIndexExceededLength();
+[[noreturn]] void error_smallListIndexExceededLength();
 
-void error_smallListWasEmpty();
+[[noreturn]] void error_smallListWasEmpty();
 
-void error_smallListNullPtrWithPositiveLength();
+[[noreturn]] void error_smallListNullPtrWithPositiveLength();
 
 
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -65,8 +65,7 @@ void setDefaultCtrlStates(SmallList ctrls, SmallList &states) {
 
     // default ctrl state is all-1
     if (states.empty())
-        for (auto _ : ctrls)
-            states.push_back(1);
+        states.assign(ctrls.size(), 1);
 }
 
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -135,8 +135,9 @@ void removePrefixQubitsAndStates(Qureg qureg, SmallList &qubits, SmallList &stat
 
     for (int i=0; i<oldLength; i++) {
         if (util_isQubitInSuffix(qubits[i], qureg)) {
-            qubits[newLength++] = qubits[i];
-            qubits[newLength++] = states[i];
+            qubits[newLength] = qubits[i];
+            states[newLength] = states[i];
+            newLength++;
         }
     }
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -18,6 +18,7 @@
 
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/paulilogic.hpp"
 #include "quest/src/core/localiser.hpp"
@@ -44,7 +45,7 @@ using std::tuple;
  */
 
 
-void assertValidCtrlStates(vector<int> ctrls, vector<int> ctrlStates) {
+void assertValidCtrlStates(SmallList ctrls, SmallList ctrlStates) {
 
     // providing no control states is always valid (to invoke default all-on-1)
     if (ctrlStates.empty())
@@ -56,7 +57,7 @@ void assertValidCtrlStates(vector<int> ctrls, vector<int> ctrlStates) {
 }
 
 
-void setDefaultCtrlStates(vector<int> ctrls, vector<int> &states) {
+void setDefaultCtrlStates(SmallList ctrls, SmallList &states) {
 
     // no states necessary if there are no control qubits
     if (ctrls.empty())
@@ -64,11 +65,12 @@ void setDefaultCtrlStates(vector<int> ctrls, vector<int> &states) {
 
     // default ctrl state is all-1
     if (states.empty())
-        states.insert(states.end(), ctrls.size(), 1);
+        for (auto _ : ctrls)
+            states.push_back(1);
 }
 
 
-bool doesGateRequireComm(Qureg qureg, vector<int> targs) {
+bool doesGateRequireComm(Qureg qureg, SmallList targs) {
 
     // non-distributed quregs never communicate (duh)
     if (!qureg.isDistributed)
@@ -80,11 +82,11 @@ bool doesGateRequireComm(Qureg qureg, vector<int> targs) {
 
 bool doesGateRequireComm(Qureg qureg, int targ) {
 
-    return doesGateRequireComm(qureg, vector{targ});
+    return doesGateRequireComm(qureg, list_getSmallList({targ}));
 }
 
 
-bool doesChannelRequireComm(Qureg qureg, vector<int> ketQubits) {
+bool doesChannelRequireComm(Qureg qureg, SmallList ketQubits) {
     if (!qureg.isDensityMatrix)
         error_localiserPassedStateVecToChannelComCheck();
 
@@ -96,11 +98,11 @@ bool doesChannelRequireComm(Qureg qureg, vector<int> ketQubits) {
 
 bool doesChannelRequireComm(Qureg qureg, int ketQubit) {
 
-    return doesChannelRequireComm(qureg, vector{ketQubit});
+    return doesChannelRequireComm(qureg, list_getSmallList({ketQubit}));
 }
 
 
-bool doAnyLocalStatesHaveQubitValues(Qureg qureg, vector<int> qubits, vector<int> states) {
+bool doAnyLocalStatesHaveQubitValues(Qureg qureg, SmallList qubits, SmallList states) {
 
     // this answers the generic question of "do any of the given qubits lie in the
     // prefix substate with node-fixed values inconsistent with the given states?"
@@ -126,25 +128,24 @@ bool doAnyLocalStatesHaveQubitValues(Qureg qureg, vector<int> qubits, vector<int
 }
 
 
-void removePrefixQubitsAndStates(Qureg qureg, vector<int> &qubits, vector<int> &states) {
+void removePrefixQubitsAndStates(Qureg qureg, SmallList &qubits, SmallList &states) {
 
-    vector<int> suffixQubits(0);  suffixQubits.reserve(qubits.size());
-    vector<int> suffixStates(0);  suffixStates.reserve(states.size());
+    int oldLength = qubits.size();
+    int newLength = 0;
 
-    // collect suffix qubits/states
-    for (size_t i=0; i<qubits.size(); i++)
+    for (int i=0; i<oldLength; i++) {
         if (util_isQubitInSuffix(qubits[i], qureg)) {
-            suffixQubits.push_back(qubits[i]);
-            suffixStates.push_back(states[i]);
+            qubits[newLength++] = qubits[i];
+            qubits[newLength++] = states[i];
         }
+    }
 
-    // overwrite given vectors
-    qubits = suffixQubits;
-    states = suffixStates;
+    qubits.resize(newLength);
+    states.resize(newLength);
 }
 
 
-auto getCtrlsAndTargsSwappedToMinSuffix(Qureg qureg, vector<int> ctrls, vector<int> targs) {
+auto getCtrlsAndTargsSwappedToMinSuffix(Qureg qureg, SmallList ctrls, SmallList targs) {
 
     // this function is called by multi-target dense matrix, and is used to find
     // targets in the prefix substate and where they can be swapped into the suffix
@@ -200,7 +201,7 @@ auto getCtrlsAndTargsSwappedToMinSuffix(Qureg qureg, vector<int> ctrls, vector<i
 }
 
 
-auto getQubitsSwappedToMaxSuffix(Qureg qureg, vector<int> qubits) {
+auto getQubitsSwappedToMaxSuffix(Qureg qureg, SmallList qubits) {
 
     // this function is called by any-targ partial trace, and is used to find
     // targets in the prefix substate and where they can be swapped into the suffix
@@ -238,10 +239,10 @@ auto getQubitsSwappedToMaxSuffix(Qureg qureg, vector<int> qubits) {
 }
 
 
-auto getNonSwappedCtrlsAndStates(vector<int> oldCtrls, vector<int> oldStates, vector<int> newCtrls) {
+auto getNonSwappedCtrlsAndStates(SmallList oldCtrls, SmallList oldStates, SmallList newCtrls) {
 
-    vector<int> sameCtrls(0);   sameCtrls .reserve(oldCtrls.size());
-    vector<int> sameStates(0);  sameStates.reserve(oldStates.size());
+    auto sameCtrls = list_getEmptySmallList();
+    auto sameStates = list_getEmptySmallList();
 
     for (size_t i=0; i<oldCtrls.size(); i++)
         if (oldCtrls[i] == newCtrls[i]) {
@@ -446,7 +447,7 @@ void freeSpoofedLocalStateVec(Qureg spoof, bool wasMemAlloc) {
  */
 
 
-void exchangeAmpsToBuffersWhereQubitsAreInStates(Qureg qureg, int pairRank, vector<int> qubits, vector<int> states) {
+void exchangeAmpsToBuffersWhereQubitsAreInStates(Qureg qureg, int pairRank, SmallList qubits, SmallList states) {
 
     // when there are no constraining qubits, all amps are exchanged; there is no need to pack the buffer.
     // this is typically triggered when a communicating localiser function is given no control qubits
@@ -839,7 +840,7 @@ void localiser_densmatr_initMixtureOfUniformlyRandomPureStates(Qureg qureg, qind
  */
 
 
-void anyCtrlSwapBetweenPrefixAndPrefix(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
+void anyCtrlSwapBetweenPrefixAndPrefix(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) {
 
     int prefInd1 = util_getPrefixInd(targ1, qureg);
     int prefInd2 = util_getPrefixInd(targ2, qureg);
@@ -857,15 +858,15 @@ void anyCtrlSwapBetweenPrefixAndPrefix(Qureg qureg, vector<int> ctrls, vector<in
 }
 
 
-void anyCtrlSwapBetweenPrefixAndSuffix(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int suffixTarg, int prefixTarg) {
+void anyCtrlSwapBetweenPrefixAndSuffix(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int suffixTarg, int prefixTarg) {
 
     // every node exchanges at most half its amps; those where suffixTarg bit differs from rank's fixed prefixTarg bit
     int pairRank = util_getRankWithQubitFlipped(prefixTarg, qureg);
     int suffixState =  ! util_getRankBitOfQubit(prefixTarg, qureg);
 
     // pack and exchange only to-be-communicated amps between sub-buffers
-    vector<int> qubits = ctrls;
-    vector<int> states = ctrlStates;
+    auto qubits = ctrls;
+    auto states = ctrlStates;
     qubits.push_back(suffixTarg);
     states.push_back(suffixState);
     exchangeAmpsToBuffersWhereQubitsAreInStates(qureg, pairRank, qubits, states);
@@ -875,7 +876,7 @@ void anyCtrlSwapBetweenPrefixAndSuffix(Qureg qureg, vector<int> ctrls, vector<in
 }
 
 
-void localiser_statevec_anyCtrlSwap(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
+void localiser_statevec_anyCtrlSwap(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -909,7 +910,7 @@ void localiser_statevec_anyCtrlSwap(Qureg qureg, vector<int> ctrls, vector<int> 
  */
 
 
-void anyCtrlMultiSwapBetweenPrefixAndSuffix(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targsA, vector<int> targsB) {
+void anyCtrlMultiSwapBetweenPrefixAndSuffix(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targsA, SmallList targsB) {
 
     // this is an internal function called by the below routines which require
     // performing a sequence of SWAPs to reorder qubits, or move them into suffix.
@@ -944,7 +945,7 @@ void anyCtrlMultiSwapBetweenPrefixAndSuffix(Qureg qureg, vector<int> ctrls, vect
  */
 
 
-void anyCtrlOneTargDenseMatrOnPrefix(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr) {
+void anyCtrlOneTargDenseMatrOnPrefix(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr) {
   
     int pairRank = util_getRankWithQubitFlipped(targ, qureg);
     exchangeAmpsToBuffersWhereQubitsAreInStates(qureg, pairRank, ctrls, ctrlStates);
@@ -959,7 +960,7 @@ void anyCtrlOneTargDenseMatrOnPrefix(Qureg qureg, vector<int> ctrls, vector<int>
 }
 
 
-void localiser_statevec_anyCtrlOneTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr, bool conj, bool transp) {
+void localiser_statevec_anyCtrlOneTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr, bool conj, bool transp) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -992,21 +993,21 @@ void localiser_statevec_anyCtrlOneTargDenseMatr(Qureg qureg, vector<int> ctrls, 
  */
 
 
-void anyCtrlTwoOrAnyTargDenseMatrOnSuffix(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr2 matr, bool conj, bool transp) {
+void anyCtrlTwoOrAnyTargDenseMatrOnSuffix(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr2 matr, bool conj, bool transp) {
     if (conj) 
         matr = util_getConj(matr);
     if (transp)
         matr = util_getTranspose(matr);
     accel_statevec_anyCtrlTwoTargDenseMatr_sub(qureg, ctrls, ctrlStates, targs[0], targs[1], matr);
 }
-void anyCtrlTwoOrAnyTargDenseMatrOnSuffix(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr  matr, bool conj, bool transp) {
+void anyCtrlTwoOrAnyTargDenseMatrOnSuffix(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr  matr, bool conj, bool transp) {
     accel_statevec_anyCtrlAnyTargDenseMatr_sub(qureg, ctrls, ctrlStates, targs, matr, conj, transp);
 }
 
 
 // T can be CompMatr2 or CompMatr
 template <typename T>
-void anyCtrlTwoOrAnyTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, T matr, bool conj, bool transp) {
+void anyCtrlTwoOrAnyTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, T matr, bool conj, bool transp) {
 
     // node has nothing to do if all local amps violate control condition
     if (!doAnyLocalStatesHaveQubitValues(qureg, ctrls, ctrlStates))
@@ -1033,8 +1034,8 @@ void anyCtrlTwoOrAnyTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ct
     /// order to accelerate them (since more ctrls = fewer comm). However, this is strangely not
     /// working; controlling the SWAPs upon these 'meta' control qubits is breaking the unit tests!
     /// Until we better understand this, we disable this optimisation by removing all SWAP controls.
-    unmovedCtrls = {};
-    unmovedCtrlStates = {};
+    unmovedCtrls      = list_getEmptySmallList();
+    unmovedCtrlStates = list_getEmptySmallList();
 
     // perform necessary swaps to move all targets into suffix, invoking communication (swaps are real, so no need to conj)
     anyCtrlMultiSwapBetweenPrefixAndSuffix(qureg, unmovedCtrls, unmovedCtrlStates, targs, newTargs);
@@ -1052,15 +1053,15 @@ void anyCtrlTwoOrAnyTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ct
 }
 
 
-void localiser_statevec_anyCtrlTwoTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr, bool conj, bool transp) {
+void localiser_statevec_anyCtrlTwoTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr, bool conj, bool transp) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
-    anyCtrlTwoOrAnyTargDenseMatr(qureg, ctrls, ctrlStates, {targ1,targ2}, matr, conj, transp);
+    anyCtrlTwoOrAnyTargDenseMatr(qureg, ctrls, ctrlStates, list_getSmallList({targ1,targ2}), matr, conj, transp);
 }
 
 
-void localiser_statevec_anyCtrlAnyTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr, bool conj, bool transp) {
+void localiser_statevec_anyCtrlAnyTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr, bool conj, bool transp) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -1098,7 +1099,7 @@ void localiser_statevec_anyCtrlAnyTargDenseMatr(Qureg qureg, vector<int> ctrls, 
  */
 
 
-void localiser_statevec_anyCtrlOneTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr, bool conj) {
+void localiser_statevec_anyCtrlOneTargDiagMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr, bool conj) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -1115,7 +1116,7 @@ void localiser_statevec_anyCtrlOneTargDiagMatr(Qureg qureg, vector<int> ctrls, v
 }
 
 
-void localiser_statevec_anyCtrlTwoTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr, bool conj) {
+void localiser_statevec_anyCtrlTwoTargDiagMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr, bool conj) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -1132,7 +1133,7 @@ void localiser_statevec_anyCtrlTwoTargDiagMatr(Qureg qureg, vector<int> ctrls, v
 }
 
 
-void localiser_statevec_anyCtrlAnyTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent, bool conj) {
+void localiser_statevec_anyCtrlAnyTargDiagMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent, bool conj) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -1226,7 +1227,7 @@ void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qco
 
 
 template <class T>
-void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, T matr, bool conj) {
+void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, T matr, bool conj) {
 
     // this function is never invoked by operations whch require transposing matr
     bool transp = false;
@@ -1244,12 +1245,12 @@ void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg qureg, vector<int> ctrls, ve
     if constexpr (util_isCompMatr2<T>()) localiser_statevec_anyCtrlTwoTargDenseMatr(qureg, ctrls, ctrlStates, targs[0], targs[1], matr, conj, transp);
 }
 
-template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vector<int>, vector<int>, DiagMatr,  bool);
-template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vector<int>, vector<int>, DiagMatr1, bool);
-template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vector<int>, vector<int>, DiagMatr2, bool);
-template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vector<int>, vector<int>, CompMatr,  bool);
-template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vector<int>, vector<int>, CompMatr1, bool);
-template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vector<int>, vector<int>, CompMatr2, bool);
+template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, SmallList, SmallList, SmallList, DiagMatr,  bool);
+template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, SmallList, SmallList, SmallList, DiagMatr1, bool);
+template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, SmallList, SmallList, SmallList, DiagMatr2, bool);
+template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, SmallList, SmallList, SmallList, CompMatr,  bool);
+template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, SmallList, SmallList, SmallList, CompMatr1, bool);
+template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, SmallList, SmallList, SmallList, CompMatr2, bool);
 
 
 
@@ -1258,7 +1259,7 @@ template void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg, vector<int>, vecto
  */
 
 
-void anyCtrlZTensorOrGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, bool isGadget, qcomp phase) {     
+void anyCtrlZTensorOrGadget(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, bool isGadget, qcomp phase) {     
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -1282,7 +1283,7 @@ void anyCtrlZTensorOrGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStat
 }
 
 
-void anyCtrlPauliTensorOrGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qcomp ampFac, qcomp pairAmpFac) {
+void anyCtrlPauliTensorOrGadget(Qureg qureg, SmallList ctrls, SmallList ctrlStates, PauliStr str, qcomp ampFac, qcomp pairAmpFac) {
     assertValidCtrlStates(ctrls, ctrlStates);
     setDefaultCtrlStates(ctrls, ctrlStates);
 
@@ -1330,7 +1331,7 @@ void anyCtrlPauliTensorOrGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrl
 }
 
 
-void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qcomp factor) {
+void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, SmallList ctrls, SmallList ctrlStates, PauliStr str, qcomp factor) {
 
     // this function accepts a global factor, so that density matrices can effect conj(pauli)
 
@@ -1353,14 +1354,14 @@ void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, vector<int> ctrls, vecto
 }
 
 
-void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp phase) {
+void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, qcomp phase) {
 
     bool isGadget = true;
     anyCtrlZTensorOrGadget(qureg, ctrls, ctrlStates, targs, isGadget, phase);
 }
 
 
-void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qcomp phase) {
+void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, SmallList ctrls, SmallList ctrlStates, PauliStr str, qcomp phase) {
 
     // when str=IZ, we must use the above bespoke algorithm
     if (!paulis_containsXOrY(str)) {
@@ -1486,7 +1487,7 @@ void oneQubitDepolarisingOnPrefix(Qureg qureg, int ketQubit, qreal prob) {
     // pack and exchange amps to buffers where local ket qubit and fixed-prefix-bra qubit agree
     int braBit = util_getRankBitOfBraQubit(ketQubit, qureg);
     int pairRank = util_getRankWithBraQubitFlipped(ketQubit, qureg);
-    exchangeAmpsToBuffersWhereQubitsAreInStates(qureg, pairRank, {ketQubit}, {braBit});
+    exchangeAmpsToBuffersWhereQubitsAreInStates(qureg, pairRank, list_getSmallList({ketQubit}), list_getSmallList({braBit}));
 
     // use received sub-buffer to update local amps
     accel_densmatr_oneQubitDepolarising_subB(qureg, ketQubit, prob);
@@ -1536,7 +1537,8 @@ void twoQubitDepolarisingOnPrefixAndPrefix(Qureg qureg, int ketQb1, int ketQb2, 
     int braBit2 = util_getRankBitOfBraQubit(ketQb2, qureg);
 
     // pack unscaled amps before subsequent scaling
-    qindex numPacked = accel_statevec_packAmpsIntoBuffer(qureg, {ketQb1,ketQb2}, {braBit1,braBit2});
+    auto ketList = list_getSmallList({ketQb1,ketQb2});
+    qindex numPacked = accel_statevec_packAmpsIntoBuffer(qureg, ketList, list_getSmallList({braBit1,braBit2}));
 
     // scale all amps
     accel_densmatr_twoQubitDepolarising_subE(qureg, ketQb1, ketQb2, prob);
@@ -1544,7 +1546,7 @@ void twoQubitDepolarisingOnPrefixAndPrefix(Qureg qureg, int ketQb1, int ketQb2, 
     // swap the buffer with 3 other nodes to update local amps
     int pairRank1 = util_getRankWithBraQubitFlipped(ketQb1, qureg);
     int pairRank2 = util_getRankWithBraQubitFlipped(ketQb2, qureg);
-    int pairRank3 = util_getRankWithBraQubitsFlipped({ketQb1,ketQb2}, qureg);
+    int pairRank3 = util_getRankWithBraQubitsFlipped(ketList, qureg);
 
     comm_exchangeSubBuffers(qureg, numPacked, pairRank1);
     accel_densmatr_twoQubitDepolarising_subF(qureg, ketQb1, ketQb2, prob);
@@ -1631,7 +1633,7 @@ void oneQubitDampingOnPrefix(Qureg qureg, int ketQubit, qreal prob) {
     if (braBit == 1) {
 
         // pack and async send half the buffer
-        accel_statevec_packAmpsIntoBuffer(qureg, {ketQubit}, {1});
+        accel_statevec_packAmpsIntoBuffer(qureg, list_getSmallList({ketQubit}), list_getSmallList({1}));
         comm_asynchSendSubBuffer(qureg, numAmps, pairRank);
 
         // scale the local amps which were just sent
@@ -1692,7 +1694,7 @@ CompMatr getSpoofedCompMatrFromSuperOp(SuperOp op) {
 }
 
 
-void localiser_densmatr_superoperator(Qureg qureg, SuperOp op, vector<int> ketTargs) {
+void localiser_densmatr_superoperator(Qureg qureg, SuperOp op, SmallList ketTargs) {
     assert_localiserGivenDensMatr(qureg);
 
     // effect the superoperator as a dense matrix on the ket + bra qubits
@@ -1701,11 +1703,12 @@ void localiser_densmatr_superoperator(Qureg qureg, SuperOp op, vector<int> ketTa
     auto braTargs = util_getBraQubits(ketTargs, qureg);
     auto allTargs = util_getConcatenated(ketTargs, braTargs);
     CompMatr matr = getSpoofedCompMatrFromSuperOp(op);
-    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, {}, {}, allTargs, matr, conj, transp);
+    SmallList empty = list_getEmptySmallList();
+    localiser_statevec_anyCtrlAnyTargDenseMatr(qureg, empty, empty, allTargs, matr, conj, transp);
 }
 
 
-void localiser_densmatr_krausMap(Qureg qureg, KrausMap map, vector<int> ketTargs) {
+void localiser_densmatr_krausMap(Qureg qureg, KrausMap map, SmallList ketTargs) {
     
     // Kraus map is simulated through its existing superoperator
     localiser_densmatr_superoperator(qureg, map.superop, ketTargs);
@@ -1718,12 +1721,10 @@ void localiser_densmatr_krausMap(Qureg qureg, KrausMap map, vector<int> ketTargs
  */
 
 
-auto getNonTracedQubitOrder(Qureg qureg, vector<int> originalTargs, vector<int> revisedTargs) {
+auto getNonTracedQubitOrder(Qureg qureg, SmallList originalTargs, SmallList revisedTargs) {
 
-    // prepare a list of all the qureg's qubits when treated as a statevector
-    vector<int> allQubits(2*qureg.numQubits);
-    for (size_t q=0; q<allQubits.size(); q++)
-        allQubits[q] = q;
+    // get a list of all the qureg's qubits when treated as a statevector
+    auto allQubits = util_getRange(2 * qureg.numQubits);
     
     // determine the ordering of all the Qureg's qubits after swaps
     for (size_t i=0; i<originalTargs.size(); i++) {
@@ -1737,8 +1738,7 @@ auto getNonTracedQubitOrder(Qureg qureg, vector<int> originalTargs, vector<int> 
     qindex revisedMask = util_getBitMask(revisedTargs);
 
     // retain only non-targeted qubits
-    vector<int> remainingQubits;
-    remainingQubits.reserve(allQubits.size() - originalTargs.size());
+    auto remainingQubits = list_getEmptySmallList();
     for (size_t q=0; q<allQubits.size(); q++)
         if (!getBit(revisedMask, q))
             remainingQubits.push_back(allQubits[q]);
@@ -1758,7 +1758,7 @@ auto getNonTracedQubitOrder(Qureg qureg, vector<int> originalTargs, vector<int> 
 }
 
 
-void reorderReducedQureg(Qureg inQureg, Qureg outQureg, vector<int> allTargs, vector<int> suffixTargs) {
+void reorderReducedQureg(Qureg inQureg, Qureg outQureg, SmallList allTargs, SmallList suffixTargs) {
 
     /// @todo 
     /// this function performs a sequence of SWAPs which are NOT necessarily upon disjoint qubits,
@@ -1770,7 +1770,7 @@ void reorderReducedQureg(Qureg inQureg, Qureg outQureg, vector<int> allTargs, ve
     auto remainingQubits = getNonTracedQubitOrder(inQureg, allTargs, suffixTargs);
 
    // perform additional swaps to re-order the remaining qubits (heuristically starting from back)
-    for (int qubit=(int)remainingQubits.size(); qubit-- != 0; ) {
+    for (int qubit=remainingQubits.size(); qubit-- != 0; ) {
 
         // locate the next qubit which is out of its sorted position
         if (remainingQubits[qubit] == qubit)
@@ -1782,20 +1782,21 @@ void reorderReducedQureg(Qureg inQureg, Qureg outQureg, vector<int> allTargs, ve
             pair++;
         
         // and swap it directly to its required position, triggering any communication scenario (I think)
-        localiser_statevec_anyCtrlSwap(outQureg, {}, {}, qubit, pair);
+        auto empty = list_getEmptySmallList();
+        localiser_statevec_anyCtrlSwap(outQureg, empty, empty, qubit, pair);
         std::swap(remainingQubits[qubit], remainingQubits[pair]);
     }
 }
 
 
-void partialTraceOnSuffix(Qureg inQureg, Qureg outQureg, vector<int> ketTargs) {
+void partialTraceOnSuffix(Qureg inQureg, Qureg outQureg, SmallList ketTargs) {
 
     auto braTargs = util_getBraQubits(ketTargs, inQureg);
     accel_densmatr_partialTrace_sub(inQureg, outQureg, ketTargs, braTargs);
 }
 
 
-void partialTraceOnPrefix(Qureg inQureg, Qureg outQureg, vector<int> ketTargs) {
+void partialTraceOnPrefix(Qureg inQureg, Qureg outQureg, SmallList ketTargs) {
 
     // all ketTargs (pre-sorted) are in the suffix, but one or more braTargs are in the prefix
     auto braTargs = util_getBraQubits(ketTargs, inQureg); // sorted
@@ -1803,22 +1804,24 @@ void partialTraceOnPrefix(Qureg inQureg, Qureg outQureg, vector<int> ketTargs) {
     auto sufTargs = getQubitsSwappedToMaxSuffix(inQureg, allTargs); // arbitrarily ordered
 
     // swap iniQureg's prefix bra-qubits into suffix, invoking communication
-    anyCtrlMultiSwapBetweenPrefixAndSuffix(inQureg, {}, {}, sufTargs, allTargs);
+    auto empty = list_getEmptySmallList();
+    anyCtrlMultiSwapBetweenPrefixAndSuffix(inQureg, empty, empty, sufTargs, allTargs);
 
     // use the second half of sufTargs as the pair targs, which are now all in the suffix,
-    // to perform embarrassingly parallel overwriting of outQureg
-    vector<int> pairTargs(sufTargs.begin() + ketTargs.size(), sufTargs.end()); // arbitrarily ordered
+    // to perform embarrassingly parallel overwriting of outQureg (they're arbitrarily ordered)
+    auto pairTargs = list_getSmallList(sufTargs.begin() + ketTargs.size(), sufTargs.end());
+
     accel_densmatr_partialTrace_sub(inQureg, outQureg, ketTargs, pairTargs);
 
     // restore the relative order of outQureg's remaining qubits using SWAPs
     reorderReducedQureg(inQureg, outQureg, allTargs, sufTargs);
 
     // undo the swaps on inQureg
-    anyCtrlMultiSwapBetweenPrefixAndSuffix(inQureg, {}, {}, sufTargs, allTargs);
+    anyCtrlMultiSwapBetweenPrefixAndSuffix(inQureg, empty, empty, sufTargs, allTargs);
 }
 
 
-void localiser_densmatr_partialTrace(Qureg inQureg, Qureg outQureg, vector<int> targs) {
+void localiser_densmatr_partialTrace(Qureg inQureg, Qureg outQureg, SmallList targs) {
     assert_localiserPartialTraceGivenCompatibleQuregs(inQureg, outQureg, targs.size());
 
     // this function requires inQureg and outQureg are both or neither distributed;
@@ -1871,7 +1874,7 @@ qreal localiser_densmatr_calcTotalProb(Qureg qureg) {
 }
 
 
-qreal localiser_statevec_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal localiser_statevec_calcProbOfMultiQubitOutcome(Qureg qureg, SmallList qubits, SmallList outcomes) {
     assert_localiserGivenStateVec(qureg);
 
     qreal prob = 0;
@@ -1892,7 +1895,7 @@ qreal localiser_statevec_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qu
 }
 
 
-qreal localiser_densmatr_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal localiser_densmatr_calcProbOfMultiQubitOutcome(Qureg qureg, SmallList qubits, SmallList outcomes) {
     assert_localiserGivenDensMatr(qureg);
 
     qreal prob = 0;
@@ -1905,8 +1908,8 @@ qreal localiser_densmatr_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qu
     if (doAnyLocalStatesHaveQubitValues(qureg, braQubits, outcomes)) {
 
         // such nodes need only know the ket qubits/outcomes for which the bra-qubits are in suffix
-        vector<int> ketQubitsWithBraInSuffix;
-        vector<int> ketOutcomesWithBraInSuffix;
+        auto ketQubitsWithBraInSuffix = list_getEmptySmallList();
+        auto ketOutcomesWithBraInSuffix = list_getEmptySmallList();
         for (size_t q=0; q<qubits.size(); q++)
             if (util_isBraQubitInSuffix(qubits[q], qureg)) {
                 ketQubitsWithBraInSuffix.push_back(qubits[q]);
@@ -1925,7 +1928,7 @@ qreal localiser_densmatr_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qu
 }
 
 
-void localiser_statevec_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void localiser_statevec_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, SmallList qubits) {
     assert_localiserGivenStateVec(qureg);
 
     /// @todo
@@ -1965,7 +1968,7 @@ void localiser_statevec_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg 
 }
 
 
-void localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, SmallList qubits) {
     assert_localiserGivenDensMatr(qureg);
 
     // each node independently populates local outProbs
@@ -1986,7 +1989,7 @@ void localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg 
 PAULI_MASK_TYPE paulis_getKeyOfSameMixedAmpsGroup(PauliStr str);
 
 
-qcomp getStateVecExpecAllSuffixPauliStr(Qureg qureg, vector<int> suffixX, vector<int> suffixY, vector<int> suffixZ) {
+qcomp getStateVecExpecAllSuffixPauliStr(Qureg qureg, SmallList suffixX, SmallList suffixY, SmallList suffixZ) {
     assert_localiserGivenStateVec(qureg);
 
     // optimised scenario when str = I
@@ -2318,7 +2321,7 @@ qreal localiser_densmatr_calcHilbertSchmidtDistance(Qureg quregA, Qureg quregB) 
  */
 
 
-void localiser_statevec_multiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void localiser_statevec_multiQubitProjector(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     // this routine is always embarrassingly parallel; however, we handle the
     // prefix-qubits here so that the backend can receive only the suffix qubits
@@ -2339,7 +2342,7 @@ void localiser_statevec_multiQubitProjector(Qureg qureg, vector<int> qubits, vec
 }
 
 
-void localiser_densmatr_multiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void localiser_densmatr_multiQubitProjector(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
     assert_localiserGivenDensMatr(qureg);
 
     // always embarrassingly parallel

--- a/quest/src/core/localiser.hpp
+++ b/quest/src/core/localiser.hpp
@@ -18,6 +18,8 @@
 #include "quest/include/matrices.h"
 #include "quest/include/channels.h"
 
+#include "quest/src/core/small_list.hpp"
+
 #include <vector>
 
 using std::vector;
@@ -78,29 +80,29 @@ void localiser_densmatr_initMixtureOfUniformlyRandomPureStates(Qureg qureg, qind
  * SWAP
  */
 
-void localiser_statevec_anyCtrlSwap(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2);
+void localiser_statevec_anyCtrlSwap(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2);
 
 
 /*
  * DENSE MATRICES
  */
 
-void localiser_statevec_anyCtrlOneTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr, bool conj, bool transp);
+void localiser_statevec_anyCtrlOneTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr, bool conj, bool transp);
 
-void localiser_statevec_anyCtrlTwoTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr, bool conj, bool transp);
+void localiser_statevec_anyCtrlTwoTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr, bool conj, bool transp);
 
-void localiser_statevec_anyCtrlAnyTargDenseMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr, bool conj, bool transp);
+void localiser_statevec_anyCtrlAnyTargDenseMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr, bool conj, bool transp);
 
 
 /*
  * DIAGONAL MATRICES
  */
 
-void localiser_statevec_anyCtrlOneTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr, bool conj);
+void localiser_statevec_anyCtrlOneTargDiagMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr, bool conj);
 
-void localiser_statevec_anyCtrlTwoTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr, bool conj);
+void localiser_statevec_anyCtrlTwoTargDiagMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr, bool conj);
 
-void localiser_statevec_anyCtrlAnyTargDiagMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent, bool conj);
+void localiser_statevec_anyCtrlAnyTargDiagMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent, bool conj);
 
 void localiser_statevec_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qcomp exponent, bool applyLeft, bool applyRight, bool conjRight);
@@ -111,18 +113,18 @@ void localiser_densmatr_allTargDiagMatr(Qureg qureg, FullStateDiagMatr matr, qco
  */
 
 template <class T>
-void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, T matr, bool conj);
+void localiser_statevec_anyCtrlAnyTargAnyMatr(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, T matr, bool conj);
 
 
 /*
  * PAULI TENSORS AND GADGETS
  */
 
-void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qcomp globalFactor=1);
+void localiser_statevec_anyCtrlPauliTensor(Qureg qureg, SmallList ctrls, SmallList ctrlStates, PauliStr str, qcomp globalFactor=1);
 
-void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, PauliStr str, qcomp phase);
+void localiser_statevec_anyCtrlPauliGadget(Qureg qureg, SmallList ctrls, SmallList ctrlStates, PauliStr str, qcomp phase);
 
-void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp phase);
+void localiser_statevec_anyCtrlPhaseGadget(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, qcomp phase);
 
 
 /*
@@ -150,16 +152,16 @@ void localiser_densmatr_oneQubitPauliChannel(Qureg qureg, int qubit, qreal pX, q
 
 void localiser_densmatr_oneQubitDamping(Qureg qureg, int qubit, qreal prob);
 
-void localiser_densmatr_superoperator(Qureg qureg, SuperOp op, vector<int> ketTargs);
+void localiser_densmatr_superoperator(Qureg qureg, SuperOp op, SmallList ketTargs);
 
-void localiser_densmatr_krausMap(Qureg qureg, KrausMap map, vector<int> qubits);
+void localiser_densmatr_krausMap(Qureg qureg, KrausMap map, SmallList qubits);
 
 
 /*
  * PARTIAL TRACE
  */
 
-void localiser_densmatr_partialTrace(Qureg inQureg, Qureg outQureg, vector<int> targs);
+void localiser_densmatr_partialTrace(Qureg inQureg, Qureg outQureg, SmallList targs);
 
 
 /*
@@ -169,11 +171,11 @@ void localiser_densmatr_partialTrace(Qureg inQureg, Qureg outQureg, vector<int> 
 qreal localiser_statevec_calcTotalProb(Qureg qureg);
 qreal localiser_densmatr_calcTotalProb(Qureg qureg);
 
-qreal localiser_statevec_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qubits, vector<int> outcomes);
-qreal localiser_densmatr_calcProbOfMultiQubitOutcome(Qureg qureg, vector<int> qubits, vector<int> outcomes);
+qreal localiser_statevec_calcProbOfMultiQubitOutcome(Qureg qureg, SmallList qubits, SmallList outcomes);
+qreal localiser_densmatr_calcProbOfMultiQubitOutcome(Qureg qureg, SmallList qubits, SmallList outcomes);
 
-void localiser_statevec_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, vector<int> qubits);
-void localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, vector<int> qubits);
+void localiser_statevec_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, SmallList qubits);
+void localiser_densmatr_calcProbsOfAllMultiQubitOutcomes(qreal* outProbs, Qureg qureg, SmallList qubits);
 
 
 /*
@@ -205,8 +207,8 @@ qcomp localiser_densmatr_calcExpecFullStateDiagMatr(Qureg qureg, FullStateDiagMa
  * PROJECTORS 
  */
 
-void localiser_statevec_multiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
-void localiser_densmatr_multiQubitProjector(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
+void localiser_statevec_multiQubitProjector(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
+void localiser_densmatr_multiQubitProjector(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
 
 
 #endif // LOCALISER_HPP

--- a/quest/src/core/paulilogic.cpp
+++ b/quest/src/core/paulilogic.cpp
@@ -9,6 +9,7 @@
 #include "quest/include/qureg.h"
 
 #include "quest/src/core/paulilogic.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/errors.hpp"
@@ -113,7 +114,7 @@ int paulis_getSignOfPauliStrConj(PauliStr str) {
 }
 
 
-int paulis_getPrefixZSign(Qureg qureg, vector<int> prefixZ) {
+int paulis_getPrefixZSign(Qureg qureg, SmallList prefixZ) {
 
     int sign = 1;
 
@@ -125,7 +126,7 @@ int paulis_getPrefixZSign(Qureg qureg, vector<int> prefixZ) {
 }
 
 
-qcomp paulis_getPrefixPaulisElem(Qureg qureg, vector<int> prefixY, vector<int> prefixZ) {
+qcomp paulis_getPrefixPaulisElem(Qureg qureg, SmallList prefixY, SmallList prefixZ) {
 
     // each Z contributes +- 1
     qcomp elem = paulis_getPrefixZSign(qureg, prefixZ);
@@ -138,12 +139,10 @@ qcomp paulis_getPrefixPaulisElem(Qureg qureg, vector<int> prefixY, vector<int> p
 }
 
 
-vector<int> paulis_getTargetInds(PauliStr str) {
+SmallList paulis_getTargetInds(PauliStr str) {
 
     int maxInd = paulis_getIndOfLefmostNonIdentityPauli(str);
-
-    vector<int> inds(0);
-    inds.reserve(maxInd+1);
+    auto inds = list_getEmptySmallList();
 
     for (int i=0; i<=maxInd; i++)
         if (paulis_getPauliAt(str, i) != 0) // Id
@@ -170,12 +169,14 @@ qindex paulis_getTargetBitMask(PauliStr str) {
 }
 
 
-std::array<vector<int>,3> paulis_getSeparateInds(PauliStr str) {
+std::array<SmallList,3> paulis_getSeparateInds(PauliStr str) {
 
-    vector<int> iXYZ = paulis_getTargetInds(str);
-    vector<int> iX, iY, iZ;
+    auto iXYZ = paulis_getTargetInds(str);
+    auto iX = list_getEmptySmallList();
+    auto iY = list_getEmptySmallList();
+    auto iZ = list_getEmptySmallList();
 
-    vector<int>* ptrs[] = {&iX, &iY, &iZ};
+    SmallList* ptrs[] = {&iX, &iY, &iZ};
 
     for (int i : iXYZ)
         ptrs[paulis_getPauliAt(str, i) - 1]->push_back(i);

--- a/quest/src/core/paulilogic.hpp
+++ b/quest/src/core/paulilogic.hpp
@@ -12,6 +12,8 @@
 #include "quest/include/paulis.h"
 #include "quest/include/qureg.h"
 
+#include "quest/src/core/small_list.hpp"
+
 #include <utility>
 #include <vector>
 #include <array>
@@ -43,13 +45,13 @@ int paulis_getIndOfLefmostNonIdentityPauli(PauliStr* strings, qindex numStrings)
 
 int paulis_getSignOfPauliStrConj(PauliStr str);
 
-int paulis_getPrefixZSign(Qureg qureg, vector<int> prefixZ);
+int paulis_getPrefixZSign(Qureg qureg, SmallList prefixZ);
 
-qcomp paulis_getPrefixPaulisElem(Qureg qureg, vector<int> prefixY, vector<int> prefixZ);
+qcomp paulis_getPrefixPaulisElem(Qureg qureg, SmallList prefixY, SmallList prefixZ);
 
-vector<int> paulis_getTargetInds(PauliStr str);
+SmallList paulis_getTargetInds(PauliStr str);
 
-std::array<vector<int>,3> paulis_getSeparateInds(PauliStr str);
+std::array<SmallList,3> paulis_getSeparateInds(PauliStr str);
 
 qindex paulis_getTargetBitMask(PauliStr str);
 

--- a/quest/src/core/small_list.hpp
+++ b/quest/src/core/small_list.hpp
@@ -38,7 +38,7 @@
  */
 
 
-constexpr int MAX_LIST_LENGTH = 64;
+constexpr size_t MAX_LIST_LENGTH = 64;
 
 
 
@@ -62,7 +62,10 @@ private:
     // Readers may wonder why we avoid std::array;
     // it has a surprise overhead in pass-by-ref!
     int elems[MAX_LIST_LENGTH];
-    int length;
+
+    // We use size_t, over the arguably internally
+    // natural int, for consistency with STL containers
+    size_t length;
 
 public:
 
@@ -100,7 +103,7 @@ public:
     INLINE bool empty() const { 
         return length == 0; 
     }
-    INLINE int size() const { 
+    INLINE size_t size() const { 
         return length;
     }
     INLINE int* data() {
@@ -118,12 +121,12 @@ public:
         elems[length++] = elem;
     }
 
-    INLINE void resize(int newLength, int value=0) {
+    INLINE void resize(size_t newLength, int value=0) {
 
         if (newLength > MAX_LIST_LENGTH)
             error_smallListLengthExceededMax();
 
-        for (int i=length; i<newLength; i++)
+        for (auto i=length; i<newLength; i++)
             elems[i] = value;
 
         length = newLength;
@@ -131,7 +134,7 @@ public:
 
     INLINE const int& back() const {
 
-        if (empty())
+        if (length == 0)
             error_smallListWasEmpty();
 
         return elems[length - 1];
@@ -167,7 +170,7 @@ INLINE SmallList list_getSmallList(const int* begin, const int* end) {
     if (end < begin)
         error_smallListIndexExceededLength();
 
-    int length = static_cast<int>(end - begin);
+    auto length = static_cast<size_t>(end - begin);
     if (length > MAX_LIST_LENGTH)
         error_smallListLengthExceededMax();
 
@@ -180,12 +183,16 @@ INLINE SmallList list_getSmallList(const int* begin, const int* end) {
 }
 
 
-INLINE SmallList list_getSmallList(const int* elems, int length) {
+INLINE SmallList list_getSmallList(const int* elems, size_t length) {
 
+    if (elems == nullptr && length > 0)
+        error_smallListNullPtrWithPositiveLength();
+    
+    // no ptr necessary whgen list is empty
     if (elems == nullptr)
         return list_getEmptySmallList();
 
-    return list_getSmallList(elems, elems + length);
+    return list_getSmallList(elems, elems + length); // validates length <= MAX
 }
 
 

--- a/quest/src/core/small_list.hpp
+++ b/quest/src/core/small_list.hpp
@@ -1,0 +1,206 @@
+/** @file
+ * A stack-based list of length <= 64, primarily
+ * for storing qubit indices, as an alternative to
+ * std::vector and associated heap-alloc/copy
+ * overheads. Use of SmallList optimises few-qubit
+ * simulation where STL container costs dominate;
+ * and in the GPU backend, use of SmallList avoids
+ * CUDA memory writes before kernel launches!
+ * 
+ * The functions herein are inlined (in this header-
+ * only file) in the hopes of unbridled compiler
+ * optimisations, but this may prove incompatible
+ * with GPU mode (since INLINE specifies __device__,
+ * which may be incompatible with initialiser lists)
+ * 
+ * @author Tyson Jones
+ */
+
+#ifndef SMALL_LIST_HPP
+#define SMALL_LIST_HPP
+
+#include "quest/src/core/errors.hpp"
+#include "quest/src/core/inliner.hpp"
+
+
+
+/*
+ * CAPACITY
+ *
+ * Since stored in stack, we must upperbound the length of
+ * a SmallList; we choose 64, which is around the maximum
+ * addressable number of qubits by qindex. In theory, we
+ * could permit users to compile-time reduce this length,
+ * restricting their max simulable system but speeding up
+ * SmallList copies in function calls - this may have a
+ * measurable benefit for Quregs of 1-8 qubits. But Donald
+ * Knuth knows and sees all, and he won't be happy!
+ */
+
+
+constexpr int MAX_LIST_LENGTH = 64;
+
+
+
+/*
+ * SMALL LIST DECLARATION
+ *
+ * which mimics an STL container so that it is easily
+ * substituted for std::vector in our codebase, but
+ * crucially, remains (almost) POD and with no heap
+ * allocs, and compatible with CUDA kernels 
+ */
+
+
+struct SmallList {
+
+private:
+
+    // Keep data private to dissuade inconsistent
+    // access patterns (e.g. .elems vs .data()),
+    // and so users cannot invalidly mutate length.
+    // Readers may wonder why we avoid std::array;
+    // it has a surprise overhead in pass-by-ref!
+    int elems[MAX_LIST_LENGTH];
+    int length;
+
+public:
+
+    // Note there is deliberately no constructor!
+    // This keeps the struct trivial and compatible
+    // with CUDA; we must forego initializer ctors
+    // and other syntactic goodies :(
+
+    // let SmallList be iterable, e.g. for(auto x : list)
+    auto begin()       { return elems; }
+    auto begin() const { return elems; }
+    auto end()         { return elems + length; }
+    auto end()   const { return elems + length; }
+
+    // let SmallList be indexable, e.g. list[3]
+    const int& operator[](int index) const {
+
+        if (index < 0)
+            error_smallListIndexWasNegative();
+        if (index >= length)
+            error_smallListIndexExceededLength();
+
+        return elems[index];
+    }
+    int& operator[](int index) {
+
+        return const_cast<int&>(
+            static_cast<const SmallList&>(*this)[index]);
+    }
+
+    // give SmallList all the familiar methods of std::vector
+    bool empty() const { 
+        return length == 0; 
+    }
+    int size() const { 
+        return length;
+    }
+    int* data() {
+        return elems;
+    }
+    const int* data() const {
+        return elems;
+    }
+
+    void push_back(int elem) {
+
+        if (length >= MAX_LIST_LENGTH)
+            error_smallListLengthExceededMax();
+
+        elems[length++] = elem;
+    }
+
+    void resize(int newLength, int value=0) {
+
+        if (length >= MAX_LIST_LENGTH)
+            error_smallListLengthExceededMax();
+
+        for (int i=length; i<newLength; i++)
+            elems[i] = value;
+
+        length = newLength;
+    }
+
+    const int& back() const {
+
+        if (empty())
+            error_smallListWasEmpty();
+
+        return elems[length - 1];
+    }
+    int& back() {
+
+        return const_cast<int&>(
+            static_cast<const SmallList&>(*this).back());
+    }
+};
+
+
+
+/*
+ * SMALL LIST CONSTRUCTORS
+ *
+ * which are separated here because making them actual
+ * constructors stops SmallList being POD/trivial, and
+ * makes it incompatible with CUDA kernels
+ */
+
+
+INLINE SmallList list_getEmptySmallList() {
+
+    SmallList out;
+    out.resize(0);
+    return out;
+}
+
+
+INLINE SmallList list_getSmallList(const int* begin, const int* end) {
+
+    if (end < begin)
+        error_smallListIndexExceededLength();
+
+    int length = static_cast<int>(end - begin);
+    if (length > MAX_LIST_LENGTH)
+        error_smallListLengthExceededMax();
+
+    SmallList out = list_getEmptySmallList();
+
+    for (const int* ptr = begin; ptr != end; ++ptr)
+        out.push_back(*ptr);
+
+    return out;
+}
+
+
+INLINE SmallList list_getSmallList(const int* elems, int length) {
+
+    return list_getSmallList(elems, elems + length);
+}
+
+
+INLINE SmallList list_getSmallList(std::initializer_list<int> init) {
+
+    return list_getSmallList(init.begin(), init.end());
+}
+
+
+
+/*
+ * ASSERT TRIVIAL
+ *
+ * which doesn't really gaurantee CUDA compatibility, but may
+ * catch a developer accidentally breaking compatibility
+ */
+
+
+static_assert(std::is_trivially_copyable_v<SmallList>);
+static_assert(std::is_standard_layout_v<SmallList>);
+
+
+
+#endif // SMALL_LIST_HPP

--- a/quest/src/core/small_list.hpp
+++ b/quest/src/core/small_list.hpp
@@ -72,13 +72,13 @@ public:
     // and other syntactic goodies :(
 
     // let SmallList be iterable, e.g. for(auto x : list)
-    auto begin()       { return elems; }
-    auto begin() const { return elems; }
-    auto end()         { return elems + length; }
-    auto end()   const { return elems + length; }
+    INLINE auto begin()       { return elems; }
+    INLINE auto begin() const { return elems; }
+    INLINE auto end()         { return elems + length; }
+    INLINE auto end()   const { return elems + length; }
 
     // let SmallList be indexable, e.g. list[3]
-    const int& operator[](int index) const {
+    INLINE const int& operator[](int index) const {
 
         if (index < 0)
             error_smallListIndexWasNegative();
@@ -87,30 +87,30 @@ public:
 
         return elems[index];
     }
-    int& operator[](int index) {
+    INLINE int& operator[](int index) {
 
         return const_cast<int&>(
             static_cast<const SmallList&>(*this)[index]);
     }
 
     // give SmallList all the familiar methods of std::vector
-    void clear() {
+    INLINE void clear() {
         length = 0;
     }
-    bool empty() const { 
+    INLINE bool empty() const { 
         return length == 0; 
     }
-    int size() const { 
+    INLINE int size() const { 
         return length;
     }
-    int* data() {
+    INLINE int* data() {
         return elems;
     }
-    const int* data() const {
+    INLINE const int* data() const {
         return elems;
     }
 
-    void push_back(int elem) {
+    INLINE void push_back(int elem) {
 
         if (length >= MAX_LIST_LENGTH)
             error_smallListLengthExceededMax();
@@ -118,7 +118,7 @@ public:
         elems[length++] = elem;
     }
 
-    void resize(int newLength, int value=0) {
+    INLINE void resize(int newLength, int value=0) {
 
         if (newLength > MAX_LIST_LENGTH)
             error_smallListLengthExceededMax();
@@ -129,14 +129,14 @@ public:
         length = newLength;
     }
 
-    const int& back() const {
+    INLINE const int& back() const {
 
         if (empty())
             error_smallListWasEmpty();
 
         return elems[length - 1];
     }
-    int& back() {
+    INLINE int& back() {
 
         return const_cast<int&>(
             static_cast<const SmallList&>(*this).back());

--- a/quest/src/core/small_list.hpp
+++ b/quest/src/core/small_list.hpp
@@ -144,6 +144,17 @@ public:
         return const_cast<int&>(
             static_cast<const SmallList&>(*this).back());
     }
+
+    INLINE void assign(size_t count, int value) {
+
+        if (count > MAX_LIST_LENGTH)
+            error_smallListLengthExceededMax();
+
+        for (auto i = 0; i < count; i++)
+            elems[i] = value;
+
+        length = count;
+    }
 };
 
 

--- a/quest/src/core/small_list.hpp
+++ b/quest/src/core/small_list.hpp
@@ -85,7 +85,7 @@ public:
 
         if (index < 0)
             error_smallListIndexWasNegative();
-        if (index >= length)
+        if (index >= static_cast<int>(length))
             error_smallListIndexExceededLength();
 
         return elems[index];
@@ -150,7 +150,7 @@ public:
         if (count > MAX_LIST_LENGTH)
             error_smallListLengthExceededMax();
 
-        for (auto i = 0; i < count; i++)
+        for (size_t i = 0; i < count; i++)
             elems[i] = value;
 
         length = count;
@@ -170,7 +170,7 @@ public:
 
 INLINE SmallList list_getEmptySmallList() {
 
-    SmallList out;
+    SmallList out{};
     out.clear();
     return out;
 }

--- a/quest/src/core/small_list.hpp
+++ b/quest/src/core/small_list.hpp
@@ -94,6 +94,9 @@ public:
     }
 
     // give SmallList all the familiar methods of std::vector
+    void clear() {
+        length = 0;
+    }
     bool empty() const { 
         return length == 0; 
     }
@@ -117,7 +120,7 @@ public:
 
     void resize(int newLength, int value=0) {
 
-        if (length >= MAX_LIST_LENGTH)
+        if (newLength > MAX_LIST_LENGTH)
             error_smallListLengthExceededMax();
 
         for (int i=length; i<newLength; i++)
@@ -154,7 +157,7 @@ public:
 INLINE SmallList list_getEmptySmallList() {
 
     SmallList out;
-    out.resize(0);
+    out.clear();
     return out;
 }
 
@@ -178,6 +181,9 @@ INLINE SmallList list_getSmallList(const int* begin, const int* end) {
 
 
 INLINE SmallList list_getSmallList(const int* elems, int length) {
+
+    if (elems == nullptr)
+        return list_getEmptySmallList();
 
     return list_getSmallList(elems, elems + length);
 }

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -160,7 +160,7 @@ int util_getRankWithBraQubitsFlipped(SmallList ketQubits, Qureg qureg) {
 SmallList util_getBraQubits(SmallList ketQubits, Qureg qureg) {
 
     for (int &qubit : ketQubits)
-        qubit += util_getBraQubit(qubit, qureg);
+        qubit = util_getBraQubit(qubit, qureg);
 
     return ketQubits;
 }

--- a/quest/src/core/utilities.cpp
+++ b/quest/src/core/utilities.cpp
@@ -19,6 +19,7 @@
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/memory.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/validation.hpp"
 #include "quest/src/cpu/cpu_config.hpp"
@@ -73,7 +74,7 @@ bool util_isQubitInSuffix(int qubit, Qureg qureg) {
     return qubit < qureg.logNumAmpsPerNode;
 }
 
-bool util_areAllQubitsInSuffix(vector<int> qubits, Qureg qureg) {
+bool util_areAllQubitsInSuffix(SmallList qubits, Qureg qureg) {
 
     for (int q : qubits)
         if (!util_isQubitInSuffix(q, qureg))
@@ -89,22 +90,21 @@ bool util_isBraQubitInSuffix(int ketQubit, Qureg qureg) {
     return ketQubit < qureg.logNumColsPerNode;
 }
 
-vector<int> getPrefixOrSuffixQubits(vector<int> qubits, Qureg qureg, bool getSuffix) {
+SmallList getPrefixOrSuffixQubits(SmallList qubits, Qureg qureg, bool getSuffix) {
 
     // note that when the qureg is local/duplicated, 
     // all qubits will be suffix, none will be prefix
 
-    vector<int> subQubits(0);
-    subQubits.reserve(qubits.size());
-
+    int newLength = 0;
     for (int qubit : qubits)
         if (util_isQubitInSuffix(qubit, qureg) == getSuffix)
-            subQubits.push_back(qubit);
+            qubits[newLength++] = qubit;
 
-    return subQubits;
+    qubits.resize(newLength);
+    return qubits;
 }
 
-std::array<vector<int>,2> util_getPrefixAndSuffixQubits(vector<int> qubits, Qureg qureg) {
+std::array<SmallList,2> util_getPrefixAndSuffixQubits(SmallList qubits, Qureg qureg) {
     return {
         getPrefixOrSuffixQubits(qubits, qureg, false), 
         getPrefixOrSuffixQubits(qubits, qureg, true)
@@ -132,7 +132,7 @@ int util_getRankWithQubitFlipped(int prefixKetQubit, Qureg qureg) {
     return rankFlip;
 }
 
-int util_getRankWithQubitsFlipped(vector<int> prefixQubits,  Qureg qureg) {
+int util_getRankWithQubitsFlipped(SmallList prefixQubits,  Qureg qureg) {
 
     int rank = qureg.rank;
     for (int qubit : prefixQubits)
@@ -148,7 +148,7 @@ int util_getRankWithBraQubitFlipped(int ketQubit, Qureg qureg) {
     return rankFlip;
 }
 
-int util_getRankWithBraQubitsFlipped(vector<int> ketQubits, Qureg qureg) {
+int util_getRankWithBraQubitsFlipped(SmallList ketQubits, Qureg qureg) {
 
     int rank = qureg.rank;
     for (int qubit : ketQubits)
@@ -157,23 +157,19 @@ int util_getRankWithBraQubitsFlipped(vector<int> ketQubits, Qureg qureg) {
     return rank;
 }
 
-vector<int> util_getBraQubits(vector<int> ketQubits, Qureg qureg) {
+SmallList util_getBraQubits(SmallList ketQubits, Qureg qureg) {
 
-    vector<int> braInds(0);
-    braInds.reserve(ketQubits.size());
+    for (int &qubit : ketQubits)
+        qubit += util_getBraQubit(qubit, qureg);
 
-    for (int qubit : ketQubits)
-        braInds.push_back(util_getBraQubit(qubit, qureg));
-
-    return braInds;
+    return ketQubits;
 }
 
-vector<int> util_getNonTargetedQubits(int* targets, int numTargets, int numQubits) {
+SmallList util_getNonTargetedQubits(SmallList targets, int numQubits) {
     
-    qindex mask = getBitMask(targets, numTargets);
+    qindex mask = util_getBitMask(targets);
 
-    vector<int> nonTargets;
-    nonTargets.reserve(numQubits - numTargets);
+    SmallList nonTargets = list_getEmptySmallList();
 
     for (int i=0; i<numQubits; i++)
         if (getBit(mask, i) == 0)
@@ -182,41 +178,83 @@ vector<int> util_getNonTargetedQubits(int* targets, int numTargets, int numQubit
     return nonTargets;
 }
 
-vector<int> util_getConcatenated(vector<int> list1, vector<int> list2) {
+SmallList util_getConcatenated(SmallList list1, SmallList list2) {
 
-    // modify the copy of list1
-    list1.insert(list1.end(), list2.begin(), list2.end());
+    for (auto elem : list2)
+        list1.push_back(elem);
+
     return list1;
 }
 
-vector<int> util_getSorted(vector<int> qubits) {
+SmallList util_getSorted(SmallList list) {
 
-    vector<int> copy = qubits;
-    std::sort(copy.begin(), copy.end());
-    return copy;
+    // optimise common edgecases
+    if (list.size() < 2)
+        return list;
+
+    if (list.size() == 2) {
+        if (list[0] > list[1])
+            std::swap(list[0], list[1]);
+        return list;
+    }
+
+    // fallback to inbuilt sort
+    std::sort(list.begin(), list.end());
+    return list;
 }
 
-vector<int> util_getSorted(vector<int> ctrls, vector<int> targs) {
+SmallList util_getSorted(SmallList ctrls, SmallList targs) {
 
     return util_getSorted(util_getConcatenated(ctrls, targs));
 }
 
-qindex util_getBitMask(vector<int> qubits) {
+SmallList util_getSorted(SmallList ctrls, std::initializer_list<int> targs) {
+
+    return util_getSorted(ctrls, list_getSmallList(targs));
+}
+
+SmallList util_getRange(int maxExcl) {
+
+    SmallList out = list_getEmptySmallList();
+
+    for (int i=0; i<maxExcl; i++)
+        out.push_back(i);
+        
+    return out;
+}
+
+SmallList util_getConstantList(int elem, int length) {
+
+    SmallList out = list_getEmptySmallList();
+
+    for (int i=0; i<length; i++)
+        out.push_back(elem);
+    
+    return out;
+}
+
+qindex util_getBitMask(SmallList qubits) {
 
     // inserts qubits in state 1
     return getBitMask(qubits.data(), qubits.size());
 }
 
-qindex util_getBitMask(vector<int> qubits, vector<int> states) {
+qindex util_getBitMask(SmallList qubits, SmallList states) {
 
+    // assumes qubits.size() == states.size()
     return getBitMask(qubits.data(), states.data(), states.size());
 }
 
-qindex util_getBitMask(vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, vector<int> targStates) {
+qindex util_getBitMask(SmallList ctrls, SmallList ctrlStates, SmallList targs, SmallList targStates) {
 
     auto qubits = util_getConcatenated(ctrls, targs);
     auto states = util_getConcatenated(ctrlStates, targStates);
     return util_getBitMask(qubits, states);
+}
+
+qindex util_getBitMask(SmallList ctrls, SmallList ctrlStates, std::initializer_list<int> targs, std::initializer_list<int> targStates) {
+
+    return util_getBitMask(ctrls, ctrlStates, list_getSmallList(targs), list_getSmallList(targStates));
 }
 
 

--- a/quest/src/core/utilities.hpp
+++ b/quest/src/core/utilities.hpp
@@ -20,6 +20,8 @@
 #include "quest/include/channels.h"
 #include "quest/include/environment.h"
 
+#include "quest/src/core/small_list.hpp"
+
 #include <type_traits>
 #include <functional>
 #include <utility>
@@ -38,36 +40,42 @@ using std::vector;
 
 bool util_isQubitInSuffix(int qubit, Qureg qureg);
 bool util_isBraQubitInSuffix(int ketQubit, Qureg qureg);
-bool util_areAllQubitsInSuffix(vector<int> qubits, Qureg qureg);
+bool util_areAllQubitsInSuffix(SmallList qubits, Qureg qureg);
 
 int util_getBraQubit(int ketQubit, Qureg qureg);
 
 int util_getPrefixInd(int qubit, Qureg qureg);
 int util_getPrefixBraInd(int ketQubit, Qureg qureg);
 
-std::array<vector<int>,2> util_getPrefixAndSuffixQubits(vector<int> qubits, Qureg qureg);
+std::array<SmallList,2> util_getPrefixAndSuffixQubits(SmallList qubits, Qureg qureg);
 
 int util_getRankBitOfQubit(int ketQubit, Qureg qureg);
 int util_getRankBitOfBraQubit(int ketQubit, Qureg qureg);
 
 int util_getRankWithQubitFlipped(int ketQubit, Qureg qureg);
-int util_getRankWithQubitsFlipped(vector<int> prefixQubits, Qureg qureg);
+int util_getRankWithQubitsFlipped(SmallList prefixQubits, Qureg qureg);
 
 int util_getRankWithBraQubitFlipped(int ketQubit, Qureg qureg);
-int util_getRankWithBraQubitsFlipped(vector<int> ketQubits, Qureg qureg);
+int util_getRankWithBraQubitsFlipped(SmallList ketQubits, Qureg qureg);
 
-vector<int> util_getBraQubits(vector<int> ketQubits, Qureg qureg);
+SmallList util_getBraQubits(SmallList ketQubits, Qureg qureg);
 
-vector<int> util_getNonTargetedQubits(int* targets, int numTargets, int numQubits);
+SmallList util_getNonTargetedQubits(SmallList, int numQubits);
 
-vector<int> util_getConcatenated(vector<int> list1, vector<int> list2);
+SmallList util_getConcatenated(SmallList list1, SmallList list2);
 
-vector<int> util_getSorted(vector<int> list);
-vector<int> util_getSorted(vector<int> ctrls, vector<int> targs);
+SmallList util_getRange(int maxExcl);
 
-qindex util_getBitMask(vector<int> qubits);
-qindex util_getBitMask(vector<int> qubits, vector<int> states);
-qindex util_getBitMask(vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, vector<int> targStates);
+SmallList util_getConstantList(int elem, int length);
+
+SmallList util_getSorted(SmallList list);
+SmallList util_getSorted(SmallList ctrls, SmallList targs);
+SmallList util_getSorted(SmallList ctrls, std::initializer_list<int> targs);
+
+qindex util_getBitMask(SmallList qubits);
+qindex util_getBitMask(SmallList qubits, SmallList states);
+qindex util_getBitMask(SmallList ctrls, SmallList ctrlStates, SmallList targs, SmallList targStates);
+qindex util_getBitMask(SmallList ctrls, SmallList ctrlStates, std::initializer_list<int> targs, std::initializer_list<int> targStates);
 
 
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -216,7 +216,7 @@ void cpu_fullstatediagmatr_setElemsFromMultiVarFunc(FullStateDiagMatr out, qcomp
 
 
 template <int NumQubits>
-qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubitInds, vector<int> qubitStates) {
+qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubitInds, SmallList qubitStates) {
 
     assert_numQubitsMatchesQubitStatesAndTemplateParam(qubitInds.size(), qubitStates.size(), NumQubits);
 
@@ -281,7 +281,7 @@ qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qu
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, cpu_statevec_packAmpsIntoBuffer, (Qureg, vector<int>, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, cpu_statevec_packAmpsIntoBuffer, (Qureg, SmallList, SmallList) )
 
 
 
@@ -291,7 +291,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, cpu_statevec_packAmpsIntoBuffe
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
+void cpu_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -321,7 +321,7 @@ void cpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> c
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) {
+void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -357,7 +357,7 @@ void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> c
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) {
+void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -393,9 +393,9 @@ void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> c
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subA, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subB, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subC, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subA, (Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subB, (Qureg qureg, SmallList ctrls, SmallList ctrlStates) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subC, (Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState) )
 
 
 
@@ -405,7 +405,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlSwap_subC, (
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr) {
+void cpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -441,7 +441,7 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, v
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1) {
+void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, qcomp fac0, qcomp fac1) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -477,8 +477,8 @@ void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, vector<int>, vector<int>, int, CompMatr1) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subB, (Qureg, vector<int>, vector<int>, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, SmallList, SmallList, int, CompMatr1) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDenseMatr_subB, (Qureg, SmallList, SmallList, qcomp, qcomp) )
 
 
 
@@ -488,7 +488,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDense
 
 
 template <int NumCtrls> 
-void cpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr) {
+void cpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -530,7 +530,7 @@ void cpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlTwoTargDenseMatr_sub, (Qureg, vector<int>, vector<int>, int, int, CompMatr2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlTwoTargDenseMatr_sub, (Qureg, SmallList, SmallList, int, int, CompMatr2) )
 
 
 
@@ -540,7 +540,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlTwoTargDense
 
 
 template <int NumCtrls, int NumTargs, bool ApplyConj, bool ApplyTransp>
-void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr) {
+void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr) {
     
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
     assert_numTargsMatchesTemplateParam(targs.size(), NumTargs);
@@ -572,7 +572,7 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 
     // prepare a mask which yields ctrls in specified state, and targs in all-zero
     auto sortedQubits   = util_getSorted(ctrls, targs);
-    auto qubitStateMask = util_getBitMask(ctrls, ctrlStates, targs, vector<int>(targs.size(),0));
+    auto qubitStateMask = util_getBitMask(ctrls, ctrlStates, targs, util_getConstantList(0,targs.size()));
 
     // attempt to use compile-time variables to automatically optimise/unroll dependent loops
     SET_VAR_AT_COMPILE_TIME(int, numCtrlBits, NumCtrls, ctrls.size());
@@ -642,7 +642,7 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 }
 
 
-INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_anyCtrlAnyTargDenseMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, CompMatr) )
+INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_anyCtrlAnyTargDenseMatr_sub, (Qureg, SmallList, SmallList, SmallList, CompMatr) )
 
 
 
@@ -652,7 +652,7 @@ INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr) {
+void cpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -684,7 +684,7 @@ void cpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, int, DiagMatr1) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDiagMatr_sub, (Qureg, SmallList, SmallList, int, DiagMatr1) )
 
 
 
@@ -694,7 +694,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlOneTargDiagM
 
 
 template <int NumCtrls>
-void cpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr) {
+void cpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -726,7 +726,7 @@ void cpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlTwoTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, int, int, DiagMatr2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlTwoTargDiagMatr_sub, (Qureg, SmallList, SmallList, int, int, DiagMatr2) )
 
 
 
@@ -736,7 +736,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevec_anyCtrlTwoTargDiagM
 
 
 template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower>
-void cpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent) {
+void cpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent) {
     
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
     assert_numTargsMatchesTemplateParam(targs.size(), NumTargs);
@@ -788,7 +788,7 @@ void cpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
 }
 
 
-INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_anyCtrlAnyTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, DiagMatr, qcomp) )
+INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevec_anyCtrlAnyTargDiagMatr_sub, (Qureg, SmallList, SmallList, SmallList, DiagMatr, qcomp) )
 
 
 /// @todo
@@ -961,8 +961,8 @@ INLINE void applyPauliUponAmpPair(
 
 template <int NumCtrls, int NumTargs>
 void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(
-    Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, 
-    vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac
+    Qureg qureg, SmallList ctrls, SmallList ctrlStates, 
+    SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac
 ) {
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
     assert_numTargsMatchesTemplateParam(x.size() + y.size(), NumTargs);
@@ -976,11 +976,11 @@ void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(
     cpu_qcomp f1 = getCpuQcomp(pairAmpFac);
     
     // only X and Y count as targets
-    vector<int> sortedTargsXY = util_getSorted(util_getConcatenated(x, y));
+    SmallList sortedTargsXY = util_getSorted(util_getConcatenated(x, y));
 
     // prepare a mask which yields ctrls in specified state, and X-Y targs in all-zero
     auto sortedQubits   = util_getSorted(ctrls, sortedTargsXY);
-    auto qubitStateMask = util_getBitMask(ctrls, ctrlStates, sortedTargsXY, vector<int>(sortedTargsXY.size(),0));
+    auto qubitStateMask = util_getBitMask(ctrls, ctrlStates, sortedTargsXY, util_getConstantList(0, sortedTargsXY.size()));
 
     // prepare masks for extracting Pauli parities
     auto maskXY = util_getBitMask(sortedTargsXY);
@@ -1044,8 +1044,8 @@ void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(
 
 template <int NumCtrls>
 void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(
-    Qureg qureg, vector<int> ctrls, vector<int> ctrlStates,
-    vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY
+    Qureg qureg, SmallList ctrls, SmallList ctrlStates,
+    SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY
 ) {
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -1091,8 +1091,8 @@ void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevector_anyCtrlPauliTensorOrGadget_subA, (Qureg, vector<int>, vector<int>, vector<int>, vector<int>, vector<int>, qcomp, qcomp) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevector_anyCtrlPauliTensorOrGadget_subB, (Qureg, vector<int>, vector<int>, vector<int>, vector<int>, vector<int>, qcomp, qcomp, qindex) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, cpu_statevector_anyCtrlPauliTensorOrGadget_subA, (Qureg, SmallList, SmallList, SmallList, SmallList, SmallList, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevector_anyCtrlPauliTensorOrGadget_subB, (Qureg, SmallList, SmallList, SmallList, SmallList, SmallList, qcomp, qcomp, qindex) )
 
 
 
@@ -1103,7 +1103,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevector_anyCtrlPauliTens
 
 template <int NumCtrls>
 void cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(
-    Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, 
+    Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, 
     qcomp fac0, qcomp fac1
 ) {
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
@@ -1135,7 +1135,7 @@ void cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub, (Qureg, vector<int>, vector<int>, vector<int>, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub, (Qureg, SmallList, SmallList, SmallList, qcomp, qcomp) )
 
 
 
@@ -1854,7 +1854,7 @@ void cpu_densmatr_oneQubitDamping_subD(Qureg qureg, int qubit, qreal prob) {
 
 
 template <int NumTargs>
-void cpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> targs, vector<int> pairTargs) {
+void cpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targs, SmallList pairTargs) {
 
     assert_numTargsMatchesTemplateParam(targs.size(), NumTargs);
 
@@ -1908,7 +1908,7 @@ void cpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> ta
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_densmatr_partialTrace_sub, (Qureg, Qureg, vector<int>, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_densmatr_partialTrace_sub, (Qureg, Qureg, SmallList, SmallList) )
 
 
 
@@ -1990,7 +1990,7 @@ qreal cpu_densmatr_calcTotalProb_sub(Qureg qureg) {
 
 
 template <int NumQubits>
-qreal cpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal cpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -2023,7 +2023,7 @@ qreal cpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubi
 
 
 template <int NumQubits>
-qreal cpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal cpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -2063,7 +2063,7 @@ qreal cpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubi
 
 
 template <int NumQubits>
-void cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -2104,7 +2104,7 @@ void cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qu
 
 
 template <int NumQubits>
-void cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -2148,10 +2148,10 @@ void cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qu
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, cpu_statevec_calcProbOfMultiQubitOutcome_sub, (Qureg, vector<int>, vector<int>) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, cpu_densmatr_calcProbOfMultiQubitOutcome_sub, (Qureg, vector<int>, vector<int>) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, vector<int>) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, cpu_statevec_calcProbOfMultiQubitOutcome_sub, (Qureg, SmallList, SmallList) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, cpu_densmatr_calcProbOfMultiQubitOutcome_sub, (Qureg, SmallList, SmallList) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, SmallList) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, SmallList) )
 
 
 
@@ -2259,7 +2259,7 @@ template qcomp cpu_densmatr_calcFidelityWithPureState_sub<false>(Qureg, Qureg);
  */
 
 
-qreal cpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qreal cpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
     // use cpu_qcomp arithmetic overloads (avoid qcomp's)
     cpu_qcomp* amps = getCpuQcompPtr(qureg.cpuAmps);
@@ -2283,7 +2283,7 @@ qreal cpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp cpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qcomp cpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
     // use cpu_qcomp arithmetic overloads (avoid qcomp's)
     cpu_qcomp* amps = getCpuQcompPtr(qureg.cpuAmps);
@@ -2318,7 +2318,7 @@ qcomp cpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     // use cpu_qcomp arithmetic overloads (avoid qcomp's)
     cpu_qcomp* amps = getCpuQcompPtr(qureg.cpuAmps);
@@ -2352,7 +2352,7 @@ qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int
 }
 
 
-qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     // use cpu_qcomp arithmetic overloads (avoid qcomp's)
     cpu_qcomp* amps   = getCpuQcompPtr(qureg.cpuAmps);
@@ -2395,7 +2395,7 @@ qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int
 }
 
 
-qcomp cpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp cpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     // use cpu_qcomp arithmetic overloads (avoid qcomp's)
     cpu_qcomp* amps = getCpuQcompPtr(qureg.cpuAmps);
@@ -2563,7 +2563,7 @@ template qcomp cpu_densmatr_calcExpecFullStateDiagMatr_sub<false,true >(Qureg, F
 
 
 template <int NumQubits>
-void cpu_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void cpu_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     // all qubits are in suffix
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
@@ -2594,7 +2594,7 @@ void cpu_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vecto
 
 
 template <int NumQubits>
-void cpu_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void cpu_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     // this function is merely an optimisation to avoid calling the above
     // cpu_statevec_multiQubitProjector_sub() twice upon a density matrix;
@@ -2635,8 +2635,8 @@ void cpu_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vecto
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_multiQubitProjector_sub, (Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_densmatr_multiQubitProjector_sub, (Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_multiQubitProjector_sub, (Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_densmatr_multiQubitProjector_sub, (Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) )
 
 
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -44,7 +44,7 @@ void cpu_fullstatediagmatr_setElemsFromMultiVarFunc(FullStateDiagMatr out, qcomp
  * COMMUNICATION BUFFER PACKING
  */
 
-template <int NumQubits> qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubitInds, vector<int> qubitStates);
+template <int NumQubits> qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubitInds, SmallList qubitStates);
 
 qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 
@@ -53,32 +53,32 @@ qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qu
  * SWAPS
  */
 
-template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2);
-template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates);
-template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState);
+template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2);
+template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates);
+template <int NumCtrls> void cpu_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState);
 
 
 /*
  * DENSE MATRIX
  */
 
-template <int NumCtrls> void cpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr);
-template <int NumCtrls> void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1);
+template <int NumCtrls> void cpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr);
+template <int NumCtrls> void cpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, qcomp fac0, qcomp fac1);
 
-template <int NumCtrls> void cpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr);
+template <int NumCtrls> void cpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr);
 
-template <int NumCtrls, int NumTargs, bool ApplyConj, bool ApplyTransp> void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr);
+template <int NumCtrls, int NumTargs, bool ApplyConj, bool ApplyTransp> void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr);
 
 
 /*
  * DIAGONAL MATRIX
  */
 
-template <int NumCtrls> void cpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr);
+template <int NumCtrls> void cpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr);
 
-template <int NumCtrls> void cpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr);
+template <int NumCtrls> void cpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr);
 
-template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower> void cpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent);
+template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower> void cpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent);
 
 template <bool HasPower> void cpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
@@ -89,11 +89,11 @@ template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight> void c
  * PAULI TENSOR AND GADGET
  */
 
-template <int NumCtrls, int NumTargs> void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
+template <int NumCtrls, int NumTargs> void cpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac);
 
-template <int NumCtrls> void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
+template <int NumCtrls> void cpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
 
-template <int NumCtrls> void cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp fac0, qcomp fac1);
+template <int NumCtrls> void cpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, qcomp fac0, qcomp fac1);
 
 
 /*
@@ -140,7 +140,7 @@ void cpu_densmatr_oneQubitDamping_subD(Qureg qureg, int qubit, qreal prob);
  * PARTIAL TRACE
  */
 
-template <int NumTargs> void cpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> targs, vector<int> pairTargs);
+template <int NumTargs> void cpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targs, SmallList pairTargs);
 
 
 /*
@@ -150,11 +150,11 @@ template <int NumTargs> void cpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg 
 qreal cpu_statevec_calcTotalProb_sub(Qureg qureg);
 qreal cpu_densmatr_calcTotalProb_sub(Qureg qureg);
 
-template <int NumQubits> qreal cpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes);
-template <int NumQubits> qreal cpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes);
+template <int NumQubits> qreal cpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes);
+template <int NumQubits> qreal cpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes);
 
-template <int NumQubits> void cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits);
-template <int NumQubits> void cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits);
+template <int NumQubits> void cpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits);
+template <int NumQubits> void cpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits);
 
 
 /*
@@ -172,12 +172,12 @@ template <bool Conj> qcomp cpu_densmatr_calcFidelityWithPureState_sub(Qureg rho,
  * EXPECTATION VALUES
  */
 
-qreal cpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
-qcomp cpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
+qreal cpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs);
+qcomp cpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs);
 
-qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
-qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
-qcomp cpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp cpu_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z);
+qcomp cpu_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z);
+qcomp cpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, SmallList x, SmallList y, SmallList z);
 
 template <bool HasPower, bool UseRealPow> qcomp cpu_statevec_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 template <bool HasPower, bool UseRealPow> qcomp cpu_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
@@ -187,8 +187,8 @@ template <bool HasPower, bool UseRealPow> qcomp cpu_densmatr_calcExpecFullStateD
  * PROJECTORS
  */
 
-template <int NumQubits> void cpu_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
-template <int NumQubits> void cpu_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
+template <int NumQubits> void cpu_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
+template <int NumQubits> void cpu_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
 
 
 /*

--- a/quest/src/gpu/gpu_cuquantum.cuh
+++ b/quest/src/gpu/gpu_cuquantum.cuh
@@ -44,6 +44,7 @@
 
 #include "quest/include/precision.h"
 
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
 #include "quest/src/gpu/gpu_qcomp.cuh"
@@ -174,7 +175,7 @@ void gpu_finalizeCuQuantum() {
  */
 
 
-void cuquantum_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
+void cuquantum_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) {
 
     // our SWAP targets are bundled into pairs
     int2 targPairs[] = {{targ1, targ2}};;
@@ -199,7 +200,7 @@ void cuquantum_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<
  */
 
 
-void cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, gpu_qcomp* flatMatrElems, bool applyAdj) {
+void cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, gpu_qcomp* flatMatrElems, bool applyAdj) {
 
     // this funciton is called 'subA' instead of just 'sub', because it is also called in 
     // the one-target case whereby it is strictly the embarrassingly parallel _subA scenario
@@ -222,7 +223,7 @@ void cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(Qureg qureg, vector<int> 
 // there is no bespoke cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subB()
 
 
-void cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, gpu_qcomp* flatMatrElems, bool conj) {
+void cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, gpu_qcomp* flatMatrElems, bool conj) {
 
     // beware that despite diagonal matrices being embarrassingly parallel,
     // the target qubits must still all be suffix-only to avoid a cuStateVec error
@@ -262,10 +263,11 @@ void cuquantum_densmatr_oneQubitDephasing_subA(Qureg qureg, int qubit, qreal pro
     gpu_qcomp a = {1,        0};
     gpu_qcomp b = {1-2*prob, 0};
     gpu_qcomp elems[] = {a, b, b, a};
-    vector<int> targs {qubit, util_getBraQubit(qubit,qureg)};
+    auto targs = list_getSmallList({qubit, util_getBraQubit(qubit,qureg)});
 
     bool conj = false;
-    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, {}, {}, targs, elems, conj);
+    auto empty = list_getEmptySmallList();
+    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, empty, empty, targs, elems, conj);
 }
 
 
@@ -299,10 +301,11 @@ void cuquantum_densmatr_twoQubitDephasing_subA(Qureg qureg, int qubitA, int qubi
     gpu_qcomp a = {1,          0};
     gpu_qcomp b = {1-4*prob/3, 0};
     gpu_qcomp elems[] = {a,b,b,b, b,a,b,b, b,b,a,b, b,b,b,a};
-    vector<int> targs {qubitA, qubitB, util_getBraQubit(qubitA,qureg), util_getBraQubit(qubitB,qureg)};
+    auto targs = list_getSmallList({qubitA, qubitB, util_getBraQubit(qubitA,qureg), util_getBraQubit(qubitB,qureg)});
 
     bool conj = false;
-    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, {}, {}, targs, elems, conj);
+    auto empty = list_getEmptySmallList();
+    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, empty, empty targs, elems, conj);
 }
 
 
@@ -339,7 +342,7 @@ qreal cuquantum_statevec_calcTotalProb_sub(Qureg qureg) {
 }
 
 
-qreal cuquantum_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal cuquantum_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     // cuQuantum probabilities are always double
     double prob;
@@ -353,7 +356,7 @@ qreal cuquantum_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int
 }
 
 
-void cuquantum_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void cuquantum_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     // cuQuantum can accept a host-pointer (like outProbs), but only
     // double precision; if qreal != double, we use temporary memory
@@ -384,12 +387,12 @@ void cuquantum_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qu
  */
 
 
-qreal cuquantum_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qreal cuquantum_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     // prepare term (XX...YY...ZZ...)
     size_t numPaulis = x.size() + y.size() + z.size();
     vector<custatevecPauli_t> paulis; 
-    vector<int32_t> targs; 
+    vector<int32_t> targs; // forego SmallList for symmetry
     
     paulis.reserve(numPaulis);
     targs.reserve(numPaulis);
@@ -416,9 +419,10 @@ qreal cuquantum_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vect
 }
 
 
-qreal cuquantum_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qreal cuquantum_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
-    return cuquantum_statevec_calcExpecPauliStr_subA(qureg, {}, {}, targs);
+    auto empty = list_getEmptySmallList();
+    return cuquantum_statevec_calcExpecPauliStr_subA(qureg, empty, empty, targs);
 }
 
 
@@ -428,7 +432,7 @@ qreal cuquantum_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
  */
 
 
-void cuquantum_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void cuquantum_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     CUDA_CHECK( custatevecCollapseByBitString(
         config.handle,

--- a/quest/src/gpu/gpu_cuquantum.cuh
+++ b/quest/src/gpu/gpu_cuquantum.cuh
@@ -285,9 +285,9 @@ void cuquantum_densmatr_oneQubitDephasing_subB(Qureg qureg, int ketQubit, qreal 
     int targ = qureg.logNumAmpsPerNode - 1; // leftmost suffix bra qubit
 
     bool conj = false;
-    auto ctrls  = list_getEmptySmallList({ketQubit});
-    auto states = list_getEmptySmallList({!braBit});
-    auto targs  = list_getEmptySmallList({targ});
+    auto ctrls  = list_getSmallList({ketQubit});
+    auto states = list_getSmallList({!braBit});
+    auto targs  = list_getSmallList({targ});
     cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, states, targs, elems, conj);
 }
 

--- a/quest/src/gpu/gpu_cuquantum.cuh
+++ b/quest/src/gpu/gpu_cuquantum.cuh
@@ -285,7 +285,10 @@ void cuquantum_densmatr_oneQubitDephasing_subB(Qureg qureg, int ketQubit, qreal 
     int targ = qureg.logNumAmpsPerNode - 1; // leftmost suffix bra qubit
 
     bool conj = false;
-    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, {ketQubit}, {!braBit}, {targ}, elems, conj);
+    auto ctrls  = list_getEmptySmallList({ketQubit});
+    auto states = list_getEmptySmallList({!braBit});
+    auto targs  = list_getEmptySmallList({targ});
+    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, states, targs, elems, conj);
 }
 
 
@@ -305,7 +308,7 @@ void cuquantum_densmatr_twoQubitDephasing_subA(Qureg qureg, int qubitA, int qubi
 
     bool conj = false;
     auto empty = list_getEmptySmallList();
-    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, empty, empty targs, elems, conj);
+    cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, empty, empty, targs, elems, conj);
 }
 
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -363,7 +363,7 @@ void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, Smal
 #if COMPILE_CUQUANTUM
 
     bool applyAdj = false;
-    auto targsList = list_getSmallList({targ});
+    auto targsList = list_getSmallList({targ1, targ2});
     auto arr = getFlattenedGpuQcompMatrix<4>(matr.elems); // explicit template for MSVC, grr!
     cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(qureg, ctrls, ctrlStates, targsList, arr.data(), applyAdj);
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -134,7 +134,7 @@ void gpu_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliStr
 
 
 template <int NumQubits>
-qindex gpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubits, vector<int> qubitStates) {
+qindex gpu_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubits, SmallList qubitStates) {
 
     assert_numQubitsMatchesQubitStatesAndTemplateParam(qubits.size(), qubitStates.size(), NumQubits);
 
@@ -187,7 +187,7 @@ qindex gpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qu
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, gpu_statevec_packAmpsIntoBuffer, (Qureg, vector<int>, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, gpu_statevec_packAmpsIntoBuffer, (Qureg, SmallList, SmallList) )
 
 
 
@@ -197,7 +197,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, gpu_statevec_packAmpsIntoBuffe
 
 
 template <int NumCtrls> 
-void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) {
+void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -225,7 +225,7 @@ void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> c
 
 
 template <int NumCtrls> 
-void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) {
+void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -250,7 +250,7 @@ void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> c
 
 
 template <int NumCtrls> 
-void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) {
+void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -274,9 +274,9 @@ void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> c
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subA, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subB, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subC, (Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subA, (Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subB, (Qureg qureg, SmallList ctrls, SmallList ctrlStates) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subC, (Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState) )
 
 
 
@@ -286,7 +286,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlSwap_subC, (
 
 
 template <int NumCtrls>
-void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr) {
+void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -319,7 +319,7 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, v
 
 
 template <int NumCtrls>
-void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1) {
+void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, qcomp fac0, qcomp fac1) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -344,8 +344,8 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, v
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, vector<int>, vector<int>, int, CompMatr1) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subB, (Qureg, vector<int>, vector<int>, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subA, (Qureg, SmallList, SmallList, int, CompMatr1) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDenseMatr_subB, (Qureg, SmallList, SmallList, qcomp, qcomp) )
 
 
 
@@ -355,7 +355,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDense
 
 
 template <int NumCtrls> 
-void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr) {
+void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -388,7 +388,7 @@ void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 #endif
 }
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlTwoTargDenseMatr_sub, (Qureg, vector<int>, vector<int>, int, int, CompMatr2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlTwoTargDenseMatr_sub, (Qureg, SmallList, SmallList, int, int, CompMatr2) )
 
 
 
@@ -398,7 +398,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlTwoTargDense
 
 
 template <int NumCtrls, int NumTargs, bool ApplyConj, bool ApplyTransp>
-void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr) {
+void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
     assert_numTargsMatchesTemplateParam(targs.size(), NumTargs);
@@ -434,7 +434,7 @@ void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 
     devints deviceTargs = targs;
     devints deviceQubits = util_getSorted(ctrls, targs);
-    qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targs, vector<int>(targs.size(),0));
+    qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targs, util_getConstantList(0,targs.size()));
 
     // unpacking args (to better distinguish below signatures)
     auto ampsPtr   = getGpuQcompPtr(qureg.gpuAmps);
@@ -519,7 +519,7 @@ void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, ve
 }
 
 
-INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_anyCtrlAnyTargDenseMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, CompMatr) )
+INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_anyCtrlAnyTargDenseMatr_sub, (Qureg, SmallList, SmallList, SmallList, CompMatr) )
 
 
 
@@ -529,7 +529,7 @@ INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_
 
 
 template <int NumCtrls> 
-void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr) {
+void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -550,7 +550,8 @@ void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
         bool conj = false;
 
         // we can pass 1D CPU .elems array directly to cuQuantum which will recognise host pointers
-        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, {targ}, getGpuQcompPtr(matr.elems), conj);
+        auto targs = list_getSmallList({targ});
+        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, targs, getGpuQcompPtr(matr.elems), conj);
         
         // explicitly return to avoid re-simulation below
         return;
@@ -587,7 +588,7 @@ void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, int, DiagMatr1) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDiagMatr_sub, (Qureg, SmallList, SmallList, int, DiagMatr1) )
 
 
 
@@ -597,7 +598,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlOneTargDiagM
 
 
 template <int NumCtrls> 
-void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr) {
+void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -618,7 +619,8 @@ void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
         bool conj = false;
 
         // we can pass 1D CPU array directly to cuQuantum, and it will recognise host pointers
-        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, {targ1, targ2}, getGpuQcompPtr(matr.elems), conj);
+        auto targs = list_getSmallList({targ1, targ2});
+        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, targs, getGpuQcompPtr(matr.elems), conj);
 
         // explicitly return to avoid re-simulation below
         return;
@@ -656,7 +658,7 @@ void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlTwoTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, int, int, DiagMatr2) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlTwoTargDiagMatr_sub, (Qureg, SmallList, SmallList, int, int, DiagMatr2) )
 
 
 
@@ -666,7 +668,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevec_anyCtrlTwoTargDiagM
 
 
 template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower>
-void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent) {
+void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
     assert_numTargsMatchesTemplateParam(targs.size(), NumTargs);
@@ -724,7 +726,7 @@ void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vec
 }
 
 
-INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_anyCtrlAnyTargDiagMatr_sub, (Qureg, vector<int>, vector<int>, vector<int>, DiagMatr, qcomp) )
+INSTANTIATE_TWO_BOOL_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevec_anyCtrlAnyTargDiagMatr_sub, (Qureg, SmallList, SmallList, SmallList, DiagMatr, qcomp) )
 
 
 
@@ -792,7 +794,7 @@ template void gpu_densmatr_allTargDiagMatr_sub<true,  false, true,  false> (Qure
 
 
 template <int NumCtrls, int NumTargs> 
-void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac) {
+void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
     assert_numTargsMatchesTemplateParam(x.size() + y.size(), NumTargs);
@@ -813,7 +815,7 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ct
 
     devints deviceTargs   = targsXY;
     devints deviceQubits  = util_getSorted(ctrls, targsXY);
-    qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targsXY, vector<int>(targsXY.size(),0));
+    qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targsXY, util_getConstantList(0,targsXY.size()));
 
     // unlike the analogous cpu routine, this function has only a single parallelisation
     // granularity; where every pair-of-amps is modified by an independent thread, despite
@@ -836,7 +838,7 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ct
 
 
 template <int NumCtrls> 
-void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY) {
+void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -866,8 +868,8 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ct
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subA, (Qureg, vector<int>, vector<int>, vector<int>, vector<int>, vector<int>, qcomp, qcomp) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subB, (Qureg, vector<int>, vector<int>, vector<int>, vector<int>, vector<int>, qcomp, qcomp, qindex) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS_AND_TARGS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subA, (Qureg, SmallList, SmallList, SmallList, SmallList, SmallList, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlPauliTensorOrGadget_subB, (Qureg, SmallList, SmallList, SmallList, SmallList, SmallList, qcomp, qcomp, qindex) )
 
 
 
@@ -877,7 +879,7 @@ INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlPauliTens
 
 
 template <int NumCtrls> 
-void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp fac0, qcomp fac1) {
+void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, qcomp fac0, qcomp fac1) {
 
     assert_numCtrlsMatchesNumCtrlStatesAndTemplateParam(ctrls.size(), ctrlStates.size(), NumCtrls);
 
@@ -902,7 +904,7 @@ void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> c
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub, (Qureg, vector<int>, vector<int>, vector<int>, qcomp, qcomp) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_CTRLS( void, gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub, (Qureg, SmallList, SmallList, SmallList, qcomp, qcomp) )
 
 
 
@@ -1430,7 +1432,7 @@ void gpu_densmatr_oneQubitDamping_subD(Qureg qureg, int qubit, qreal prob) {
 
 
 template <int NumTargs> 
-void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> targs, vector<int> pairTargs) {
+void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targs, SmallList pairTargs) {
 
     assert_numTargsMatchesTemplateParam(targs.size(), NumTargs);
 
@@ -1454,7 +1456,7 @@ void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> ta
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_densmatr_partialTrace_sub, (Qureg, Qureg, vector<int>, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_densmatr_partialTrace_sub, (Qureg, Qureg, SmallList, SmallList) )
 
 
 
@@ -1491,7 +1493,7 @@ qreal gpu_densmatr_calcTotalProb_sub(Qureg qureg) {
 
 
 template <int NumQubits> 
-qreal gpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal gpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -1512,7 +1514,7 @@ qreal gpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubi
 
 
 template <int NumQubits> 
-qreal gpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal gpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -1528,7 +1530,7 @@ qreal gpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubi
 
 
 template <int NumQubits> 
-void gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -1582,7 +1584,7 @@ void gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qu
 
 
 template <int NumQubits> 
-void gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits) {
+void gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits) {
 
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
 
@@ -1616,11 +1618,11 @@ void gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qu
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, gpu_statevec_calcProbOfMultiQubitOutcome_sub, (Qureg, vector<int>, vector<int>) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, gpu_densmatr_calcProbOfMultiQubitOutcome_sub, (Qureg, vector<int>, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, gpu_statevec_calcProbOfMultiQubitOutcome_sub, (Qureg, SmallList, SmallList) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qreal, gpu_densmatr_calcProbOfMultiQubitOutcome_sub, (Qureg, SmallList, SmallList) )
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, vector<int>) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, vector<int>) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, SmallList) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub, (qreal* outProbs, Qureg, SmallList) )
 
 
 
@@ -1681,7 +1683,7 @@ template qcomp gpu_densmatr_calcFidelityWithPureState_sub<false>(Qureg, Qureg);
  */
 
 
-qreal gpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qreal gpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
 #if COMPILE_CUQUANTUM
 
@@ -1698,7 +1700,7 @@ qreal gpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
 #if COMPILE_CUQUANTUM || COMPILE_CUDA
 
@@ -1712,7 +1714,7 @@ qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
 #if COMPILE_CUQUANTUM
 
@@ -1730,7 +1732,7 @@ qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int
 }
 
 
-qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
 #if COMPILE_CUQUANTUM || COMPILE_CUDA
 
@@ -1744,7 +1746,7 @@ qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int
 }
 
 
-qcomp gpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+qcomp gpu_densmatr_calcExpecPauliStr_sub(Qureg qureg, SmallList x, SmallList y, SmallList z) {
     
 #if COMPILE_CUQUANTUM || COMPILE_CUDA
 
@@ -1815,7 +1817,7 @@ template qcomp gpu_densmatr_calcExpecFullStateDiagMatr_sub<false,true >(Qureg, F
 
 
 template <int NumQubits> 
-void gpu_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void gpu_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     // all qubits are in suffix
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
@@ -1837,7 +1839,7 @@ void gpu_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vecto
 
 
 template <int NumQubits> 
-void gpu_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) {
+void gpu_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) {
 
     // qubits are unconstrained, and can include prefix qubits
     assert_numTargsMatchesTemplateParam(qubits.size(), NumQubits);
@@ -1853,8 +1855,8 @@ void gpu_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vecto
 }
 
 
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_statevec_multiQubitProjector_sub, (Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) )
-INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_densmatr_multiQubitProjector_sub, (Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_statevec_multiQubitProjector_sub, (Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, gpu_densmatr_multiQubitProjector_sub, (Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob) )
 
 
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -363,8 +363,9 @@ void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, Smal
 #if COMPILE_CUQUANTUM
 
     bool applyAdj = false;
+    auto targsList = list_getSmallList({targ});
     auto arr = getFlattenedGpuQcompMatrix<4>(matr.elems); // explicit template for MSVC, grr!
-    cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(qureg, ctrls, ctrlStates, {targ1, targ2}, arr.data(), applyAdj);
+    cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(qureg, ctrls, ctrlStates, targsList, arr.data(), applyAdj);
 
 #elif COMPILE_CUDA
 

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -293,8 +293,9 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, Sma
 #if COMPILE_CUQUANTUM
 
     bool applyAdj = false;
+    auto targsList = list_getSmallList({targ});
     auto arr = getFlattenedGpuQcompMatrix<2>(matr.elems); // explicit template for MSVC, grr!
-    cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(qureg, ctrls, ctrlStates, {targ}, arr.data(), applyAdj);
+    cuquantum_statevec_anyCtrlAnyTargDenseMatrix_subA(qureg, ctrls, ctrlStates, targsList, arr.data(), applyAdj);
 
 #elif COMPILE_CUDA
 
@@ -550,8 +551,8 @@ void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, Small
         bool conj = false;
 
         // we can pass 1D CPU .elems array directly to cuQuantum which will recognise host pointers
-        auto targs = list_getSmallList({targ});
-        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, targs, getGpuQcompPtr(matr.elems), conj);
+        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(
+            qureg, ctrls, ctrlStates, list_getSmallList({targ}), getGpuQcompPtr(matr.elems), conj);
         
         // explicitly return to avoid re-simulation below
         return;
@@ -613,14 +614,15 @@ void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, Small
 
 #if COMPILE_CUQUANTUM
 
-    if (util_areAllQubitsInSuffix({targ1,targ2}, qureg)) {
+    auto targsList = list_getSmallList({targ1, targ2});
+
+    if (util_areAllQubitsInSuffix(targsList, qureg)) {
 
         // we never conjugate DiagMatr2 at this level; the caller will have already conjugated
         bool conj = false;
 
         // we can pass 1D CPU array directly to cuQuantum, and it will recognise host pointers
-        auto targs = list_getSmallList({targ1, targ2});
-        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, targs, getGpuQcompPtr(matr.elems), conj);
+        cuquantum_statevec_anyCtrlAnyTargDiagMatr_sub(qureg, ctrls, ctrlStates, targsList, getGpuQcompPtr(matr.elems), conj);
 
         // explicitly return to avoid re-simulation below
         return;

--- a/quest/src/gpu/gpu_subroutines.cpp
+++ b/quest/src/gpu/gpu_subroutines.cpp
@@ -144,7 +144,7 @@ qindex gpu_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubits, SmallList 
     qindex numBlocks = getNumBlocks(numThreads);
     qindex sendInd = getSubBufferSendInd(qureg);
 
-    devints sortedQubits = util_getSorted(qubits);
+    devints sortedQubits = getDevInts(util_getSorted(qubits));
     qindex qubitStateMask  = util_getBitMask(qubits, qubitStates);
 
     kernel_statevec_packAmpsIntoBuffer <NumQubits> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -210,7 +210,7 @@ void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlS
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(2 + ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints sortedQubits = util_getSorted(ctrls, {targ2, targ1});
+    devints sortedQubits = getDevInts(util_getSorted(ctrls, {targ2, targ1}));
     qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, {targ2, targ1}, {0, 1});
 
     kernel_statevec_anyCtrlSwap_subA <NumCtrls> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -235,7 +235,7 @@ void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlS
     qindex numBlocks = getNumBlocks(numThreads);
     qindex recvInd = getBufferRecvInd();
 
-    devints sortedCtrls = util_getSorted(ctrls);
+    devints sortedCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
 
     kernel_statevec_anyCtrlSwap_subB <NumCtrls> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -260,7 +260,7 @@ void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlS
     qindex numBlocks = getNumBlocks(numThreads);
     qindex recvInd = getBufferRecvInd();
 
-    devints sortedQubits = util_getSorted(ctrls, {targ});
+    devints sortedQubits = getDevInts(util_getSorted(ctrls, {targ}));
     qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, {targ}, {targState});
 
     kernel_statevec_anyCtrlSwap_subC <NumCtrls> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -301,7 +301,7 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, Sma
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size() + 1);
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints sortedQubits = util_getSorted(ctrls, {targ});
+    devints sortedQubits = getDevInts(util_getSorted(ctrls, {targ}));
     qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, {targ}, {0});
 
     auto [m00, m01, m10, m11] = getFlattenedGpuQcompMatrix<2>(matr.elems); // explicit template for MSVC, grr!
@@ -329,7 +329,7 @@ void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, Sma
     qindex numBlocks = getNumBlocks(numThreads);
     qindex recvInd = getBufferRecvInd();
 
-    devints sortedCtrls = util_getSorted(ctrls);
+    devints sortedCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
 
     kernel_statevec_anyCtrlOneTargDenseMatr_subB <NumCtrls> <<<numBlocks,NUM_THREADS_PER_BLOCK>>> (
@@ -370,7 +370,7 @@ void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, Smal
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size() + 2);
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints sortedQubits = util_getSorted(ctrls, {targ1,targ2});
+    devints sortedQubits = getDevInts(util_getSorted(ctrls, {targ1,targ2}));
     qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, {targ1,targ2}, {0,0});
 
     // unpack matrix elems which are more efficiently accessed by kernels as args than shared mem (... maybe...)
@@ -432,8 +432,8 @@ void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, Smal
     // task each thread with processing more than a single batch
     qindex numBatches = qureg.numAmpsPerNode / powerOf2(ctrls.size() + targs.size());
 
-    devints deviceTargs = targs;
-    devints deviceQubits = util_getSorted(ctrls, targs);
+    devints deviceTargs = getDevInts(targs);
+    devints deviceQubits = getDevInts(util_getSorted(ctrls, targs));
     qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targs, util_getConstantList(0,targs.size()));
 
     // unpacking args (to better distinguish below signatures)
@@ -569,7 +569,7 @@ void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, Small
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints deviceCtrls = util_getSorted(ctrls);
+    devints deviceCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
     auto elems = getGpuQcompArray<2>(matr.elems); // explicit template for MSVC, grr!
 
@@ -638,7 +638,7 @@ void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, Small
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints deviceCtrls = util_getSorted(ctrls);
+    devints deviceCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
     auto elems = getGpuQcompArray<4>(matr.elems); // explicit template for MSVC, grr!
 
@@ -706,8 +706,8 @@ void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, Small
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints deviceTargs = targs;
-    devints deviceCtrls = util_getSorted(ctrls);
+    devints deviceTargs = getDevInts(targs);
+    devints deviceCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
 
     kernel_statevec_anyCtrlAnyTargDiagMatr_sub <NumCtrls, NumTargs, ApplyConj, HasPower> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -813,8 +813,8 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, SmallList ctrl
     auto maskXY  = util_getBitMask(targsXY);
     auto maskYZ  = util_getBitMask(util_getConcatenated(y, z));
 
-    devints deviceTargs   = targsXY;
-    devints deviceQubits  = util_getSorted(ctrls, targsXY);
+    devints deviceTargs   = getDevInts(targsXY);
+    devints deviceQubits  = getDevInts(util_getSorted(ctrls, targsXY));
     qindex qubitStateMask = util_getBitMask(ctrls, ctrlStates, targsXY, util_getConstantList(0,targsXY.size()));
 
     // unlike the analogous cpu routine, this function has only a single parallelisation
@@ -852,7 +852,7 @@ void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, SmallList ctrl
     auto maskXY = util_getBitMask(util_getConcatenated(x, y));
     auto maskYZ = util_getBitMask(util_getConcatenated(y, z));
 
-    devints sortedCtrls = util_getSorted(ctrls);
+    devints sortedCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
 
     kernel_statevector_anyCtrlPauliTensorOrGadget_subB <NumCtrls> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -888,7 +888,7 @@ void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, SmallList ctr
     qindex numThreads = qureg.numAmpsPerNode / powerOf2(ctrls.size());
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints sortedCtrls = util_getSorted(ctrls);
+    devints sortedCtrls = getDevInts(util_getSorted(ctrls));
     qindex ctrlStateMask = util_getBitMask(ctrls, ctrlStates);
     qindex targMask = util_getBitMask(targs);
 
@@ -1441,9 +1441,9 @@ void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targ
     qindex numThreads = outQureg.numAmpsPerNode;
     qindex numBlocks = getNumBlocks(numThreads);
 
-    devints devTargs = targs;
-    devints devPairTargs = pairTargs;
-    devints devAllTargs = util_getSorted(targs, pairTargs);
+    devints devTargs = getDevInts(targs);
+    devints devPairTargs = getDevInts(pairTargs);
+    devints devAllTargs = getDevInts(util_getSorted(targs, pairTargs));
 
     kernel_densmatr_partialTrace_sub <NumTargs> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
         getGpuQcompPtr(inQureg.gpuAmps), getGpuQcompPtr(outQureg.gpuAmps), numThreads,
@@ -1562,7 +1562,7 @@ void gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qu
     qindex numBlocks = getNumBlocks(numThreads);
 
     // allocate exponentially-big temporary memory (error if failed)
-    devints devQubits = qubits;
+    devints devQubits = getDevInts(qubits);
     devreals devProbs = getDeviceRealsVec(powerOf2(qubits.size())); // throws
 
     kernel_statevec_calcProbsOfAllMultiQubitOutcomes_sub<NumQubits> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (
@@ -1599,7 +1599,7 @@ void gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qu
     qindex numAmpsPerCol = powerOf2(qureg.numQubits);
 
     // allocate exponentially-big temporary memory (error if failed)
-    devints devQubits = qubits;
+    devints devQubits = getDevInts(qubits);
     devreals devProbs = getDeviceRealsVec(powerOf2(qubits.size())); // throws
 
     kernel_densmatr_calcProbsOfAllMultiQubitOutcomes_sub<NumQubits> <<<numBlocks, NUM_THREADS_PER_BLOCK>>> (

--- a/quest/src/gpu/gpu_subroutines.hpp
+++ b/quest/src/gpu/gpu_subroutines.hpp
@@ -12,6 +12,8 @@
 #include "quest/include/paulis.h"
 #include "quest/include/matrices.h"
 
+#include "quest/src/core/small_list.hpp"
+
 #include <vector>
 
 using std::vector;
@@ -37,7 +39,7 @@ void gpu_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliStr
  * COMMUNICATION BUFFER PACKING
  */
 
-template <int NumQubits> qindex gpu_statevec_packAmpsIntoBuffer(Qureg qureg, vector<int> qubits, vector<int> qubitStates);
+template <int NumQubits> qindex gpu_statevec_packAmpsIntoBuffer(Qureg qureg, SmallList qubits, SmallList qubitStates);
 
 qindex gpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 
@@ -46,32 +48,32 @@ qindex gpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qu
  * SWAPS
  */
 
-template <int NumCtrls> void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2);
-template <int NumCtrls> void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates);
-template <int NumCtrls> void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, int targState);
+template <int NumCtrls> void gpu_statevec_anyCtrlSwap_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2);
+template <int NumCtrls> void gpu_statevec_anyCtrlSwap_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates);
+template <int NumCtrls> void gpu_statevec_anyCtrlSwap_subC(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, int targState);
 
 
 /*
  * DENSE MATRIX
  */
 
-template <int NumCtrls> void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, CompMatr1 matr);
-template <int NumCtrls> void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, qcomp fac0, qcomp fac1);
+template <int NumCtrls> void gpu_statevec_anyCtrlOneTargDenseMatr_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, CompMatr1 matr);
+template <int NumCtrls> void gpu_statevec_anyCtrlOneTargDenseMatr_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, qcomp fac0, qcomp fac1);
 
-template <int NumCtrls> void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, CompMatr2 matr);
+template <int NumCtrls> void gpu_statevec_anyCtrlTwoTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, CompMatr2 matr);
 
-template <int NumCtrls, int NumTargs, bool ApplyConj, bool ApplyTransp> void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, CompMatr matr);
+template <int NumCtrls, int NumTargs, bool ApplyConj, bool ApplyTransp> void gpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, CompMatr matr);
 
 
 /*
  * DIAGONAL MATRIX
  */
 
-template <int NumCtrls> void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ, DiagMatr1 matr);
+template <int NumCtrls> void gpu_statevec_anyCtrlOneTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ, DiagMatr1 matr);
 
-template <int NumCtrls> void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, int targ1, int targ2, DiagMatr2 matr);
+template <int NumCtrls> void gpu_statevec_anyCtrlTwoTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, int targ1, int targ2, DiagMatr2 matr);
 
-template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower> void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, DiagMatr matr, qcomp exponent);
+template <int NumCtrls, int NumTargs, bool ApplyConj, bool HasPower> void gpu_statevec_anyCtrlAnyTargDiagMatr_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, DiagMatr matr, qcomp exponent);
 
 template <bool HasPower> void gpu_statevec_allTargDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 
@@ -82,11 +84,11 @@ template <bool HasPower, bool ApplyLeft, bool ApplyRight, bool ConjRight> void g
  * PAULI TENSOR AND GADGET
  */
 
-template <int NumCtrls, int NumTargs> void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac);
+template <int NumCtrls, int NumTargs> void gpu_statevector_anyCtrlPauliTensorOrGadget_subA(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac);
 
-template <int NumCtrls> void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> x, vector<int> y, vector<int> z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
+template <int NumCtrls> void gpu_statevector_anyCtrlPauliTensorOrGadget_subB(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList x, SmallList y, SmallList z, qcomp ampFac, qcomp pairAmpFac, qindex bufferMaskXY);
 
-template <int NumCtrls> void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, vector<int> ctrls, vector<int> ctrlStates, vector<int> targs, qcomp fac0, qcomp fac1);
+template <int NumCtrls> void gpu_statevector_anyCtrlAnyTargZOrPhaseGadget_sub(Qureg qureg, SmallList ctrls, SmallList ctrlStates, SmallList targs, qcomp fac0, qcomp fac1);
 
 
 /*
@@ -133,7 +135,7 @@ void gpu_densmatr_oneQubitDamping_subD(Qureg qureg, int qubit, qreal prob);
  * PARTIAL TRACE
  */
 
-template <int NumTargs> void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, vector<int> targs, vector<int> pairTargs);
+template <int NumTargs> void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg outQureg, SmallList targs, SmallList pairTargs);
 
 
 /*
@@ -143,11 +145,11 @@ template <int NumTargs> void gpu_densmatr_partialTrace_sub(Qureg inQureg, Qureg 
 qreal gpu_statevec_calcTotalProb_sub(Qureg qureg);
 qreal gpu_densmatr_calcTotalProb_sub(Qureg qureg);
 
-template <int NumQubits> qreal gpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes);
-template <int NumQubits> qreal gpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes);
+template <int NumQubits> qreal gpu_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes);
+template <int NumQubits> qreal gpu_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes);
 
-template <int NumQubits> void gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits);
-template <int NumQubits> void gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, vector<int> qubits);
+template <int NumQubits> void gpu_statevec_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits);
+template <int NumQubits> void gpu_densmatr_calcProbsOfAllMultiQubitOutcomes_sub(qreal* outProbs, Qureg qureg, SmallList qubits);
 
 
 /*
@@ -165,13 +167,13 @@ template <bool Conj> qcomp gpu_densmatr_calcFidelityWithPureState_sub(Qureg rho,
  * EXPECTATION VALUES
  */
 
-qreal gpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
-qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs);
+qreal gpu_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs);
+qcomp gpu_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs);
 
 
-qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
-qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
-qcomp gpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, vector<int> x, vector<int> y, vector<int> z);
+qcomp gpu_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z);
+qcomp gpu_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z);
+qcomp gpu_densmatr_calcExpecPauliStr_sub (Qureg qureg, SmallList x, SmallList y, SmallList z);
 
 template <bool HasPower, bool UseRealPow> qcomp gpu_statevec_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
 template <bool HasPower, bool UseRealPow> qcomp gpu_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateDiagMatr matr, qcomp exponent);
@@ -181,8 +183,8 @@ template <bool HasPower, bool UseRealPow> qcomp gpu_densmatr_calcExpecFullStateD
  * PROJECTORS
  */
 
-template <int NumQubits> void gpu_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
-template <int NumQubits> void gpu_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal prob);
+template <int NumQubits> void gpu_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
+template <int NumQubits> void gpu_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal prob);
 
 
 /*

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -37,6 +37,7 @@
 #include "quest/src/core/errors.hpp"
 #include "quest/src/core/bitwise.hpp"
 #include "quest/src/core/constants.hpp"
+#include "quest/src/core/small_list.hpp"
 #include "quest/src/core/utilities.hpp"
 #include "quest/src/core/randomiser.hpp"
 #include "quest/src/core/fastmath.hpp"
@@ -66,6 +67,13 @@
  * and passed directly to CUDA kernels (though qcomp must be
  * reinterpreted to gpu_qcomp)
  */
+
+
+// TODO / DEBUG :
+// Tyson here: I have broken all this by switching to SmallList,
+// but will not fix because James' PR is already overhauling, and
+// I believe non-GPU compilation will succeed despite this header
+// being broken. This msg will self destruct (when u delete it)
 
 
 using devints = thrust::device_vector<int>;
@@ -779,7 +787,7 @@ qreal thrust_densmatr_calcTotalProb_sub(Qureg qureg) {
 
 
 template <int NumQubits>
-qreal thrust_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal thrust_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     devints sortedQubits = util_getSorted(qubits);
     qindex valueMask = util_getBitMask(qubits, outcomes);
@@ -799,7 +807,7 @@ qreal thrust_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> q
 
 
 template <int NumQubits>
-qreal thrust_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes) {
+qreal thrust_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
     // cannot move these into functor_insertBits constructor, since the memory
     // would dangle - and we cannot bind deviceints as an attribute - it's host-only!
@@ -878,7 +886,7 @@ gpu_qcomp thrust_densmatr_calcFidelityWithPureState_sub(Qureg rho, Qureg psi) {
  */
 
 
-qreal thrust_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+qreal thrust_statevec_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
     qindex mask = util_getBitMask(targs);
     auto functor = functor_getExpecStateVecZTerm(mask);
@@ -893,7 +901,7 @@ qreal thrust_statevec_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
 }
 
 
-gpu_qcomp thrust_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) {
+gpu_qcomp thrust_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, SmallList targs) {
 
     qindex dim = powerOf2(qureg.numQubits);
     qindex ind = util_getLocalIndexOfFirstDiagonalAmp(qureg);
@@ -908,7 +916,7 @@ gpu_qcomp thrust_densmatr_calcExpecAnyTargZ_sub(Qureg qureg, vector<int> targs) 
 }
 
 
-gpu_qcomp thrust_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+gpu_qcomp thrust_statevec_calcExpecPauliStr_subA(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     qindex maskXY = util_getBitMask(util_getConcatenated(x, y));
     qindex maskYZ = util_getBitMask(util_getConcatenated(y, z));
@@ -925,7 +933,7 @@ gpu_qcomp thrust_statevec_calcExpecPauliStr_subA(Qureg qureg, vector<int> x, vec
 }
 
 
-gpu_qcomp thrust_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+gpu_qcomp thrust_statevec_calcExpecPauliStr_subB(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     qindex maskXY = util_getBitMask(util_getConcatenated(x, y));
     qindex maskYZ = util_getBitMask(util_getConcatenated(y, z));
@@ -943,7 +951,7 @@ gpu_qcomp thrust_statevec_calcExpecPauliStr_subB(Qureg qureg, vector<int> x, vec
 }
 
 
-gpu_qcomp thrust_densmatr_calcExpecPauliStr_sub(Qureg qureg, vector<int> x, vector<int> y, vector<int> z) {
+gpu_qcomp thrust_densmatr_calcExpecPauliStr_sub(Qureg qureg, SmallList x, SmallList y, SmallList z) {
 
     qindex mXY = util_getBitMask(util_getConcatenated(x, y));
     qindex mYZ = util_getBitMask(util_getConcatenated(y, z));
@@ -1005,7 +1013,7 @@ gpu_qcomp thrust_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateD
 
 
 template <int NumQubits>
-void thrust_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal renorm) {
+void thrust_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal renorm) {
 
     devints devQubits = qubits;
     qindex retainValue = getIntegerFromBits(outcomes.data(), outcomes.size());
@@ -1021,7 +1029,7 @@ void thrust_statevec_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, ve
 
 
 template <int NumQubits>
-void thrust_densmatr_multiQubitProjector_sub(Qureg qureg, vector<int> qubits, vector<int> outcomes, qreal renorm) {
+void thrust_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal renorm) {
 
     devints devQubits = qubits;
     qindex retainValue = getIntegerFromBits(outcomes.data(), outcomes.size());

--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -65,18 +65,21 @@
  * copy constructor (devicevec d_vec = hostvec). The pointer 
  * to the data (d_vec.data()) can be cast into a raw pointer
  * and passed directly to CUDA kernels (though qcomp must be
- * reinterpreted to gpu_qcomp)
+ * reinterpreted to gpu_qcomp).
  */
 
 
-// TODO / DEBUG :
-// Tyson here: I have broken all this by switching to SmallList,
-// but will not fix because James' PR is already overhauling, and
-// I believe non-GPU compilation will succeed despite this header
-// being broken. This msg will self destruct (when u delete it)
-
-
 using devints = thrust::device_vector<int>;
+
+devints getDevInts(SmallList h_list) {
+
+    // DEBUG: this is a placeholder! James' GPU refactor should make it redundant, 
+    // and we can pass SmallList directly to a CUDA kernel, paying no heap allocs,
+    // nor CUDA memcpy costs
+
+    devints d_list = std::vector<int>(h_list.data(), h_list.data() + h_list.size());
+    return d_list;
+}
 
 int* getPtr(devints& qubits) {
 
@@ -789,7 +792,7 @@ qreal thrust_densmatr_calcTotalProb_sub(Qureg qureg) {
 template <int NumQubits>
 qreal thrust_statevec_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qubits, SmallList outcomes) {
 
-    devints sortedQubits = util_getSorted(qubits);
+    devints sortedQubits = getDevInts(util_getSorted(qubits));
     qindex valueMask = util_getBitMask(qubits, outcomes);
 
     auto indFunctor = functor_insertBits<NumQubits>(getPtr(sortedQubits), valueMask, qubits.size());
@@ -811,7 +814,7 @@ qreal thrust_densmatr_calcProbOfMultiQubitOutcome_sub(Qureg qureg, SmallList qub
 
     // cannot move these into functor_insertBits constructor, since the memory
     // would dangle - and we cannot bind deviceints as an attribute - it's host-only!
-    devints sortedQubits = util_getSorted(qubits);
+    devints sortedQubits = getDevInts(util_getSorted(qubits));
     qindex valueMask = util_getBitMask(qubits, outcomes);
 
     auto basisIndFunctor = functor_insertBits<NumQubits>(getPtr(sortedQubits), valueMask, qubits.size());
@@ -1015,7 +1018,7 @@ gpu_qcomp thrust_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateD
 template <int NumQubits>
 void thrust_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal renorm) {
 
-    devints devQubits = qubits;
+    devints devQubits = getDevInts(qubits);
     qindex retainValue = getIntegerFromBits(outcomes.data(), outcomes.size());
     auto projFunctor = functor_projectStateVec<NumQubits>(
         getPtr(devQubits), qubits.size(), retainValue, renorm);
@@ -1031,7 +1034,7 @@ void thrust_statevec_multiQubitProjector_sub(Qureg qureg, SmallList qubits, Smal
 template <int NumQubits>
 void thrust_densmatr_multiQubitProjector_sub(Qureg qureg, SmallList qubits, SmallList outcomes, qreal renorm) {
 
-    devints devQubits = qubits;
+    devints devQubits = getDevInts(qubits);
     qindex retainValue = getIntegerFromBits(outcomes.data(), outcomes.size());
     auto projFunctor = functor_projectDensMatr<NumQubits>(
         getPtr(devQubits), qubits.size(), qureg.rank, qureg.numQubits,


### PR DESCRIPTION
This is to circumvent the `std::vector` performance overheads visible in few-qubit simulation (responsible for a performance regression from v3; see #720), and also so that qubit lists can be passed directly to CUDA kernels without conversion (as explored in #739).
