### PR TITLE
Improve applyCompMatr summation accuracy

### DIFF
--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -607,7 +607,8 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, ConstList64 ctrls, Co
 
                 // i = nth local index where ctrls are active and targs form value k
                 qindex i = setBits(i0, targs.data(), numTargBits, k); // loop may be unrolled
-                amps[i] = getCpuQcomp(0, 0);
+                cpu_qcomp sum = getCpuQcomp(0, 0);
+                cpu_qcomp correction = getCpuQcomp(0, 0);
             
                 // loop may be unrolled
                 for (qindex j=0; j<numTargAmps; j++) {
@@ -624,18 +625,19 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, ConstList64 ctrls, Co
                     if constexpr (ApplyConj)
                         elem = conj(elem);
 
-                    amps[i] += elem * cache[j];
+                    cpu_qcomp term = elem * cache[j];
+                    qreal re = term.re - correction.re;
+                    qreal nextRe = sum.re + re;
+                    correction.re = (nextRe - sum.re) - re;
+                    sum.re = nextRe;
 
-                    /// @todo
-                    /// qureg.cpuAmps[i] is being serially updated by only this thread,
-                    /// so is a candidate for Kahan summation for improved numerical
-                    /// stability. Explore whether this is time-free and worthwhile!
-                    ///
-                    /// BEWARE that Kahan summation may be incompatible with
-                    /// the commutator tricks used in base_qcomp's (ancestor
-                    /// of cpu_qcomp) arithmetic operator overloads. Check
-                    /// base_qcomp.hpp before implementing compensation.
+                    qreal im = term.im - correction.im;
+                    qreal nextIm = sum.im + im;
+                    correction.im = (nextIm - sum.im) - im;
+                    sum.im = nextIm;
                 }
+
+                amps[i] = sum;
             }
         }
     }

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -40,6 +40,8 @@
 #include "tests/utils/macros.hpp"
 #include "tests/utils/random.hpp"
 
+#include <cmath>
+#include <limits>
 #include <tuple>
 
 using std::tuple;
@@ -1315,6 +1317,42 @@ TEST_ALL_CTRL_OPERATIONS( PauliGadget, any, pauligad, nullptr );
 TEST_ALL_CTRL_OPERATIONS( CompMatr1, one, compmatr, nullptr );
 TEST_ALL_CTRL_OPERATIONS( CompMatr2, two, compmatr, nullptr );
 TEST_ALL_CTRL_OPERATIONS( CompMatr,  any, compmatr, nullptr );
+
+TEST_CASE( "applyCompMatr uses compensated summation", TEST_CATEGORY_OPS ) {
+
+    int numTargs = 4;
+    qindex numAmps = getPow2(numTargs);
+    int targets[] = {0,1,2,3};
+
+    Qureg qureg = createQureg(numTargs);
+    CompMatr matrix = createCompMatr(numTargs);
+
+    qvector amps(numAmps, qcomp(1, 0));
+    setQuregAmps(qureg, 0, amps.data(), amps.size());
+
+    for (qindex i=0; i<matrix.numRows; i++)
+        for (qindex j=0; j<matrix.numRows; j++)
+            matrix.cpuElems[i][j] = 0;
+
+    qreal large = std::ldexp(qreal(1), std::numeric_limits<qreal>::digits);
+    matrix.cpuElems[0][0] = qcomp( large,  large);
+    for (qindex j=1; j<matrix.numRows-1; j++)
+        matrix.cpuElems[0][j] = qcomp(1, -1);
+    matrix.cpuElems[0][matrix.numRows-1] = qcomp(-large, -large);
+    syncCompMatr(matrix);
+
+    setQuESTValidationEpsilon(0);
+    applyCompMatr(qureg, targets, numTargs, matrix);
+    setQuESTValidationEpsilonToDefault();
+
+    qcomp amp = getQuregAmp(qureg, 0);
+    REQUIRE( std::real(amp) == qreal(numAmps - 2) );
+    REQUIRE( std::imag(amp) == -qreal(numAmps - 2) );
+
+    destroyCompMatr(matrix);
+    destroyQureg(qureg);
+}
+
 TEST_ALL_CTRL_OPERATIONS( DiagMatr1, one, diagmatr, nullptr );
 TEST_ALL_CTRL_OPERATIONS( DiagMatr2, two, diagmatr, nullptr );
 TEST_ALL_CTRL_OPERATIONS( DiagMatr,  any, diagmatr, nullptr );


### PR DESCRIPTION
Closes #598.

## Summary

- Replaces the naive inner accumulation in `cpu_statevec_anyCtrlAnyTargDenseMatr_sub()` with component-wise compensated summation over `cpu_qcomp.re` and `cpu_qcomp.im`.
- Writes each output amplitude once after its local reduction rather than repeatedly updating `amps[i]` inside the summation loop.
- Adds a deterministic complex cancellation regression for 4-target `applyCompMatr`, which exercises the 3+ target `CompMatr` path rather than the one/two-target specialisations.

## Notes

I saw the earlier closed attempt in #777. This version keeps the same narrow two-file scope, but uses direct `qreal` compensation for the real and imaginary components instead of relying on complex add/sub overloads in the hot loop. I also checked `base_qcomp`: the current operators are ordinary component-wise arithmetic, so independent real/imaginary Kahan compensation is compatible with the backend representation.

## Local measurements

Configuration: Windows, GCC 13.2.0, Release, single CPU (`QUEST_ENABLE_OMP=OFF`, `QUEST_ENABLE_MPI=OFF`, `QUEST_ENABLE_CUDA=OFF`, `QUEST_ENABLE_HIP=OFF`). The benchmark applies a dense `CompMatr` whose first output row is `[large+i*large, 1-i, ..., 1-i, -large-i*large]` to an all-ones state. The expected first amplitude is `(2^targets - 2) - i(2^targets - 2)`.

| precision | targets | baseline abs error | patched abs error | baseline avg ms | patched avg ms |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 4 | 14 | 0 | 0.0114 | 0.0117 |
| 1 | 8 | 254 | 0 | 0.0779 | 0.2100 |
| 1 | 10 | 1022 | 0 | 1.0715 | 3.0297 |
| 2 | 4 | 14 | 0 | 0.0113 | 0.0121 |
| 2 | 8 | 254 | 0 | 0.0801 | 0.2008 |
| 2 | 10 | 1022 | 0 | 1.4134 | 3.2629 |
| 4 | 4 | 14 | 0 | 0.0137 | 0.0134 |
| 4 | 8 | 254 | 0 | 0.4391 | 0.4150 |
| 4 | 10 | 1022 | 0 | 7.1805 | 6.6778 |

The measurements show the expected accuracy improvement. The overhead is visible for larger single/double precision reductions, which seems consistent with the tradeoff described in the issue.

## Testing

```bash
cmake -S . -B build-598-fp2 -G Ninja -D CMAKE_BUILD_TYPE=Release -D QUEST_BUILD_TESTS=ON -D QUEST_FLOAT_PRECISION=2 -D QUEST_ENABLE_OMP=OFF -D QUEST_ENABLE_MPI=OFF -D QUEST_ENABLE_CUDA=OFF -D QUEST_ENABLE_HIP=OFF
cmake --build build-598-fp2 --parallel
build-598-fp2/tests/tests.exe '*applyCompMatr*' --reporter compact
ctest --test-dir build-598-fp2 --output-on-failure -j 4
git diff --check
```

Results:

- `*applyCompMatr*`: passed, 10 test cases / 10,003 assertions.
- Full CPU-only double-precision `ctest`: passed.
- `git diff --check`: passed; Git emitted only Windows line-ending conversion warnings.

Prepared with AI assistance; I reviewed the patch and ran the listed local checks.