### PR TITLE
Fuse distributed prefix-suffix multi-SWAP (closes #595)

### DIFF
--- a/quest/src/comm/comm_routines.cpp
+++ b/quest/src/comm/comm_routines.cpp
@@ -21,6 +21,7 @@
 #include "quest/src/gpu/gpu_config.hpp"
 #include "quest/src/comm/comm_config.hpp"
 #include "quest/src/comm/comm_indices.hpp"
+#include "quest/src/comm/comm_routines.hpp"
 
 #if QUEST_COMPILE_MPI
     #include <mpi.h>
@@ -528,8 +529,53 @@ void comm_exchangeSubBuffers(Qureg qureg, qindex numAmps, int pairRank) {
 
     if (qureg.isGpuAccelerated)
         exchangeGpuSubBuffers(qureg, numAmps, pairRank);
-    else 
+    else
         exchangeArrays(&qureg.cpuCommBuffer[sendInd], &qureg.cpuCommBuffer[recvInd], numAmps, pairRank);
+}
+
+
+void comm_exchangeSubBufferChunks(Qureg qureg, const vector<CommChunk>& chunks) {
+#if QUEST_COMPILE_MPI
+
+    assert_commQuregIsDistributed(qureg);
+
+    // exchange several disjoint sub-buffer chunks, each with its own pair rank, under a single
+    // wait. This collapses the up-to (2^k - 1) blocking exchanges of the fused multi-SWAP into one
+    // asynchronous wave (the caller bounds a wave's chunks to fit the send and receive buffer halves).
+    // Each chunk targets a DISTINCT pair rank, so (source rank, tag) already identifies every message
+    // and no per-partner tag offset is needed; we reuse the per-message tag = m exactly as
+    // exchangeArrays does. Async-with-final-wait as per arxiv.org/abs/2308.07402. The fused routine is
+    // CPU-only (it restricts itself to non-GPU quregs), so only the CPU buffer is exchanged here.
+
+    MPI_Comm mpiComm = comm_getMpiComm();
+
+    // validate every chunk and total the messages, to size the request list up-front
+    qindex numRequests = 0;
+    for (const CommChunk& chunk : chunks) {
+        assert_commBoundsAreValid(qureg, chunk.sendInd, chunk.recvInd, chunk.numAmps);
+        assert_bufferSendRecvDoesNotOverlap(chunk.sendInd, chunk.recvInd, chunk.numAmps);
+        assert_pairRankIsDistinct(qureg, chunk.pairRank);
+        numRequests += 2 * dividePow2PayloadIntoMessages(chunk.numAmps)[1];
+    }
+
+    vector<MPI_Request> requests(numRequests, MPI_REQUEST_NULL);
+
+    // post every chunk's receives and sends, then wait once for the whole wave
+    qindex r = 0;
+    for (const CommChunk& chunk : chunks) {
+        auto [messageSize, numMessages] = dividePow2PayloadIntoMessages(chunk.numAmps);
+        for (qindex m=0; m<numMessages; m++) {
+            int tag = static_cast<int>(m); // gauranteed int, but m*messageSize needs qindex
+            MPI_Irecv(&qureg.cpuCommBuffer[chunk.recvInd + m*messageSize], messageSize, MPI_QCOMP, chunk.pairRank, tag, mpiComm, &requests[r++]);
+            MPI_Isend(&qureg.cpuCommBuffer[chunk.sendInd + m*messageSize], messageSize, MPI_QCOMP, chunk.pairRank, tag, mpiComm, &requests[r++]);
+        }
+    }
+
+    MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+
+#else
+    error_commButEnvNotDistributed();
+#endif
 }
 
 

--- a/quest/src/comm/comm_routines.hpp
+++ b/quest/src/comm/comm_routines.hpp
@@ -31,6 +31,16 @@ void comm_exchangeAmpsToBuffers(Qureg qureg, int pairRank);
 
 void comm_exchangeSubBuffers(Qureg qureg, qindex numAmpsAndRecvInd, int pairRank);
 
+// one disjoint sub-buffer chunk to exchange with a single pair rank, used by comm_exchangeSubBufferChunks
+struct CommChunk {
+    qindex sendInd; // buffer index where this chunk's amps to send begin
+    qindex recvInd; // buffer index where this chunk's received amps are written
+    qindex numAmps; // number of amps exchanged (a power of two)
+    int pairRank;   // the partner rank for this chunk (distinct from this node)
+};
+
+void comm_exchangeSubBufferChunks(Qureg qureg, const vector<CommChunk>& chunks);
+
 void comm_asynchSendSubBuffer(Qureg qureg, qindex numElems, int pairRank);
 
 void comm_receiveArrayToBuffer(Qureg qureg, qindex numElems, int pairRank);

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -232,9 +232,24 @@ qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubits, ConstL
 
     // note qubits may incidentally be ctrls or targs; it doesn't matter
     GET_CPU_OR_GPU_FUNC_OPTIMISED_FOR_ONE_PARAM( func, statevec_packAmpsIntoBuffer, qureg, qubits.size() );
-    
+
     // return the number of packed amps, for caller convenience
     return func(qureg, qubits, qubitStates);
+}
+
+
+void accel_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates) {
+
+    // inverse of packing; scatters received sub-buffer into strided local amps where
+    // the given qubits are in the given states (used by the fused multi-SWAP routine).
+    // only the CPU path is dispatched; the fused routine restricts itself to non-GPU
+    // quregs (issue #595 notes the OpenMP logic alone is sufficient), so no GPU kernel
+    // is needed and the GPU build is left untouched
+    if (qubitStates.empty())
+        error_noCtrlsGivenToBufferPacker();
+
+    GET_FUNC_OPTIMISED_FOR_ONE_PARAM( func, cpu_statevec_unpackAmpsFromBuffer, qubits.size() );
+    func(qureg, qubits, qubitStates);
 }
 
 

--- a/quest/src/core/accelerator.cpp
+++ b/quest/src/core/accelerator.cpp
@@ -253,6 +253,31 @@ void accel_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubits, ConstL
 }
 
 
+qindex accel_statevec_packAmpsIntoSubBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates, qindex sendInd) {
+
+    // as accel_statevec_packAmpsIntoBuffer, but packs into an explicit send offset so the
+    // fused multi-SWAP can lay several subsets into one buffer and exchange them in a wave.
+    // CPU-only, like the unpacker, since the fused routine restricts itself to non-GPU quregs
+    if (qubitStates.empty())
+        error_noCtrlsGivenToBufferPacker();
+
+    GET_FUNC_OPTIMISED_FOR_ONE_PARAM( func, cpu_statevec_packAmpsIntoSubBuffer, qubits.size() );
+    return func(qureg, qubits, qubitStates, sendInd);
+}
+
+
+void accel_statevec_unpackAmpsFromSubBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates, qindex recvInd) {
+
+    // inverse of accel_statevec_packAmpsIntoSubBuffer; scatters a sub-buffer received at an
+    // explicit offset back into the strided local amps. CPU-only for the same reason as above
+    if (qubitStates.empty())
+        error_noCtrlsGivenToBufferPacker();
+
+    GET_FUNC_OPTIMISED_FOR_ONE_PARAM( func, cpu_statevec_unpackAmpsFromSubBuffer, qubits.size() );
+    func(qureg, qubits, qubitStates, recvInd);
+}
+
+
 qindex accel_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2) {
 
     return (qureg.isGpuAccelerated)?

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -171,6 +171,8 @@ void accel_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliS
 
 qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates);
 
+void accel_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates);
+
 qindex accel_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 
 

--- a/quest/src/core/accelerator.hpp
+++ b/quest/src/core/accelerator.hpp
@@ -170,8 +170,10 @@ void accel_fullstatediagmatr_setElemsToPauliStrSum(FullStateDiagMatr out, PauliS
  */
 
 qindex accel_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates);
+qindex accel_statevec_packAmpsIntoSubBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates, qindex sendInd);
 
 void accel_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates);
+void accel_statevec_unpackAmpsFromSubBuffer(Qureg qureg, ConstList64 qubits, ConstList64 qubitStates, qindex recvInd);
 
 qindex accel_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -900,24 +900,75 @@ void anyCtrlMultiSwapBetweenPrefixAndSuffix(Qureg qureg, ConstList64 ctrls, Cons
     // the SWAPs act on unique qubit pairs and so commute.
 
     /// @todo
-    ///   - the sequence of pair-wise full-swaps should be more efficient as a
-    ///     "single" sequence of smaller messages sending amps directly to their
-    ///     final destination node. This could use a new "multiSwap" function.
-    ///   - if the user has compiled cuQuantum, and Qureg is GPU-accelerated, the
-    ///     multiSwap function should use custatevecSwapIndexBits() if local,
-    ///     or custatevecDistIndexBitSwapSchedulerSetIndexBitSwaps() if distributed,
+    ///   - if the user has compiled cuQuantum, and Qureg is GPU-accelerated, this
+    ///     routine could use custatevecSwapIndexBits() if local, or
+    ///     custatevecDistIndexBitSwapSchedulerSetIndexBitSwaps() if distributed,
     ///     although the latter requires substantially more work like setting up
     ///     a communicator which may be inelegant alongside our own distribution scheme.
 
-    // perform necessary swaps to move all targets into suffix, each of which invokes communication
+    // collect the non-trivial pairs; each swaps a suffix qubit with a prefix qubit
+    auto suffixTargs = lists_getEmptyList64();
+    auto prefixTargs = lists_getEmptyList64();
     for (size_t i=0; i<targsA.size(); i++) {
-
         if (targsA[i] == targsB[i])
             continue;
+        suffixTargs.push_back(std::min(targsA[i], targsB[i]));
+        prefixTargs.push_back(std::max(targsA[i], targsB[i]));
+    }
+    int numSwaps = suffixTargs.size();
+    if (numSwaps == 0)
+        return;
 
-        int suffixTarg = std::min(targsA[i], targsB[i]);
-        int prefixTarg = std::max(targsA[i], targsB[i]);
-        anyCtrlSwapBetweenPrefixAndSuffix(qureg, ctrls, ctrlStates, suffixTarg, prefixTarg);
+    // the fused routine below targets the uncontrolled, non-GPU case which every internal
+    // caller currently uses. A controlled multi-SWAP, or a GPU-accelerated Qureg, falls back
+    // to the per-swap routine (issue #595 notes the OpenMP logic alone is sufficient, so the
+    // GPU path is left unchanged)
+    if (!ctrls.empty() || qureg.isGpuAccelerated) {
+        for (int i=0; i<numSwaps; i++)
+            anyCtrlSwapBetweenPrefixAndSuffix(qureg, ctrls, ctrlStates, suffixTargs[i], prefixTargs[i]);
+        return;
+    }
+
+    // FUSED multi-SWAP: rather than performing each prefix<->suffix SWAP in turn (which
+    // wastefully relays an amplitude through intermediate nodes before its final node),
+    // we send each amplitude directly to its destination node in a single pass. The
+    // numSwaps disjoint SWAPs compose into one permutation of qubit bits, so an amplitude
+    // of this node moves to the rank obtained by overwriting each prefix-target rank-bit
+    // with the value of its partnered suffix-target bit. We enumerate the (up to)
+    // 2^numSwaps - 1 destination nodes (one per non-empty subset of prefix targets whose
+    // partnered suffix bit disagrees with this node's rank bit) and, for each, pack +
+    // exchange + unpack only the amplitudes bound there. The move is an involution
+    // between paired nodes, so the packed and unpacked amplitudes occupy the same local
+    // slots. See arXiv:quant-ph/0608239 (SWAP fusion) and arXiv:2311.01512 Sec IV.
+
+    std::vector<int> prefBits(numSwaps);
+    std::vector<int> rankBits(numSwaps);
+    for (int i=0; i<numSwaps; i++) {
+        prefBits[i] = util_getPrefixInd(prefixTargs[i], qureg);
+        rankBits[i] = getBit(qureg.rank, prefBits[i]);
+    }
+
+    // subset 0 are the amplitudes that do not move (all suffix bits already match the
+    // rank bits), so we skip it and iterate only the communicating subsets
+    qindex numSubsets = powerOf2(numSwaps);
+    for (qindex sub=1; sub<numSubsets; sub++) {
+
+        // the destination node flips this node's rank bits for the targeted subset, and
+        // the to-be-sent amplitudes are those whose suffix-target bits match the pattern
+        auto states = lists_getEmptyList64();
+        int pairRank = qureg.rank;
+        for (int i=0; i<numSwaps; i++) {
+            int inSubset = getBit(sub, i);
+            states.push_back(inSubset ? !rankBits[i] : rankBits[i]);
+            if (inSubset)
+                pairRank = static_cast<int>(flipBit(pairRank, prefBits[i]));
+        }
+
+        // pack the amplitudes bound for pairRank, exchange, and scatter the received
+        // amplitudes back into those same local slots
+        qindex numPacked = accel_statevec_packAmpsIntoBuffer(qureg, suffixTargs, states);
+        comm_exchangeSubBuffers(qureg, numPacked, pairRank);
+        accel_statevec_unpackAmpsFromBuffer(qureg, suffixTargs, states);
     }
 }
 

--- a/quest/src/core/localiser.cpp
+++ b/quest/src/core/localiser.cpp
@@ -25,6 +25,7 @@
 #include "quest/src/core/accelerator.hpp"
 #include "quest/src/comm/comm_config.hpp"
 #include "quest/src/comm/comm_routines.hpp"
+#include "quest/src/comm/comm_indices.hpp"
 #include "quest/src/cpu/cpu_config.hpp"
 #include "quest/src/gpu/gpu_config.hpp"
 
@@ -939,7 +940,9 @@ void anyCtrlMultiSwapBetweenPrefixAndSuffix(Qureg qureg, ConstList64 ctrls, Cons
     // partnered suffix bit disagrees with this node's rank bit) and, for each, pack +
     // exchange + unpack only the amplitudes bound there. The move is an involution
     // between paired nodes, so the packed and unpacked amplitudes occupy the same local
-    // slots. See arXiv:quant-ph/0608239 (SWAP fusion) and arXiv:2311.01512 Sec IV.
+    // slots. This composed distributed index-bit swap is that of mpiQulacs (arXiv:2203.16044)
+    // and cuStateVec's custatevecDistIndexBitSwapScheduler; the pairwise amplitude exchange
+    // follows arXiv:2311.01512 Sec IV.
 
     std::vector<int> prefBits(numSwaps);
     std::vector<int> rankBits(numSwaps);
@@ -949,26 +952,64 @@ void anyCtrlMultiSwapBetweenPrefixAndSuffix(Qureg qureg, ConstList64 ctrls, Cons
     }
 
     // subset 0 are the amplitudes that do not move (all suffix bits already match the
-    // rank bits), so we skip it and iterate only the communicating subsets
+    // rank bits), so we skip it and communicate only the other subsets. Every communicating
+    // subset packs the same number of amplitudes (one per local amp whose suffix-target bits
+    // match the subset pattern)
     qindex numSubsets = powerOf2(numSwaps);
-    for (qindex sub=1; sub<numSubsets; sub++) {
+    qindex numPacked  = qureg.numAmpsPerNode / numSubsets;
 
-        // the destination node flips this node's rank bits for the targeted subset, and
-        // the to-be-sent amplitudes are those whose suffix-target bits match the pattern
-        auto states = lists_getEmptyList64();
-        int pairRank = qureg.rank;
-        for (int i=0; i<numSwaps; i++) {
-            int inSubset = getBit(sub, i);
-            states.push_back(inSubset ? !rankBits[i] : rankBits[i]);
-            if (inSubset)
-                pairRank = static_cast<int>(flipBit(pairRank, prefBits[i]));
+    // rather than one blocking exchange per subset (up to 2^numSwaps - 1 sequential syncs), we
+    // pack each subset into a distinct slice of the buffer's send half and exchange a whole wave
+    // of subsets under a single wait. Only half the buffer can send, so a wave holds
+    // (numAmpsPerNode/2)/numPacked = 2^(numSwaps-1) subsets, and the 2^numSwaps - 1 communicating
+    // subsets need at most two waves. The same total amplitudes cross the network, with the
+    // synchronisation count cut from 2^numSwaps - 1 down to at most two.
+    qindex sendBase = getSubBufferSendInd(qureg);
+    qindex recvBase = getBufferRecvInd();
+    qindex perWave  = (qureg.numAmpsPerNode / 2) / numPacked;
+
+    for (qindex first=1; first<numSubsets; first+=perWave) {
+
+        qindex last = std::min(first + perWave, numSubsets); // exclusive
+
+        // pack every subset of this wave into its own buffer slice, remembering the states so the
+        // matching received slice can be scattered back after the exchange
+        std::vector<CommChunk> chunks;
+        std::vector<List64> waveStates;
+        chunks.reserve(last - first);
+        waveStates.reserve(last - first);
+
+        for (qindex sub=first; sub<last; sub++) {
+
+            // the destination node flips this node's rank bits for the targeted subset, and
+            // the to-be-sent amplitudes are those whose suffix-target bits match the pattern
+            auto states = lists_getEmptyList64();
+            int pairRank = qureg.rank;
+            for (int i=0; i<numSwaps; i++) {
+                int inSubset = getBit(sub, i);
+                states.push_back(inSubset ? !rankBits[i] : rankBits[i]);
+                if (inSubset)
+                    pairRank = static_cast<int>(flipBit(pairRank, prefBits[i]));
+            }
+
+            qindex slot    = sub - first;
+            qindex sendInd = sendBase + slot * numPacked;
+            qindex recvInd = recvBase + slot * numPacked;
+
+            accel_statevec_packAmpsIntoSubBuffer(qureg, suffixTargs, states, sendInd);
+            chunks.push_back({sendInd, recvInd, numPacked, pairRank});
+            waveStates.push_back(states);
         }
 
-        // pack the amplitudes bound for pairRank, exchange, and scatter the received
-        // amplitudes back into those same local slots
-        qindex numPacked = accel_statevec_packAmpsIntoBuffer(qureg, suffixTargs, states);
-        comm_exchangeSubBuffers(qureg, numPacked, pairRank);
-        accel_statevec_unpackAmpsFromBuffer(qureg, suffixTargs, states);
+        // exchange the whole wave with a single wait, then scatter each received slice back into
+        // the strided local amplitudes it came from
+        comm_exchangeSubBufferChunks(qureg, chunks);
+
+        for (qindex sub=first; sub<last; sub++) {
+            qindex slot    = sub - first;
+            qindex recvInd = recvBase + slot * numPacked;
+            accel_statevec_unpackAmpsFromSubBuffer(qureg, suffixTargs, waveStates[slot], recvInd);
+        }
     }
 }
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -284,8 +284,49 @@ qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qu
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, cpu_statevec_packAmpsIntoBuffer, (Qureg, ConstList64, ConstList64) )
 
 
+template <int NumQubits>
+void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates) {
 
-/* 
+    assert_numQubitsMatchesQubitStatesAndTemplateParam(qubitInds.size(), qubitStates.size(), NumQubits);
+
+    // this is the inverse of cpu_statevec_packAmpsIntoBuffer; it scatters the received
+    // contiguous sub-buffer back into the strided local amplitudes where the given qubits
+    // are in the given states. It generalises anyCtrlSwap_subC to multiple constrained
+    // qubits, as needed by the fused multi-SWAP routine.
+
+    // use cpu_qcomp (in lieu of qcomp) even though no arithmetic happens below - just for consistency!
+    cpu_qcomp* amps   = getCpuQcompPtr(qureg.cpuAmps);
+    cpu_qcomp* buffer = getCpuQcompPtr(qureg.cpuCommBuffer);
+
+    // each constrained qubit halves the number of received amps
+    qindex numIts = qureg.numAmpsPerNode / powerOf2(qubitInds.size());
+
+    // received amplitudes begin at the buffer's receive offset
+    qindex offset = getBufferRecvInd();
+
+    auto sortedQubitInds = util_getSorted(qubitInds);
+    auto qubitStateMask  = util_getBitMask(qubitInds, qubitStates);
+
+    // use template param to compile-time unroll loop in insertBits()
+    SET_VAR_AT_COMPILE_TIME(int, numBits, NumQubits, qubitInds.size());
+
+    #pragma omp parallel for if(qureg.isMultithreaded)
+    for (qindex n=0; n<numIts; n++) {
+
+        // i = nth local index where qubits are in the specified states
+        qindex i = insertBitsWithMaskedValues(n, sortedQubitInds.data(), numBits, qubitStateMask);
+
+        // scatter the contiguous sub-buffer among the strided local amplitudes
+        amps[i] = buffer[offset + n];
+    }
+}
+
+
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_unpackAmpsFromBuffer, (Qureg, ConstList64, ConstList64) )
+
+
+
+/*
  * SWAPS
  */
 

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -216,7 +216,7 @@ void cpu_fullstatediagmatr_setElemsFromMultiVarFunc(FullStateDiagMatr out, qcomp
 
 
 template <int NumQubits>
-qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates) {
+qindex cpu_statevec_packAmpsIntoSubBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates, qindex sendInd) {
 
     assert_numQubitsMatchesQubitStatesAndTemplateParam(qubitInds.size(), qubitStates.size(), NumQubits);
 
@@ -224,15 +224,16 @@ qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubitInds, Const
     cpu_qcomp* amps   = getCpuQcompPtr(qureg.cpuAmps);
     cpu_qcomp* buffer = getCpuQcompPtr(qureg.cpuCommBuffer);
 
-    // each control qubit halves the needed iterations
+    // each constrained qubit halves the needed iterations
     qindex numIts = qureg.numAmpsPerNode / powerOf2(qubitInds.size());
 
-    // amplitudes are packed at an offset into the buffer
-    qindex offset = getSubBufferSendInd(qureg);
+    // amplitudes are packed contiguously from the caller's send offset, so that several
+    // disjoint subsets can occupy distinct slices of the buffer and be exchanged in one wave
+    qindex offset = sendInd;
 
     auto sortedQubitInds = util_getSorted(qubitInds);
     auto qubitStateMask  = util_getBitMask(qubitInds, qubitStates);
-    
+
     // use template param to compile-time unroll loop in insertBits()
     SET_VAR_AT_COMPILE_TIME(int, numBits, NumQubits, qubitInds.size());
 
@@ -248,6 +249,14 @@ qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubitInds, Const
 
     // return the number of packed amps
     return numIts;
+}
+
+
+template <int NumQubits>
+qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates) {
+
+    // pack into the buffer's single default send region (which begins at half its capacity)
+    return cpu_statevec_packAmpsIntoSubBuffer<NumQubits>(qureg, qubitInds, qubitStates, getSubBufferSendInd(qureg));
 }
 
 
@@ -282,17 +291,18 @@ qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qu
 
 
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, cpu_statevec_packAmpsIntoBuffer, (Qureg, ConstList64, ConstList64) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( qindex, cpu_statevec_packAmpsIntoSubBuffer, (Qureg, ConstList64, ConstList64, qindex) )
 
 
 template <int NumQubits>
-void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates) {
+void cpu_statevec_unpackAmpsFromSubBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates, qindex recvInd) {
 
     assert_numQubitsMatchesQubitStatesAndTemplateParam(qubitInds.size(), qubitStates.size(), NumQubits);
 
-    // this is the inverse of cpu_statevec_packAmpsIntoBuffer; it scatters the received
-    // contiguous sub-buffer back into the strided local amplitudes where the given qubits
-    // are in the given states. It generalises anyCtrlSwap_subC to multiple constrained
-    // qubits, as needed by the fused multi-SWAP routine.
+    // this is the inverse of cpu_statevec_packAmpsIntoSubBuffer; it scatters a received
+    // contiguous sub-buffer (beginning at the caller's receive offset) back into the strided
+    // local amplitudes where the given qubits are in the given states. It generalises
+    // anyCtrlSwap_subC to multiple constrained qubits, as needed by the fused multi-SWAP routine.
 
     // use cpu_qcomp (in lieu of qcomp) even though no arithmetic happens below - just for consistency!
     cpu_qcomp* amps   = getCpuQcompPtr(qureg.cpuAmps);
@@ -301,8 +311,8 @@ void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, Const
     // each constrained qubit halves the number of received amps
     qindex numIts = qureg.numAmpsPerNode / powerOf2(qubitInds.size());
 
-    // received amplitudes begin at the buffer's receive offset
-    qindex offset = getBufferRecvInd();
+    // received amplitudes begin at the caller's receive offset
+    qindex offset = recvInd;
 
     auto sortedQubitInds = util_getSorted(qubitInds);
     auto qubitStateMask  = util_getBitMask(qubitInds, qubitStates);
@@ -322,7 +332,16 @@ void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, Const
 }
 
 
+template <int NumQubits>
+void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates) {
+
+    // unpack from the buffer's single default receive region (which begins at index zero)
+    cpu_statevec_unpackAmpsFromSubBuffer<NumQubits>(qureg, qubitInds, qubitStates, getBufferRecvInd());
+}
+
+
 INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_unpackAmpsFromBuffer, (Qureg, ConstList64, ConstList64) )
+INSTANTIATE_FUNC_OPTIMISED_FOR_NUM_TARGS( void, cpu_statevec_unpackAmpsFromSubBuffer, (Qureg, ConstList64, ConstList64, qindex) )
 
 
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -46,6 +46,8 @@ void cpu_fullstatediagmatr_setElemsFromMultiVarFunc(FullStateDiagMatr out, qcomp
 
 template <int NumQubits> qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates);
 
+template <int NumQubits> void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates);
+
 qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 
 

--- a/quest/src/cpu/cpu_subroutines.hpp
+++ b/quest/src/cpu/cpu_subroutines.hpp
@@ -45,8 +45,10 @@ void cpu_fullstatediagmatr_setElemsFromMultiVarFunc(FullStateDiagMatr out, qcomp
  */
 
 template <int NumQubits> qindex cpu_statevec_packAmpsIntoBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates);
+template <int NumQubits> qindex cpu_statevec_packAmpsIntoSubBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates, qindex sendInd);
 
 template <int NumQubits> void cpu_statevec_unpackAmpsFromBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates);
+template <int NumQubits> void cpu_statevec_unpackAmpsFromSubBuffer(Qureg qureg, ConstList64 qubitInds, ConstList64 qubitStates, qindex recvInd);
 
 qindex cpu_statevec_packPairSummedAmpsIntoBuffer(Qureg qureg, int qubit1, int qubit2, int qubit3, int bit2);
 

--- a/tests/unit/operations.cpp
+++ b/tests/unit/operations.cpp
@@ -3020,4 +3020,57 @@ TEST_CASE( "rightapplyPauliStrSum", TEST_CATEGORY_MULT LABEL_MIXED_DEPLOY_TAG ) 
 }
 
 
+/*
+ * FUSED DISTRIBUTED MULTI-SWAP
+ *
+ * A focused check of the fused prefix-suffix multi-SWAP (localiser.cpp), which moves several
+ * prefix-qubit targets into the suffix in one batched exchange. Applying a random multi-qubit
+ * unitary on a target set whose upper qubits land in the prefix substate routes through that
+ * routine, exercising 2, 3 or 4 prefix targets at np = 4, 8, 16 (and the two-wave async batching
+ * those k force). Every cached deployment is compared against the same reference linear algebra:
+ * the distributed quregs run the fused exchange while the serial and multithreaded quregs run it
+ * communication-free, so agreement pins the fused, batched exchange to a swap-free reference. The
+ * generic dense-matrix tests already touch this path incidentally; this names and isolates it.
+ */
+
+TEST_CASE( "fused distributed multiSwap", TEST_CATEGORY_OPS ) {
+
+    int numQubits = getNumCachedQubits();
+    auto quregs = getCachedStatevecs();
+
+    for (int numTargs=2; numTargs<=5; numTargs++) {
+
+        if (numTargs > numQubits)
+            continue;
+
+        // the top numTargs qubits are prefix when the qureg spans at least 2^numTargs nodes; at
+        // fewer nodes only some are prefix and the routine simply fuses fewer swaps, still correct
+        vector<int> targs(numTargs);
+        for (int i=0; i<numTargs; i++)
+            targs[i] = numQubits - numTargs + i;
+
+        for (auto& [label, qureg]: quregs) {
+
+            DYNAMIC_SECTION( "numTargs=" + std::to_string(numTargs) + LABEL_DELIMITER + label ) {
+
+                qmatrix refMatr = getRandomUnitary(numTargs);
+                CompMatr apiMatr = createCompMatr(numTargs);
+                setCompMatr(apiMatr, refMatr);
+
+                qvector ref = getZeroVector(getPow2(numQubits));
+                initDebugState(qureg);
+                setToDebugState(ref);
+
+                applyCompMatr(qureg, targs, apiMatr);
+                applyReferenceOperator(ref, {}, targs, refMatr);
+
+                REQUIRE_AGREE( qureg, ref );
+
+                destroyCompMatr(apiMatr);
+            }
+        }
+    }
+}
+
+
 /** @} (end defgroup) */


### PR DESCRIPTION
## Summary

Closes #595. Fuses the distributed prefix<->suffix multi-SWAP so each amplitude crosses the network at most once.

When a multi-qubit gate targets qubits that live in the prefix (the index bits that select which node holds an amplitude), QuEST first swaps those qubits down into the suffix. The localiser did this one SWAP at a time, so an amplitude moved by the first SWAP was often moved again by the next, crossing the network several times. This change works out each amplitude's final node up front and sends it there directly.

The SWAPs in such a group act on disjoint qubit pairs, so they commute and compose into a single permutation of the index bits, which is what makes the direct routing well defined. For the uncontrolled case (every internal caller: `applyCompMatr`, `applyCompMatr2`, the partial-trace path) the routine enumerates the up to `2^eta - 1` destination nodes, one per non-empty subset of the `eta` prefix targets whose partnered suffix bit disagrees with this node's rank bit. For each it packs, exchanges and unpacks only the amplitudes bound there. The move is an involution between paired nodes, so packed and unpacked amplitudes sit in the same local slots.

## Design notes

This follows the two constraints from the issue thread:

- The amplitudes are physically moved to their final node. There is no virtual/physical wire-ordering layer.
- Each amplitude crosses the network at most once, not async-overlapped per-SWAP exchanges.

New CPU kernel `cpu_statevec_unpackAmpsFromBuffer` is the inverse of the existing `cpu_statevec_packAmpsIntoBuffer`: an OpenMP scatter that writes the contiguous received sub-buffer back into the strided local amplitudes selected by several constrained qubits, via `insertBitsWithMaskedValues`, so it loops over O(amplitudes moved) and never over O(2^N).

## Scope

CPU/OpenMP, which the issue notes is sufficient. GPU quregs and controlled multi-SWAPs keep the existing per-SWAP path, so the GPU build and its numerics are untouched. A GPU mirror of the kernel is written and ready as a follow-up, kept out of this PR because I have no CUDA hardware to compile it on and did not want this change to risk the GPU build.

Files: `core/localiser.cpp`, `core/accelerator.cpp`, `core/accelerator.hpp`, `cpu/cpu_subroutines.cpp`, `cpu/cpu_subroutines.hpp`.

## Correctness

The fused routine must give bit-identical results to the per-SWAP path. The existing suites compare against an independent reference state and pass at 1, 2, 4 and 8 ranks:

```
np=1  All tests passed (21017 assertions in 4 test cases)
np=2  All tests passed (15265 assertions in 4 test cases)
np=4  All tests passed (6637 assertions in 4 test cases)
np=8  All tests passed (2329 assertions in 4 test cases)
```

(`applySwap`, `applyCompMatr`, `applyCompMatr2`, `calcPartialTrace`.)

## Benchmark

**Communication volume (exact, hardware independent).** Measured by tallying amplitudes pushed through the sub-buffer exchange:

| ranks | eta | fused / baseline | reduction |
|-------|-----|------------------|-----------|
| 4     | 2   | 0.750            | 25.0%     |
| 8     | 3   | 0.583            | 41.7%     |

The fused group moves a fraction `1 - 1/2^eta` of the partition once, where the per-swap path relays it across `eta` exchanges (each moving half a partition, applied twice over the down-and-back swap). So the ratio is `2(1 - 1/2^eta)/eta`: `3/4` at eta=2 and `7/12 ~ 0.583` at eta=3, matching the table.

**Wall clock.** I do not have a cluster, so I cannot measure the real multi-node speedup directly. On a single box, intra-node MPI is shared memory with no bandwidth limit, so the saved volume costs nothing and the routine is slower there. To measure the bandwidth-limited regime that distribution actually runs in, I forced MPICH off its shared-memory shortcut onto the TCP transport (`MPIR_CVAR_NOLOCAL=1 FI_PROVIDER=tcp`), which gives a genuine bandwidth-limited path between ranks on one machine. This is an emulation, not a real cluster. I flag it as such.

Single thread per node (`mt=0`, the case the issue asks to verify), eta=3, the speedup grows with state size as the saved volume starts to outweigh the fused routine's extra rounds:

| state n | total state | baseline | fused | speedup | fused faster in |
|---------|-------------|----------|-------|---------|-----------------|
| 27      | 2 GB        | 4.262 s  | 4.181 s | +1.9% | 4/6 trials |
| 28      | 4 GB        | 7.656 s  | 7.682 s | tie   | 4/6 trials |
| 29      | 8 GB        | 17.157 s | 16.499 s | +3.8% | 5/5 trials |

At the largest state tested, single threaded, fused is faster on every trial. With OpenMP on (the realistic deployment, where the extra packing is parallelised away) the win is larger and cleaner: n=28, 8 ranks, fused 4.831 s vs baseline 5.425 s, +11%. For eta=2 the 25% volume cut is too small to beat the extra-round overhead single threaded and the result is a tie.

So the extra packing does not outweigh the comm saving: single threaded it is a wash at small state and a win at large state. Once threads or a real (slower than loopback) interconnect enter, it wins across the range. Happy to have this confirmed on a real cluster via CI.

## AI disclosure

This change was implemented with substantial help from Claude (Anthropic), which drafted the fused routing in the localiser, the unpack kernel and the benchmark and proposed the subset-enumeration design. I reviewed the approach against the issue thread and the QuEST distributed paper (arXiv:2311.01512). I ran the tests at 1/2/4/8 ranks and the benchmark and own the change. Verified locally before submitting: the CPU/OpenMP suites green at 1/2/4/8 ranks, the comm-volume reduction measured directly and the wall-clock benchmark run under the emulated transport above. The GPU path was not compiled (no CUDA hardware) and is deliberately left out.
