### PR TITLE
Add function to sample outcomes from a Qureg

### DIFF
--- a/quest/include/operations.h
+++ b/quest/include/operations.h
@@ -27,6 +27,7 @@
 
 #ifdef __cplusplus
     #include <vector>
+    #include <unordered_map>
 #endif
 
 
@@ -2342,6 +2343,12 @@ qindex applyMultiQubitMeasurementAndGetProb(Qureg qureg, std::vector<int> qubits
 /// @cppvectoroverload
 /// @see applyForcedMultiQubitMeasurement()
 qreal applyForcedMultiQubitMeasurement(Qureg qureg, std::vector<int> qubits, std::vector<int> outcomes);
+
+/// @notyettested
+/// @notyetvalidated
+/// @notyetdoced
+std::unordered_map<int, int> sampleQureg(Qureg qureg, int* qubits, int numQubits, int shots);
+
 
 
 #endif // __cplusplus

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -1728,7 +1728,42 @@ qreal applyForcedMultiQubitMeasurement(Qureg qureg, vector<int> qubits, vector<i
     return applyForcedMultiQubitMeasurement(qureg, qubits.data(), outcomes.data(), outcomes.size());
 }
 
+std::unordered_map<int, int> sampleQureg(Qureg qureg, int* qubits, int numQubits, int shots) {
 
+    validate_quregFields(qureg, __func__);
+    validate_targets(qureg, qubits, numQubits, __func__);
+
+    // find the probability of all possible outcomes...
+    qindex numProbs = powerOf2(numQubits);
+
+    // by allocating a temp vector, and validating successful (since exponentially big!)
+    vector<qreal> probs;
+    auto callback = [&]() { validate_tempAllocSucceeded(false, numProbs, sizeof(qreal), __func__); };
+    util_tryAllocVector(probs, numProbs, callback);
+
+    // populate probs
+    calcProbsOfAllMultiQubitOutcomes(probs.data(), qureg, qubits, numQubits); // harmlessly re-validates
+
+    // we cannot meaningfully sample these probs if not normalised
+    validate_measurementProbsAreNormalised(probs, __func__);
+
+    std::unordered_map<int, int> counts;
+
+    for (int i = 0; i < shots; i++) {
+        // randomly choose an outcome
+        qindex outcome = rand_getRandomMultiQubitOutcome(probs);
+
+        // map outcome to individual qubit outcomes
+        auto qubitVec = util_getVector(qubits, numQubits);
+        auto outcomeVec = vector<int>(numQubits);
+        getBitsFromInteger(outcomeVec.data(), outcome, numQubits);
+
+        // increase outcome count
+        counts[outcome]++; 
+    }
+
+    return counts;
+}
 
 /*
  * QFT

--- a/quest/src/api/operations.cpp
+++ b/quest/src/api/operations.cpp
@@ -22,6 +22,7 @@
 #include "quest/src/core/paulilogic.hpp"
 
 #include <vector>
+#include <unordered_map>
 
 using std::vector;
 


### PR DESCRIPTION
Hi!

I added a `sampleQureg` function to obtain multiple random outcomes from the distribution of a `Qureg`. The function is based on `applyMultiQubitMeasurementAndGetProb`, but drawing as many outcomes from the distribution as the user selects (stored as counts on a `std::unordered_map`) and without projecting the `Qureg` afterwards, so information can be extracted at intermediate points during the simulation.

Feel free to reject the pull request if this doesn't mesh well with the philosophy of `QuEST`, as I suspect that the lack of a function of the sort might be intentional.

Best,
Daniel