### PR TITLE
Compensated summation for cpu_statevec_anyCtrlAnyTargDenseMatr_sub (#598) - [unitaryHACK]

### DIFF
--- a/quest/src/cpu/CMakeLists.txt
+++ b/quest/src/cpu/CMakeLists.txt
@@ -5,3 +5,13 @@ target_sources(QuEST
   cpu_config.cpp
   cpu_subroutines.cpp
 )
+
+# issue #598: optionally use compensated (Kahan) summation in applyCompMatr's
+# dense-matrix CPU subroutine. Off by default (naive summation); enable with
+#   -DQUEST_COMPENSATE_DENSEMATR_SUM=ON
+# to trade ~2-7x runtime for ~25x better accuracy on many-target matrices.
+option(QUEST_COMPENSATE_DENSEMATR_SUM "Use compensated (Kahan) summation in applyCompMatr's CPU subroutine (issue #598)" OFF)
+if (QUEST_COMPENSATE_DENSEMATR_SUM)
+  target_compile_definitions(QuEST PRIVATE QUEST_COMPENSATED_DENSEMATR_SUM=1)
+  message(STATUS "Compensated (Kahan) dense-matrix summation is turned ON.")
+endif()

--- a/quest/src/cpu/cpu_subroutines.cpp
+++ b/quest/src/cpu/cpu_subroutines.cpp
@@ -607,8 +607,14 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, ConstList64 ctrls, Co
 
                 // i = nth local index where ctrls are active and targs form value k
                 qindex i = setBits(i0, targs.data(), numTargBits, k); // loop may be unrolled
-                amps[i] = getCpuQcomp(0, 0);
-            
+
+                // accumulate the row-vector inner-product (matr[k] . cache) in a
+                // thread-private scalar, writing to memory once at the end
+                cpu_qcomp sum = getCpuQcomp(0, 0);
+                #if defined(QUEST_COMPENSATED_DENSEMATR_SUM)
+                    cpu_qcomp comp = getCpuQcomp(0, 0); // running Kahan compensation
+                #endif
+
                 // loop may be unrolled
                 for (qindex j=0; j<numTargAmps; j++) {
 
@@ -624,18 +630,24 @@ void cpu_statevec_anyCtrlAnyTargDenseMatr_sub(Qureg qureg, ConstList64 ctrls, Co
                     if constexpr (ApplyConj)
                         elem = conj(elem);
 
-                    amps[i] += elem * cache[j];
+                    cpu_qcomp term = elem * cache[j];
 
-                    /// @todo
-                    /// qureg.cpuAmps[i] is being serially updated by only this thread,
-                    /// so is a candidate for Kahan summation for improved numerical
-                    /// stability. Explore whether this is time-free and worthwhile!
-                    ///
-                    /// BEWARE that Kahan summation may be incompatible with
-                    /// the commutator tricks used in base_qcomp's (ancestor
-                    /// of cpu_qcomp) arithmetic operator overloads. Check
-                    /// base_qcomp.hpp before implementing compensation.
+                    // this serial reduction over a dynamic (up to ~2^16) number of
+                    // terms is liable to catastrophic cancellation; optionally
+                    // compensate (#598). base_qcomp's operators are plain IEEE
+                    // arithmetic (no associativity tricks), so the compensation
+                    // is honoured here; enable via -DQUEST_COMPENSATE_DENSEMATR_SUM.
+                    #if defined(QUEST_COMPENSATED_DENSEMATR_SUM)
+                        cpu_qcomp y = term - comp;
+                        cpu_qcomp t = sum + y;
+                        comp = (t - sum) - y;
+                        sum = t;
+                    #else
+                        sum += term;
+                    #endif
                 }
+
+                amps[i] = sum;
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds an optional compensated-summation path to improve numerical accuracy in CPU dense-matrix target evolution.

The implementation introduces a thinner reduction in `cpu_statevec_anyCtrlAnyTargDenseMat_sub()`, controlled by the compile-time flag:

```cpp
-DQUEST_COMPENSATED_DENSEMAT_SUM=ON
```

The feature is **disabled by default** to preserve existing performance characteristics.

### Implementation Notes

- Accumulates the Kahan compensation term into a local `cpu_qcomp` variable and writes it back once after the reduction.
- Applies only to the CPU dense-matrix path.
- This source file is not built with fast-math, so the compensation term is preserved by the compiler.
- Replaces the previous TODO comment with documentation describing the behaviour and trade-offs.

### Files Changed

- `quest/src/cpu/cpu_subroutines.cpp`
- `quest/src/cpu/CMakeLists.txt`

## Accuracy & Performance

Benchmarked against a `__float128` reference using the naive vs. compensated Kahan implementation across all three floating-point precisions.

| Precision | Accuracy @ 12 Targets | Runtime Cost |
|-----------|----------------------|--------------|
| fp32 | ~58× lower error | ~3.3× |
| fp64 | ~29× lower error | ~2.2× (~1.76× for 10 targets on a 24-qubit state) |
| fp80 | ~25× lower error | ~2.1× |

### Observations

- Accuracy improvements grow with target count.
- Benefits become negligible below roughly **7 targets**.
- Runtime overhead remains greater than 1× because the kernel is compute-bound on matrix multiplication rather than memory-bandwidth limited.
- The Kahan recurrence prevents efficient vectorization.


<img width="1950" height="598" alt="accuracy" src="https://github.com/user-attachments/assets/34fc6961-e5b3-43fd-820a-aae3c4207e61" />
<img width="1560" height="598" alt="bandwidth_regime" src="https://github.com/user-attachments/assets/298233dc-f832-4343-800a-d981825303fb" />
<img width="1950" height="598" alt="runtime" src="https://github.com/user-attachments/assets/b5507881-8a83-4083-a031-164f73152713" />
<img width="1560" height="598" alt="tradeoff" src="https://github.com/user-attachments/assets/37127e75-6597-4544-afcc-7e9bd8b9f095" />

## Validation

All existing dense `CompMatr` tests pass for both compensated and uncompensated builds, including:

- `applyCompMatr`
- Controlled variants

Test results:

- **93,791 assertions**
- **4 test cases**

## Rationale for Default-Off

The improvement is primarily beneficial for large or ill-conditioned matrices, while introducing a consistent ~2–3× runtime overhead.

Keeping the feature disabled by default preserves current performance expectations while allowing users to opt in when higher numerical accuracy is required.

## Future Work

A possible alternative is pairwise summation, which offers:

- Error scaling of approximately `O(log N)`
- Better vectorization opportunities
- Potentially lower runtime overhead

This can be evaluated separately in a future PR.

I also acknowledge claude for guiding me thorough it.

 /claim #598
  
 Closes #598.
