### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/test_free.yml
+++ b/.github/workflows/test_free.yml
@@ -80,11 +80,11 @@ jobs:
       # are manually excluding each integration test by name
       - name: Run v4 tests
         if: ${{ matrix.version == 4 }}
-        run: ctest -j2 --output-on-failure --schedule-random -E "density evolution"
+        run: ctest -j2 --output-on-failure --schedule-random -C Release -E "density evolution"
         working-directory: ${{ env.build_dir }}
 
       # run v3 unit tests in random order
       - name: Run v3 tests
         if: ${{ matrix.version == 3 }}
-        run: ctest -j2 --output-on-failure --schedule-random
+        run: ctest -j2 --output-on-failure --schedule-random -C Release
         working-directory: ${{ env.depr_dir }}


### PR DESCRIPTION
Adds the Release configuration to ctest in the CI, needed since test discovery is now deferred.