### PR TITLE
Use compensated summation in applyCompMatr CPU path

### DIFF
--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -41,6 +41,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 using std::vector;
 
@@ -607,7 +608,8 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, ConstList64 ctrls, Co
 
                 // i = nth local index where ctrls are active and targs form value k
                 qindex i = setBits(i0, targs.data(), numTargBits, k); // loop may be unrolled
-                amps[i] = getCpuQcomp(0, 0);
+                cpu_qcomp sum = getCpuQcomp(0, 0);
+                cpu_qcomp compensation = getCpuQcomp(0, 0);
             
                 // loop may be unrolled
                 for (qindex j=0; j<numTargAmps; j++) {
@@ -624,18 +626,26 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, ConstList64 ctrls, Co
                     if constexpr (ApplyConj)
                         elem = conj(elem);
 
-                    amps[i] += elem * cache[j];
+                    cpu_qcomp term = elem * cache[j];
 
-                    /// @todo
-                    /// qureg.cpuAmps[i] is being serially updated by only this thread,
-                    /// so is a candidate for Kahan summation for improved numerical
-                    /// stability. Explore whether this is time-free and worthwhile!
-                    ///
-                    /// BEWARE that Kahan summation may be incompatible with
-                    /// the commutator tricks used in base_qcomp's (ancestor
-                    /// of cpu_qcomp) arithmetic operator overloads. Check
-                    /// base_qcomp.hpp before implementing compensation.
+                    // base_qcomp avoids std::complex in this hot loop, so use
+                    // explicit Neumaier compensation for each component.
+                    qreal tRe = sum.re + term.re;
+                    if (std::abs(sum.re) >= std::abs(term.re))
+                        compensation.re += (sum.re - tRe) + term.re;
+                    else
+                        compensation.re += (term.re - tRe) + sum.re;
+                    sum.re = tRe;
+
+                    qreal tIm = sum.im + term.im;
+                    if (std::abs(sum.im) >= std::abs(term.im))
+                        compensation.im += (sum.im - tIm) + term.im;
+                    else
+                        compensation.im += (term.im - tIm) + sum.im;
+                    sum.im = tIm;
                 }
+
+                amps[i] = sum + compensation;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds explicit component-wise compensated summation in `cpu_statevec_anyCtrlAnyTargDenseMatr_sub()`.
- Targets the dynamic many-target dense-matrix path used by `applyCompMatr`/left-right multiplication APIs.
- Replaces the old per-term `amps[i] += elem * cache[j]` accumulation with a local sum plus Neumaier compensation for real and imaginary components.

## Validation
Built and tested locally on macOS with CPU-only, non-OpenMP configuration. The local CommandLineTools default SDK did not expose C++ standard library headers, so I had to point CMake at the installed MacOSX15.5 SDK C++ include path.

```bash
SDK=/Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk
SDKROOT=$SDK cmake -S . -B build-macos155 \
  -DQUEST_BUILD_TESTS=ON \
  -DQUEST_ENABLE_OMP=OFF \
  -DQUEST_ENABLE_MPI=OFF \
  -DQUEST_ENABLE_CUDA=OFF \
  -DQUEST_ENABLE_HIP=OFF \
  -DCMAKE_OSX_SYSROOT=$SDK \
  -DCMAKE_CXX_FLAGS="-isystem $SDK/usr/include/c++/v1" \
  -DCMAKE_BUILD_TYPE=Release
SDKROOT=$SDK cmake --build build-macos155 --target tests -j4
SDKROOT=$SDK ./build-macos155/tests/tests "leftapplyCompMatr,rightapplyCompMatr"
```

Result: all tests passed, 5879 assertions in 2 test cases.

## Notes
- This is intentionally scoped to the CPU many-target dense-matrix subroutine mentioned in #598.
- I did not include broad benchmark claims in this PR; the change improves numerical summation behavior but adds arithmetic in the hot loop, so maintainers may want to profile the desired regimes.

## AI disclosure
This contribution was developed with assistance from OpenAI Codex. I reviewed the patch and ran the validation above before submitting.

Closes #598.