### PR TITLE
Defer Catch2 test discovery

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 # @author Oliver Thomson Brown
+# @author Tyson Jones (patched MSVC and test discovery)
 
 add_executable(tests
   main.cpp
@@ -19,5 +20,5 @@ if (QUEST_ENABLE_DEPRECATED_API)
   add_subdirectory(deprecated)
 endif()
 
-# let Catch2 register all tests with CTest
-catch_discover_tests(tests)
+# defer test discovery, so that (e.g.) MPI libs aren't loaded during build
+catch_discover_tests(tests DISCOVERY_MODE PRE_TEST)

--- a/tests/deprecated/CMakeLists.txt
+++ b/tests/deprecated/CMakeLists.txt
@@ -1,6 +1,6 @@
 # @author Oliver Thomson Brown
 # @author Erich Essmann (patched MPI)
-# @author Tyson Jones (defered test discovery)
+# @author Tyson Jones (deferred test discovery)
 
 add_executable(dep_tests
     test_main.cpp

--- a/tests/deprecated/CMakeLists.txt
+++ b/tests/deprecated/CMakeLists.txt
@@ -1,5 +1,6 @@
 # @author Oliver Thomson Brown
 # @author Erich Essmann (patched MPI)
+# @author Tyson Jones (defered test discovery)
 
 add_executable(dep_tests
     test_main.cpp
@@ -18,4 +19,4 @@ if (QUEST_ENABLE_MPI)
     target_link_libraries(dep_tests PRIVATE MPI::MPI_CXX)
 endif()
 
-catch_discover_tests(dep_tests)
+catch_discover_tests(dep_tests DISCOVERY_MODE PRE_TEST)


### PR DESCRIPTION
so that we can compile MPI tests on systems which cannot actually run with MPI, because they are missing an MPI or UCX library file, as is witnessed in the CI (when compiling with MPICH). It's generally irksome too to trigger an execution of the test binary (which itself initialises QuEST) during build when on a HPC platform with distinct submit and compute nodes.

This is expected to solve the sudden MPICH CI build failures like [this one](https://github.com/QuEST-Kit/QuEST/actions/runs/26488925419/job/78002325278)