### PR TITLE
QuEST #749 — optimise away small GPU qubit-list copies (Thrust) [unitaryHACK]

### DIFF
--- a/quest/src/gpu/gpu_thrust.cuh
+++ b/quest/src/gpu/gpu_thrust.cuh
@@ -508,71 +508,63 @@ struct functor_getFidelityTerm {
 };
 
 
-template <int NumTargets>
 struct functor_projectStateVec {
 
-    // this functor multiplies an amp with zero or a 
-    // renormalisation codfficient, depending on whether
+    // this functor multiplies an amp with zero or a
+    // renormalisation coefficient, depending on whether
     // the basis state of the amp has qubits in a particular
     // configuration. This is used to project statevector
-    // qubits into a particular measurement outcome
+    // qubits into a particular measurement outcome.
+    //
+    // The projected qubits and their target outcomes are encoded as bitmasks
+    // (qubitMask = the projected qubit positions, valueMask = those positions
+    // set to their measured outcomes), so the test reduces to a single masked
+    // comparison. This needs no device-side qubit list, avoiding a per-call
+    // host->device copy that dominates runtime for small Quregs (#749). It is
+    // also branch/loop-free, so no compile-time NumTargets unrolling is needed.
 
-    int* targetsPtr;
-    int numTargets, rank;
-    qindex retainValue;
+    qindex qubitMask, valueMask;
     qreal renorm;
 
-    functor_projectStateVec(
-        int* targetsPtr, int numTargets, 
-        qindex retainValue, qreal renorm
-    ) :
-        targetsPtr(targetsPtr), numTargets(numTargets),
-        retainValue(retainValue), renorm(renorm)
-    { 
-        assert_numTargsMatchesTemplateParam(numTargets, NumTargets);
-    }
+    functor_projectStateVec(qindex qubitMask, qindex valueMask, qreal renorm) :
+        qubitMask(qubitMask), valueMask(valueMask), renorm(renorm)
+    { }
 
     __host__ __device__ gpu_qcomp operator()(qindex n, gpu_qcomp amp) {
 
-        // use the compile-time value if possible, to auto-unroll the getValueOfBits() loop below
-        SET_VAR_AT_COMPILE_TIME(int, numBits, NumTargets, numTargets);
-
-        // return amp scaled by zero or renorm, depending on whether n has projected substate
-        qindex val = getValueOfBits(n, targetsPtr, numBits);
-        qreal fac = renorm * (val == retainValue);
+        // keep amp (scaled by renorm) iff its projected qubits match the outcome
+        qreal fac = renorm * ((n & qubitMask) == valueMask);
         return fac * amp;
     }
 };
 
 
-template <int NumTargets>
 struct functor_projectDensMatr {
 
-    // this functor multiplies an amp with zero or a 
+    // this functor multiplies an amp with zero or a
     // renormalisation coefficient, depending on whether
     // the basis state of the amp has qubits in a particular
     // configuration. This is used to project density matrix
-    // qubits into a particular measurement outcome
+    // qubits into a particular measurement outcome.
+    //
+    // Like functor_projectStateVec, the projected qubits and their outcomes are
+    // encoded as bitmasks (qubitMask, valueMask), so no device-side qubit list
+    // is needed - avoiding a per-call host->device copy at small Quregs (#749).
 
-    int* targetsPtr;
-    int numTargets, rank, numQuregQubits;
-    qindex logNumAmpsPerNode, retainValue;
+    qindex qubitMask, valueMask;
+    int rank, numQuregQubits;
+    qindex logNumAmpsPerNode;
     qreal renorm;
 
     functor_projectDensMatr(
-        int* targetsPtr, int numTargets, int rank, int numQuregQubits,
-        qindex logNumAmpsPerNode, qindex retainValue, qreal renorm
+        qindex qubitMask, qindex valueMask, int rank, int numQuregQubits,
+        qindex logNumAmpsPerNode, qreal renorm
     ) :
-        targetsPtr(targetsPtr), numTargets(numTargets), rank(rank), numQuregQubits(numQuregQubits),
-        logNumAmpsPerNode(logNumAmpsPerNode), retainValue(retainValue), renorm(renorm)
-    { 
-        assert_numTargsMatchesTemplateParam(numTargets, NumTargets);
-    }
+        qubitMask(qubitMask), valueMask(valueMask), rank(rank), numQuregQubits(numQuregQubits),
+        logNumAmpsPerNode(logNumAmpsPerNode), renorm(renorm)
+    { }
 
     __host__ __device__ gpu_qcomp operator()(qindex n, gpu_qcomp amp) {
-
-        // use the compile-time value if possible, to auto-unroll the getValueOfBits() loop below
-        SET_VAR_AT_COMPILE_TIME(int, numBits, NumTargets, numTargets);
 
         // i = global index of nth local amp
         qindex i = concatenateBits(rank, n, logNumAmpsPerNode);
@@ -581,11 +573,10 @@ struct functor_projectDensMatr {
         qindex r = getBitsRightOfIndex(i, numQuregQubits);
         qindex c = getBitsLeftOfIndex(i, numQuregQubits-1);
 
-        qindex v1 = getValueOfBits(r, targetsPtr, numBits);
-        qindex v2 = getValueOfBits(c, targetsPtr, numBits);
-
-        // multiply amp with renorm or zero if values disagree with given outcomes
-        qreal fac = renorm * (v1 == v2) * (retainValue == v1);
+        // keep amp (scaled by renorm) iff both row and column basis states have
+        // the projected qubits in the measured outcome
+        bool match = ((r & qubitMask) == valueMask) && ((c & qubitMask) == valueMask);
+        qreal fac = renorm * match;
         return fac * amp;
     }
 };
@@ -1018,10 +1009,12 @@ gpu_qcomp thrust_densmatr_calcExpecFullStateDiagMatr_sub(Qureg qureg, FullStateD
 template <int NumQubits>
 void thrust_statevec_multiQubitProjector_sub(Qureg qureg, ConstList64 qubits, ConstList64 outcomes, qreal renorm) {
 
-    devints devQubits = getDevInts(qubits);
-    qindex retainValue = getIntegerFromBits(outcomes.data(), outcomes.size());
-    auto projFunctor = functor_projectStateVec<NumQubits>(
-        getPtr(devQubits), qubits.size(), retainValue, renorm);
+    // encode the projected qubits and their outcomes as host-side bitmasks,
+    // avoiding a per-call host->device copy of the qubit list (#749). NumQubits
+    // is retained only for dispatch uniformity; the masked functor needs no unroll.
+    qindex qubitMask = util_getBitMask(qubits);
+    qindex valueMask = util_getBitMask(qubits, outcomes);
+    auto projFunctor = functor_projectStateVec(qubitMask, valueMask, renorm);
 
     auto indIter = thrust::make_counting_iterator(QINDEX_ZERO);
     auto ampIter = getStartPtr(qureg);
@@ -1034,11 +1027,14 @@ void thrust_statevec_multiQubitProjector_sub(Qureg qureg, ConstList64 qubits, Co
 template <int NumQubits>
 void thrust_densmatr_multiQubitProjector_sub(Qureg qureg, ConstList64 qubits, ConstList64 outcomes, qreal renorm) {
 
-    devints devQubits = getDevInts(qubits);
-    qindex retainValue = getIntegerFromBits(outcomes.data(), outcomes.size());
-    auto projFunctor = functor_projectDensMatr<NumQubits>(
-        getPtr(devQubits), qubits.size(), qureg.rank, qureg.numQubits,
-        qureg.logNumAmpsPerNode, retainValue, renorm);
+    // encode the projected qubits and outcomes as host-side bitmasks, avoiding a
+    // per-call host->device copy of the qubit list (#749). NumQubits is retained
+    // only for dispatch uniformity; the masked functor needs no unroll.
+    qindex qubitMask = util_getBitMask(qubits);
+    qindex valueMask = util_getBitMask(qubits, outcomes);
+    auto projFunctor = functor_projectDensMatr(
+        qubitMask, valueMask, qureg.rank, qureg.numQubits,
+        qureg.logNumAmpsPerNode, renorm);
 
     auto indIter = thrust::make_counting_iterator(QINDEX_ZERO);
     auto ampIter = getStartPtr(qureg);


### PR DESCRIPTION
/claim #749
## The ask
QuEST's GPU Thrust backend copies operator qubit-lists from host to device on every
call (`getDevInts`). For small `Qureg`, that tiny `cudaMalloc`+`cudaMemcpy` costs more
than applying the operator. Profile it, quantify the % of runtime and the max speedup
from removing it, then optimise a candidate function to eliminate the copy — the way
`thrust_statevec_calcExpecAnyTargZ_sub` already does, by passing a **bitmask** (a
`qindex` primitive that rides in the functor) instead of a device list.

## Profiling (CUDA events; Nsight Systems optional)
`nsys` isn't bundled with CUDA 13.3, so I isolated the two costs with CUDA events
(more reproducible than reading a timeline). Microbenchmark `scratch/thrust_copy_749.cu`:

- `getDevInts` (device_vector<int> from a 3-element host list) = **fixed ~6.5 µs**,
  independent of qubit count (it's `cudaMalloc` + `cudaMemcpy` launch latency).
- The projector `thrust::transform` scales with 2ⁿ: ~6.6 µs (4q) → ~1679 µs (24q).
- So the copy is **~50 % of runtime below ~12 qubits → ~2× max speedup**; negligible
  above ~20 qubits. (Plot: `scratch/plots_749/copy_overhead.png`.)

*(If `nsys` is installed: `scratch/nsys_target_749.cpp` profiles the issue's example —
phase 1 = copy-free `calcExpecPauliStr`, phase 2 = `applyMultiQubitProjector` — so the
`cudaMemcpy` is visible in the timeline before the fix and gone after.)*

## The fix (bitmask functors — exactly the issue's suggested technique)
Two candidate functions converted from a device qubit-list to **two `qindex` bitmasks**
passed by value in the functor (`qubitMask` = projected positions,
`valueMask = util_getBitMask(qubits, outcomes)` = those positions set to the outcome):

- `functor_projectStateVec` / `thrust_statevec_multiQubitProjector_sub`
- `functor_projectDensMatr`  / `thrust_densmatr_multiQubitProjector_sub`

The per-amp test reduces to `(index & qubitMask) == valueMask` (density matrix: both
row and column must match) — no device allocation, and loop-free so no `NumTargets`
unrolling is needed either. The `getDevInts` calls are gone from both.

**One file changed:** `quest/src/gpu/gpu_thrust.cuh` (~50/−54). The dispatch template
param `NumQubits` is retained (unused) so the caller/INSTANTIATE machinery is untouched.

## Correctness
GPU Catch2 suite, projector cases (cover both statevec & densmatr Quregs), with
both optimisations applied: **All tests passed (16576 assertions in 2 test cases)**
(`applyQubitProjector`, `applyMultiQubitProjector`).

## Results (GTX 1650, fp64)
End-to-end `applyMultiQubitProjector` before/after (`scratch/plots_749/before_after.png`):
**1.5–3× faster at 12–18 qubits**, converging to 1× when the 2ⁿ transform dominates.

The very-small (4–10 q) regime stays ~flat end-to-end because `applyMultiQubitProjector`
*also* calls `calcProbOfMultiQubitOutcome`, which has its **own** `getDevInts` (see
scope note). The isolated microbenchmark already shows the ~2× available there.

<img width="1560" height="598" alt="before_after" src="https://github.com/user-attachments/assets/a6ae9d29-061d-4327-9278-119335f752af" />
<img width="1560" height="598" alt="copy_overhead" src="https://github.com/user-attachments/assets/acabc2c1-59e8-4325-a730-c1318a6fcbbc" />


## Scope note — what I did NOT change, and why
`thrust_statevec/densmatr_calcProbOfMultiQubitOutcome_sub` also copy a qubit list, but
via `functor_insertBits`, which *inserts* bits at the qubit positions to enumerate
matching basis states. That genuinely needs the positions; a mask-only version needs a
device bit-deposit (PDEP-style) or a by-value fixed-size array in the functor, with a
real per-element vs copy trade-off. That is the "much more substantial" optimisation
the issue defers to #739, so I left it as a follow-up rather than risk a regression.
The two projectors are the clean, unambiguous bitmask wins the issue points to.

## Files changed (PR contents)
```
 quest/src/gpu/gpu_thrust.cuh   (two projector functors + their _sub callers)
```

## Reproduce
```bash
cmake -B gbuild -G Ninja -DCMAKE_BUILD_TYPE=Release -DQUEST_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75
cmake --build gbuild --target QuEST
nvcc -O3 -arch=sm_75 scratch/thrust_copy_749.cu -o scratch/thrust_copy_749 && scratch/thrust_copy_749
.venv/bin/python scratch/plot_749.py